### PR TITLE
docs: add Branching & PR Policy to Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -113,6 +113,7 @@ Notes for agents
 - Branch naming: `feat/<topic>-<issue#>` or `docs/<topic>` (e.g., `feat/domain-events-23`).
 - Open a Pull Request to merge into `main`; squash-merge is preferred.
 - PR requirements: all tests pass (`cargo test --workspace`), clippy clean (`cargo clippy -- -D warnings`), and reference the related issue (e.g., `Closes #23`).
+- PR↔Issue linkage: PRs must link the related issue using closing keywords (`Closes`/`Fixes`/`Resolves #<issue>`), and the issue should reference the PR once opened.
 - Keep changes focused and incremental; update `ROADMAP.md` and docs as needed.
 - Follow cross-platform rules; do not introduce OS-specific behavior.
 


### PR DESCRIPTION
Adds an explicit Branching & PR Policy: no direct commits to main, feature/docs branch naming, PR checks (tests + clippy), and squash-merge preference. This enforces the newly enabled branch ruleset. Closes #?