### PR TITLE
fix: remove leftover merge conflict marker in sqlite_adapters.rs

### DIFF
--- a/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
@@ -3524,6 +3524,5 @@ mod tests {
             .await
             .expect("check wrong type");
         assert!(!wrong_type);
->>>>>>> df40d85 (feat: add artist relationship infrastructure for collaboration tracking)
     }
 }


### PR DESCRIPTION
Removes a leftover merge conflict marker (>>>>>>> df40d85...) that was left in the tests module, causing the build to fail with 'unclosed delimiter' error.

This marker was accidentally left during the conflict resolution for PR #94 merge.