### PR TITLE
feat(api): add SSE job status stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Current implemented endpoints:
 - `GET /api/v1/events` (SSE)
 - `GET /api/v1/events/download-progress` (SSE)
 - `GET /api/v1/events/import-progress` (SSE)
+- `GET /api/v1/events/job-status` (SSE)
 - `GET /api/v1/settings/quality-profiles`
 - `GET /api/v1/settings/quality-profiles/{id}`
 - `POST /api/v1/settings/quality-profiles`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -328,7 +328,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 - [ ] Real-time updates implementation
   - [x] Download progress (`GET /api/v1/events/download-progress`) ✓
   - [x] Import progress (`GET /api/v1/events/import-progress`) ✓
-  - [ ] Job status
+  - [x] Job status (`GET /api/v1/events/job-status`) ✓
 - [ ] Event broadcasting
 - [ ] Client connection management
 

--- a/crates/chorrosion-api/src/handlers/events.rs
+++ b/crates/chorrosion-api/src/handlers/events.rs
@@ -2,6 +2,7 @@
 use crate::handlers::activity::{
     activity_import_snapshot, activity_queue_snapshot, ActivityListResponse,
 };
+use crate::handlers::system::{system_tasks_snapshot, SystemTasksResponse};
 use axum::{
     extract::State,
     response::sse::{Event, KeepAlive, Sse},
@@ -30,6 +31,12 @@ struct DownloadProgressEventPayload {
 struct ImportProgressEventPayload {
     sequence: u64,
     processing: ActivityListResponse,
+}
+
+#[derive(Debug, Serialize)]
+struct JobStatusEventPayload {
+    sequence: u64,
+    tasks: SystemTasksResponse,
 }
 
 fn event_name_for_tick(tick: u64) -> &'static str {
@@ -163,6 +170,52 @@ pub async fn stream_import_progress_events(
 
             let event = Event::default()
                 .event("import_progress_snapshot")
+                .id(sequence.to_string())
+                .data(data);
+
+            Some((Ok(event), (state, false, sequence + 1)))
+        },
+    );
+
+    Sse::new(events).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("keepalive"),
+    )
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/events/job-status",
+    responses(
+        (status = 200, description = "Server-sent job status event stream", content_type = "text/event-stream")
+    ),
+    tag = "activity"
+)]
+pub async fn stream_job_status_events(
+    State(state): State<AppState>,
+) -> Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>> {
+    debug!(target: "api", "opening job status event stream");
+
+    let events = stream::unfold(
+        (state, true, 0_u64),
+        |(state, connected, sequence)| async move {
+            if connected {
+                let event = Event::default()
+                    .event("connected")
+                    .data("{\"status\":\"connected\"}");
+                return Some((Ok(event), (state, false, sequence)));
+            }
+
+            tokio::time::sleep(Duration::from_secs(SSE_EVENT_INTERVAL_SECS)).await;
+
+            let tasks = system_tasks_snapshot(&state).await;
+            let payload = JobStatusEventPayload { sequence, tasks };
+            let data = serde_json::to_string(&payload)
+                .expect("JobStatusEventPayload is always serializable");
+
+            let event = Event::default()
+                .event("job_status_snapshot")
                 .id(sequence.to_string())
                 .data(data);
 
@@ -364,6 +417,38 @@ mod tests {
         assert!(
             text.contains("\"total\":0"),
             "expected empty processing total in payload, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_job_status_emits_job_status_event_with_tasks_payload() {
+        use axum::response::IntoResponse;
+
+        let state = make_test_state().await;
+        tokio::time::pause();
+
+        let sse = stream_job_status_events(State(state)).await;
+        let response = sse.into_response();
+        let mut data_stream = Box::pin(response.into_body().into_data_stream());
+
+        let connected = read_next_sse_event(&mut data_stream).await;
+        assert!(
+            connected.contains("event: connected"),
+            "expected connected event, got: {connected}"
+        );
+
+        let text = read_next_sse_event(&mut data_stream).await;
+        assert!(
+            text.contains("event: job_status_snapshot"),
+            "expected job_status_snapshot event, got: {text}"
+        );
+        assert!(
+            text.contains("\"tasks\""),
+            "expected tasks payload, got: {text}"
+        );
+        assert!(
+            text.contains("\"rss-sync\""),
+            "expected rss-sync job in payload, got: {text}"
         );
     }
 }

--- a/crates/chorrosion-api/src/handlers/system.rs
+++ b/crates/chorrosion-api/src/handlers/system.rs
@@ -38,77 +38,7 @@ pub struct SystemTasksResponse {
     pub max_concurrent_jobs: usize,
 }
 
-#[derive(Debug, Deserialize, IntoParams)]
-pub struct ListSystemLogsQuery {
-    #[serde(default = "default_log_limit")]
-    pub limit: i64,
-    #[serde(default)]
-    pub offset: i64,
-}
-
-fn default_log_limit() -> i64 {
-    100
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-pub struct SystemLogEntryResponse {
-    pub id: String,
-    pub level: String,
-    pub target: String,
-    pub message: String,
-    pub timestamp: String,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-pub struct SystemLogsResponse {
-    pub items: Vec<SystemLogEntryResponse>,
-    pub total: i64,
-    pub source: String,
-}
-
-#[utoipa::path(
-    get,
-    path = "/api/v1/system/status",
-    responses(
-        (status = 200, description = "System status", body = SystemStatusResponse)
-    ),
-    tag = "system"
-)]
-pub async fn get_system_status(State(_state): State<AppState>) -> Json<SystemStatusResponse> {
-    debug!(target: "api", "fetching system status");
-    Json(SystemStatusResponse {
-        status: "ok",
-        api_base: API_V1_BASE,
-    })
-}
-
-#[utoipa::path(
-    get,
-    path = "/api/v1/system/version",
-    responses(
-        (status = 200, description = "System version", body = SystemVersionResponse)
-    ),
-    tag = "system"
-)]
-pub async fn get_system_version(State(_state): State<AppState>) -> Json<SystemVersionResponse> {
-    debug!(target: "api", "fetching system version");
-    Json(SystemVersionResponse {
-        name: "chorrosion",
-        version: APP_VERSION,
-    })
-}
-
-#[utoipa::path(
-    get,
-    path = "/api/v1/system/tasks",
-    responses(
-        (status = 200, description = "Registered system tasks", body = SystemTasksResponse)
-    ),
-    tag = "system"
-)]
-pub async fn get_system_tasks(State(state): State<AppState>) -> Json<SystemTasksResponse> {
-    debug!(target: "api", "fetching system task metadata");
-
+pub(crate) async fn system_tasks_snapshot(state: &AppState) -> SystemTasksResponse {
     // NOTE: These job definitions mirror the registrations in `Scheduler::register_jobs`
     // (crates/chorrosion-scheduler/src/lib.rs). If a job is added, renamed, or its interval
     // changes there, this list must be updated to stay in sync.
@@ -192,11 +122,85 @@ pub async fn get_system_tasks(State(state): State<AppState>) -> Json<SystemTasks
         },
     });
 
-    Json(SystemTasksResponse {
+    SystemTasksResponse {
         total: items.len() as i64,
         items,
         max_concurrent_jobs: state.config.scheduler.max_concurrent_jobs,
+    }
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListSystemLogsQuery {
+    #[serde(default = "default_log_limit")]
+    pub limit: i64,
+    #[serde(default)]
+    pub offset: i64,
+}
+
+fn default_log_limit() -> i64 {
+    100
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SystemLogEntryResponse {
+    pub id: String,
+    pub level: String,
+    pub target: String,
+    pub message: String,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SystemLogsResponse {
+    pub items: Vec<SystemLogEntryResponse>,
+    pub total: i64,
+    pub source: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/system/status",
+    responses(
+        (status = 200, description = "System status", body = SystemStatusResponse)
+    ),
+    tag = "system"
+)]
+pub async fn get_system_status(State(_state): State<AppState>) -> Json<SystemStatusResponse> {
+    debug!(target: "api", "fetching system status");
+    Json(SystemStatusResponse {
+        status: "ok",
+        api_base: API_V1_BASE,
     })
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/system/version",
+    responses(
+        (status = 200, description = "System version", body = SystemVersionResponse)
+    ),
+    tag = "system"
+)]
+pub async fn get_system_version(State(_state): State<AppState>) -> Json<SystemVersionResponse> {
+    debug!(target: "api", "fetching system version");
+    Json(SystemVersionResponse {
+        name: "chorrosion",
+        version: APP_VERSION,
+    })
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/system/tasks",
+    responses(
+        (status = 200, description = "Registered system tasks", body = SystemTasksResponse)
+    ),
+    tag = "system"
+)]
+pub async fn get_system_tasks(State(state): State<AppState>) -> Json<SystemTasksResponse> {
+    debug!(target: "api", "fetching system task metadata");
+
+    Json(system_tasks_snapshot(&state).await)
 }
 
 #[utoipa::path(

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -42,8 +42,9 @@ use handlers::download_clients::{
 };
 use handlers::events::{
     __path_stream_download_progress_events, __path_stream_events,
-    __path_stream_import_progress_events, stream_download_progress_events, stream_events,
-    stream_import_progress_events,
+    __path_stream_import_progress_events, __path_stream_job_status_events,
+    stream_download_progress_events, stream_events, stream_import_progress_events,
+    stream_job_status_events,
 };
 use handlers::indexers::{
     create_indexer, delete_indexer, get_indexer, list_indexers, test_indexer_endpoint,
@@ -143,6 +144,7 @@ async fn health() -> Json<HealthResponse> {
         stream_events,
         stream_download_progress_events,
         stream_import_progress_events,
+        stream_job_status_events,
         list_quality_profiles,
         get_quality_profile,
         create_quality_profile,
@@ -276,6 +278,7 @@ pub fn router(state: AppState) -> Router {
             "/events/import-progress",
             get(stream_import_progress_events),
         )
+        .route("/events/job-status", get(stream_job_status_events))
         .route(
             "/settings/quality-profiles",
             get(list_quality_profiles).post(create_quality_profile),


### PR DESCRIPTION
## Summary
- add dedicated SSE endpoint `GET /api/v1/events/job-status`
- stream periodic `job_status_snapshot` events with current system task metadata
- extract reusable `system_tasks_snapshot` helper and reuse it in `GET /api/v1/system/tasks`
- wire route + OpenAPI path and add end-to-end SSE handler test coverage
- update README and roadmap for Phase 6.2 `Job status`

## Validation
- `cargo fmt`
- `cargo test -p chorrosion-api`
- `cargo build -p chorrosion-cli`

Builds on #210