### PR TITLE
feat(lists): add MusicBrainz list provider import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "chorrosion-domain",
  "chorrosion-fingerprint",
  "chorrosion-infrastructure",
+ "chorrosion-musicbrainz",
  "chrono",
  "lazy_static",
  "lofty",
@@ -418,6 +419,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "uuid",
  "wiremock",
 ]
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -370,7 +370,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 ### 7.4 Lists Integration
 
 - [x] List provider trait (Issue #256) ✓
-- [ ] MusicBrainz list import
+- [x] MusicBrainz list import (Issue #259) ✓
 - [ ] Spotify playlist import (optional)
 - [ ] Last.fm integration
 - [ ] Auto-add from lists

--- a/crates/chorrosion-application/Cargo.toml
+++ b/crates/chorrosion-application/Cargo.toml
@@ -10,6 +10,7 @@ tokio = { workspace = true, features = ["process"] }
 chorrosion-config = { path = "../chorrosion-config" }
 chorrosion-domain = { path = "../chorrosion-domain" }
 chorrosion-fingerprint = { path = "../chorrosion-fingerprint" }
+chorrosion-musicbrainz = { path = "../chorrosion-musicbrainz" }
 chorrosion-infrastructure = { path = "../chorrosion-infrastructure" }
 chrono = { workspace = true }
 tracing = { workspace = true }
@@ -22,6 +23,7 @@ lazy_static = "1.4"
 quick-xml = { version = "0.37", features = ["serialize"] }
 reqwest = { workspace = true }
 lofty = "0.21"
+uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -49,7 +49,7 @@ pub use indexers::{
 };
 pub use lists::{
     dedupe_list_entries, ExternalListEntry, ListEntityType, ListProvider, ListProviderCapabilities,
-    ListProviderHealth,
+    ListProviderHealth, MusicBrainzListProvider,
 };
 pub use matching::{MatchResult, MatchingError, MatchingResult, TrackMatchingService};
 pub use matching_precedence::{

--- a/crates/chorrosion-application/src/lists.rs
+++ b/crates/chorrosion-application/src/lists.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use anyhow::Result;
 use async_trait::async_trait;
+use chorrosion_config::AppConfig;
+use chorrosion_musicbrainz::MusicBrainzClient;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -61,9 +64,165 @@ pub fn dedupe_list_entries(entries: Vec<ExternalListEntry>) -> Vec<ExternalListE
     deduped
 }
 
+pub struct MusicBrainzListProvider {
+    enabled: bool,
+    client: MusicBrainzClient,
+    artist_mbids: Vec<Uuid>,
+    album_mbids: Vec<Uuid>,
+}
+
+impl MusicBrainzListProvider {
+    pub fn from_config(config: &AppConfig) -> Result<Self> {
+        let musicbrainz = &config.lists.musicbrainz;
+        let base_url = musicbrainz
+            .base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+
+        let artist_mbids = parse_mbids(&musicbrainz.artist_mbids);
+        let album_mbids = parse_mbids(&musicbrainz.album_mbids);
+
+        let client = if let Some(url) = base_url {
+            MusicBrainzClient::builder().base_url(url).build()?
+        } else {
+            MusicBrainzClient::new()?
+        };
+
+        Ok(Self {
+            enabled: musicbrainz.enabled,
+            client,
+            artist_mbids,
+            album_mbids,
+        })
+    }
+}
+
+fn parse_mbids(raw_mbids: &[String]) -> Vec<Uuid> {
+    raw_mbids
+        .iter()
+        .filter_map(|raw| {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            match Uuid::parse_str(trimmed) {
+                Ok(uuid) => Some(uuid),
+                Err(_) => {
+                    tracing::warn!(
+                        target: "application",
+                        mbid = %trimmed,
+                        "Skipping invalid MusicBrainz MBID"
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
+#[async_trait]
+impl ListProvider for MusicBrainzListProvider {
+    fn provider_name(&self) -> &'static str {
+        "musicbrainz"
+    }
+
+    fn capabilities(&self) -> ListProviderCapabilities {
+        ListProviderCapabilities {
+            supports_artists: true,
+            supports_albums: true,
+        }
+    }
+
+    async fn health_check(&self) -> Result<ListProviderHealth> {
+        let has_entries = !self.artist_mbids.is_empty() || !self.album_mbids.is_empty();
+        Ok(ListProviderHealth {
+            ok: self.enabled && has_entries,
+            message: if !self.enabled {
+                Some("provider disabled".to_string())
+            } else if !has_entries {
+                Some("no MusicBrainz MBIDs configured".to_string())
+            } else {
+                None
+            },
+        })
+    }
+
+    async fn fetch_followed_artists(&self) -> Result<Vec<ExternalListEntry>> {
+        if !self.enabled {
+            return Ok(vec![]);
+        }
+
+        let mut entries = Vec::with_capacity(self.artist_mbids.len());
+        for mbid in &self.artist_mbids {
+            match self.client.lookup_artist(*mbid).await {
+                Ok(artist) => entries.push(ExternalListEntry {
+                    entity_type: ListEntityType::Artist,
+                    external_id: artist.id.to_string(),
+                    name: artist.name,
+                    artist_name: None,
+                    source_url: Some(format!("https://musicbrainz.org/artist/{}", artist.id)),
+                    followed_at: None,
+                }),
+                Err(error) => {
+                    tracing::warn!(
+                        target: "application",
+                        mbid = %mbid,
+                        ?error,
+                        "Failed to import artist from MusicBrainz"
+                    );
+                }
+            }
+        }
+
+        Ok(dedupe_list_entries(entries))
+    }
+
+    async fn fetch_saved_albums(&self) -> Result<Vec<ExternalListEntry>> {
+        if !self.enabled {
+            return Ok(vec![]);
+        }
+
+        let mut entries = Vec::with_capacity(self.album_mbids.len());
+        for mbid in &self.album_mbids {
+            match self.client.lookup_album(*mbid).await {
+                Ok(album) => {
+                    let artist_name = album.artist_credit.first().map(|ac| ac.name.clone());
+                    entries.push(ExternalListEntry {
+                        entity_type: ListEntityType::Album,
+                        external_id: album.id.to_string(),
+                        name: album.title,
+                        artist_name,
+                        source_url: Some(format!(
+                            "https://musicbrainz.org/release-group/{}",
+                            album.id
+                        )),
+                        followed_at: None,
+                    });
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        target: "application",
+                        mbid = %mbid,
+                        ?error,
+                        "Failed to import album from MusicBrainz"
+                    );
+                }
+            }
+        }
+
+        Ok(dedupe_list_entries(entries))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::{
+        matchers::{method, path, query_param},
+        Mock, MockServer, ResponseTemplate,
+    };
 
     #[test]
     fn dedupe_list_entries_removes_entries_with_same_entity_type_and_external_id() {
@@ -123,5 +282,95 @@ mod tests {
 
         let deduped = dedupe_list_entries(entries);
         assert_eq!(deduped.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn musicbrainz_provider_imports_artists_and_albums() {
+        let server = MockServer::start().await;
+
+        let artist_id = "11111111-1111-1111-1111-111111111111";
+        Mock::given(method("GET"))
+            .and(path(format!("/artist/{artist_id}")))
+            .and(query_param("fmt", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": artist_id,
+                "name": "Artist One",
+                "sort-name": "One, Artist",
+                "type": "Group",
+                "country": "US"
+            })))
+            .mount(&server)
+            .await;
+
+        let album_id = "22222222-2222-2222-2222-222222222222";
+        Mock::given(method("GET"))
+            .and(path(format!("/release-group/{album_id}")))
+            .and(query_param("fmt", "json"))
+            .and(query_param("inc", "artist-credits"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": album_id,
+                "title": "Album Two",
+                "primary-type": "Album",
+                "secondary-types": [],
+                "first-release-date": "2020-01-01",
+                "artist-credit": [{
+                    "name": "Artist One",
+                    "artist": {
+                        "id": artist_id,
+                        "name": "Artist One",
+                        "sort-name": "One, Artist"
+                    }
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let config = AppConfig {
+            lists: chorrosion_config::ListsConfig {
+                musicbrainz: chorrosion_config::MusicBrainzListsConfig {
+                    enabled: true,
+                    base_url: Some(server.uri()),
+                    artist_mbids: vec![artist_id.to_string()],
+                    album_mbids: vec![album_id.to_string()],
+                },
+            },
+            ..AppConfig::default()
+        };
+
+        let provider = MusicBrainzListProvider::from_config(&config).unwrap();
+        let artists = provider.fetch_followed_artists().await.unwrap();
+        let albums = provider.fetch_saved_albums().await.unwrap();
+
+        assert_eq!(artists.len(), 1);
+        assert_eq!(artists[0].external_id, artist_id);
+        assert_eq!(artists[0].name, "Artist One");
+
+        assert_eq!(albums.len(), 1);
+        assert_eq!(albums[0].external_id, album_id);
+        assert_eq!(albums[0].name, "Album Two");
+        assert_eq!(albums[0].artist_name.as_deref(), Some("Artist One"));
+    }
+
+    #[tokio::test]
+    async fn musicbrainz_provider_health_check_reflects_config() {
+        let config = AppConfig {
+            lists: chorrosion_config::ListsConfig {
+                musicbrainz: chorrosion_config::MusicBrainzListsConfig {
+                    enabled: true,
+                    base_url: None,
+                    artist_mbids: vec![],
+                    album_mbids: vec![],
+                },
+            },
+            ..AppConfig::default()
+        };
+
+        let provider = MusicBrainzListProvider::from_config(&config).unwrap();
+        let health = provider.health_check().await.unwrap();
+        assert!(!health.ok);
+        assert_eq!(
+            health.message.as_deref(),
+            Some("no MusicBrainz MBIDs configured")
+        );
     }
 }

--- a/crates/chorrosion-config/src/lib.rs
+++ b/crates/chorrosion-config/src/lib.rs
@@ -217,6 +217,19 @@ pub struct ScriptNotificationConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MusicBrainzListsConfig {
+    pub enabled: bool,
+    pub base_url: Option<String>,
+    pub artist_mbids: Vec<String>,
+    pub album_mbids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ListsConfig {
+    pub musicbrainz: MusicBrainzListsConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct NotificationsConfig {
     pub email: EmailNotificationConfig,
     pub discord: DiscordNotificationConfig,
@@ -234,6 +247,7 @@ pub struct AppConfig {
     pub auth: AuthConfig,
     pub metadata: MetadataConfig,
     pub notifications: NotificationsConfig,
+    pub lists: ListsConfig,
 }
 
 /// Load configuration from defaults, optional TOML file, and environment overrides (prefix: CHORROSION_).


### PR DESCRIPTION
## Summary

Implements the next Phase 7.4 item: MusicBrainz list import.

## What changed

- Added Lists config section for MusicBrainz imports:
  - lists.musicbrainz.enabled
  - lists.musicbrainz.base_url
  - lists.musicbrainz.artist_mbids
  - lists.musicbrainz.album_mbids
- Added MusicBrainzListProvider implementing ListProvider
- Provider fetches and maps:
  - artists via lookup_artist
  - albums via lookup_album
- Added MBID parsing/validation with invalid-entry skipping
- Added health-check behavior for disabled/unconfigured provider
- Added tests for provider mapping, health-check, and dedupe behavior
- Updated roadmap to mark MusicBrainz list import complete

## Validation

- cargo test -p chorrosion-application -q (124 passed)
- cargo test -p chorrosion-api -q (169 passed)

Closes #259
