### PR TITLE
docs: sync roadmap after file organization merges

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -251,7 +251,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
   - [x] Naming pattern engine (Issue #35, PR #156, PR #158) ✓
   - [x] Token replacement (artist, album, track, disc, ext) (Issue #35, PR #156, PR #158) ✓
   - [x] Safe file operations (Issue #35, PR #156, PR #158) ✓
-- [x] Folder organization (Issue #35, PR #156, PR #158) ✓ PARTIALLY COMPLETE
+- [x] Folder organization (Issue #35, PR #156, PR #158) ✓ COMPLETE
   - [x] Artist folder structure (Issue #35, PR #156, PR #158) ✓
   - [x] Album folder structure (Issue #35, PR #156, PR #158) ✓
   - [x] Multi-disc handling (Issue #35, PR #156, PR #158) ✓


### PR DESCRIPTION
## Summary
- sync ROADMAP after merged Issue #35 implementation (PR #156) and fixes (PR #158)
- mark Phase 5.2 file organization progress as partial/complete at sub-item level
- advance next milestone to Issue #36

## Notes
- closes tracking gap between merged code and roadmap state
