### PR TITLE
docs: sync roadmap after Lyrics completion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,8 +134,8 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
     - [x] Integration tests ✓
   - [x] Scheduler-driven metadata refresh (PR #119) ✓
 - [x] Fanart.tv artwork integration (alternative art source) (Issue #103, PR #122) ✓ COMPLETE
-  - [ ] Cover art fallback sources
-  - [ ] Lyrics fetching (optional enhancement) (Issue #104)
+  - [ ] Cover art fallback sources (Issue #127)
+  - [x] Lyrics fetching (optional enhancement) (Issue #104, PR #124) ✓ COMPLETE
 
 ---
 
@@ -514,6 +514,6 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ---
 
-**Last Updated:** 2026-02-23  
+**Last Updated:** 2026-02-24  
 **Current Phase:** Phase 2: Metadata Integration  
-**Next Milestone:** Lyrics fetching kickoff (Issue #104)
+**Next Milestone:** Cover art fallback sources kickoff (Issue #127)


### PR DESCRIPTION
Aligns roadmap and issue tracking after Lyrics feature merge (Issue #104 / PR #124).\n\n## Updates\n- Mark Lyrics fetching as complete with Issue #104 + PR #124\n- Add issue linkage for remaining Phase 2.2 item: Cover art fallback sources (Issue #127)\n- Update Next Milestone to Issue #127\n- Refresh Last Updated date\n\n## Alignment\n- Issue #104 is closed and reflected as complete\n- Remaining open roadmap item now has a dedicated GitHub issue (#127)\n\nRelated: #104, #127