### PR TITLE
docs: sync roadmap after merged tag-embedding foundation (#36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,6 @@ jobs:
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup cmake (Windows)
-        if: runner.os == 'Windows'
-        uses: lukka/get-cmake@3.32.2
-
       - name: Install chromaprint (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -93,10 +89,6 @@ jobs:
 
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup cmake (Windows)
-        if: runner.os == 'Windows'
-        uses: lukka/get-cmake@3.32.2
 
       - name: Install chromaprint (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
- sync Phase 5.4 roadmap checklist with merged PR #160 foundation work
- update Last Updated date to 2026-03-03
- set next milestone text to remaining Issue #36 follow-up (format-specific backends)

## Why
PR #160 merged foundational tagging/embedding capabilities, but Issue #36 remains open for remaining format-specific writer/reader implementations.

Refs #36
