### PR TITLE
feat: wire permission checks into file operations (#336)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -258,7 +258,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
 - [x] File operations (Issue #35, PR #156, PR #158) ✓ PARTIALLY COMPLETE
   - [x] Copy vs. move logic (Issue #35, PR #156, PR #158) ✓
   - [x] Hard link support (Issue #35, PR #156, PR #158) ✓
-  - [ ] Permission handling (Issue #337) — utilities added; wiring into file operation paths pending
+  - [x] Permission handling (Issue #336, Issue #337) ✓
 
 ### 5.3 Quality Management
 

--- a/crates/chorrosion-application/src/file_organization.rs
+++ b/crates/chorrosion-application/src/file_organization.rs
@@ -418,7 +418,7 @@ mod tests {
     }
 
     #[test]
-    fn permission_check_fails_on_missing_source() {
+    fn missing_source_short_circuits_before_permission_handling() {
         let temp_dir = tempdir().expect("temp directory should be created");
         let source = temp_dir.path().join("nonexistent.flac");
         let destination = temp_dir.path().join("dest.flac");

--- a/crates/chorrosion-application/src/file_organization.rs
+++ b/crates/chorrosion-application/src/file_organization.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use crate::permission::{PermissionChecker, PermissionConfig, PermissionManager};
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::fs;
@@ -39,6 +40,8 @@ pub enum FileOrganizationError {
     InvalidPattern(String),
     #[error("file operation failed: {0}")]
     FileOperation(String),
+    #[error("permission denied: {0}")]
+    Permission(String),
 }
 
 pub fn render_naming_pattern(
@@ -106,11 +109,18 @@ pub fn apply_file_operation(
     destination: &Path,
     mode: FileOperationMode,
     overwrite: bool,
+    permission_config: Option<&PermissionConfig>,
 ) -> Result<(), FileOrganizationError> {
     if !source.exists() {
         return Err(FileOrganizationError::SourceNotFound(
             source.display().to_string(),
         ));
+    }
+
+    // Check that the source file is readable before attempting any file operation.
+    if permission_config.is_some() {
+        PermissionChecker::check_readable(source)
+            .map_err(|e| FileOrganizationError::Permission(e.to_string()))?;
     }
 
     // Guard against source and destination being the same file to prevent data loss.
@@ -126,6 +136,16 @@ pub fn apply_file_operation(
             return Ok(());
         }
     }
+
+    // For Move with permission preservation: save source permissions before the
+    // operation because the source will no longer exist afterward.
+    let saved_permissions = match (permission_config, &mode) {
+        (Some(config), FileOperationMode::Move) if config.preserve_permissions => Some(
+            PermissionManager::get_permissions(source)
+                .map_err(|e| FileOrganizationError::Permission(e.to_string()))?,
+        ),
+        _ => None,
+    };
 
     if destination.exists() {
         if !overwrite {
@@ -162,6 +182,28 @@ pub fn apply_file_operation(
                         rename_error, remove_error
                     ))
                 })?;
+            }
+        }
+    }
+
+    // Apply permissions to the destination after the file operation.
+    if let Some(config) = permission_config {
+        match mode {
+            FileOperationMode::Move => {
+                if let Some(perms) = saved_permissions {
+                    // Restore permissions saved before the move (source is now gone).
+                    fs::set_permissions(destination, perms)
+                        .map_err(|e| FileOrganizationError::Permission(e.to_string()))?;
+                } else {
+                    // Source is gone; apply configured defaults.
+                    PermissionManager::apply_defaults(destination, config)
+                        .map_err(|e| FileOrganizationError::Permission(e.to_string()))?;
+                }
+            }
+            FileOperationMode::Copy | FileOperationMode::Hardlink => {
+                // Source still exists; preserve from it or apply defaults per config.
+                PermissionManager::apply_permissions(source, destination, config)
+                    .map_err(|e| FileOrganizationError::Permission(e.to_string()))?;
             }
         }
     }
@@ -318,7 +360,7 @@ mod tests {
         let destination = temp_dir.path().join("library").join("dest.flac");
         fs::write(&source, b"audio-data").expect("source should be written");
 
-        apply_file_operation(&source, &destination, FileOperationMode::Copy, false)
+        apply_file_operation(&source, &destination, FileOperationMode::Copy, false, None)
             .expect("copy should succeed");
 
         assert!(source.exists());
@@ -332,7 +374,7 @@ mod tests {
         let destination = temp_dir.path().join("organized").join("dest.mp3");
         fs::write(&source, b"audio-data").expect("source should be written");
 
-        apply_file_operation(&source, &destination, FileOperationMode::Move, false)
+        apply_file_operation(&source, &destination, FileOperationMode::Move, false, None)
             .expect("move should succeed");
 
         assert!(!source.exists());
@@ -346,8 +388,14 @@ mod tests {
         let destination = temp_dir.path().join("organized").join("linked.flac");
         fs::write(&source, b"audio-data").expect("source should be written");
 
-        apply_file_operation(&source, &destination, FileOperationMode::Hardlink, false)
-            .expect("hardlink should succeed");
+        apply_file_operation(
+            &source,
+            &destination,
+            FileOperationMode::Hardlink,
+            false,
+            None,
+        )
+        .expect("hardlink should succeed");
 
         assert!(source.exists());
         assert!(destination.exists());
@@ -361,10 +409,98 @@ mod tests {
         fs::write(&source, b"audio-data").expect("source should be written");
         fs::write(&destination, b"existing").expect("dest should be written");
 
-        let result = apply_file_operation(&source, &destination, FileOperationMode::Copy, false);
+        let result =
+            apply_file_operation(&source, &destination, FileOperationMode::Copy, false, None);
         assert!(matches!(
             result,
             Err(FileOrganizationError::TargetExists(_))
         ));
+    }
+
+    #[test]
+    fn permission_check_fails_on_missing_source() {
+        let temp_dir = tempdir().expect("temp directory should be created");
+        let source = temp_dir.path().join("nonexistent.flac");
+        let destination = temp_dir.path().join("dest.flac");
+        let config = crate::permission::PermissionConfig::default();
+
+        let result = apply_file_operation(
+            &source,
+            &destination,
+            FileOperationMode::Copy,
+            false,
+            Some(&config),
+        );
+        assert!(matches!(
+            result,
+            Err(FileOrganizationError::SourceNotFound(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_with_permission_config_preserves_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempdir().expect("temp directory should be created");
+        let source = temp_dir.path().join("source.flac");
+        let destination = temp_dir.path().join("dest.flac");
+        fs::write(&source, b"audio-data").expect("source should be written");
+
+        // Set a specific permission on the source.
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o644))
+            .expect("should set permissions");
+
+        let config = crate::permission::PermissionConfig {
+            preserve_permissions: true,
+            ..Default::default()
+        };
+        apply_file_operation(
+            &source,
+            &destination,
+            FileOperationMode::Copy,
+            false,
+            Some(&config),
+        )
+        .expect("copy should succeed");
+
+        let dest_mode = fs::metadata(&destination)
+            .expect("dest metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dest_mode, 0o644);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_with_permission_config_applies_defaults_when_preserve_disabled() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempdir().expect("temp directory should be created");
+        let source = temp_dir.path().join("source.flac");
+        let destination = temp_dir.path().join("dest.flac");
+        fs::write(&source, b"audio-data").expect("source should be written");
+
+        let config = crate::permission::PermissionConfig {
+            preserve_permissions: false,
+            file_mode: 0o600,
+            dir_mode: 0o700,
+        };
+        apply_file_operation(
+            &source,
+            &destination,
+            FileOperationMode::Copy,
+            false,
+            Some(&config),
+        )
+        .expect("copy should succeed");
+
+        let dest_mode = fs::metadata(&destination)
+            .expect("dest metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dest_mode, 0o600);
     }
 }

--- a/crates/chorrosion-application/src/file_replacement.rs
+++ b/crates/chorrosion-application/src/file_replacement.rs
@@ -25,6 +25,8 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::{debug, instrument, warn};
 
+use crate::permission::{PermissionChecker, PermissionConfig, PermissionManager};
+
 // ============================================================================
 // Configuration
 // ============================================================================
@@ -41,6 +43,10 @@ pub struct FileReplacementConfig {
     ///
     /// Has no effect when `backup_replaced` is `false`.
     pub backup_dir: Option<PathBuf>,
+
+    /// Optional permission configuration applied to the replacement file after
+    /// it has been placed.  If `None`, no permission changes are made.
+    pub permission_config: Option<PermissionConfig>,
 }
 
 // ============================================================================
@@ -155,6 +161,10 @@ impl FileReplacementService {
             std::fs::create_dir_all(parent)?;
         }
 
+        // Permission pre-check and permission snapshot.  The snapshot must be
+        // taken here because place_file() moves new_file_path off disk.
+        let saved_perms = self.check_and_snapshot_permissions(new_file_path)?;
+
         let in_place = paths_are_same(existing_path, final_path);
 
         if in_place {
@@ -187,6 +197,8 @@ impl FileReplacementService {
             place_file(&staged, final_path)?;
             debug!(target: "file_replacement", "moved staged file to final path");
 
+            self.apply_final_permissions(final_path, &saved_perms)?;
+
             Ok(ReplacementOutcome {
                 final_path: final_path.to_path_buf(),
                 backed_up_to,
@@ -204,11 +216,71 @@ impl FileReplacementService {
 
             let backed_up_to = self.retire_existing(existing_path)?;
 
+            self.apply_final_permissions(final_path, &saved_perms)?;
+
             Ok(ReplacementOutcome {
                 final_path: final_path.to_path_buf(),
                 backed_up_to,
             })
         }
+    }
+
+    /// Check that `path` is readable and, if permission preservation is
+    /// enabled, save a snapshot of its permissions for later application.
+    ///
+    /// Returns `None` when no permission config is set, and `Some(perms)` /
+    /// `Some(None)` depending on whether preservation is enabled.
+    fn check_and_snapshot_permissions(
+        &self,
+        path: &Path,
+    ) -> Result<Option<std::fs::Permissions>, FileReplacementError> {
+        let Some(ref perm_config) = self.config.permission_config else {
+            return Ok(None);
+        };
+
+        PermissionChecker::check_readable(path).map_err(|e| {
+            FileReplacementError::Io(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                e.to_string(),
+            ))
+        })?;
+
+        if perm_config.preserve_permissions {
+            let perms = PermissionManager::get_permissions(path).map_err(|e| {
+                FileReplacementError::Io(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    e.to_string(),
+                ))
+            })?;
+            Ok(Some(perms))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Apply permissions to `final_path` after it has been placed on disk.
+    ///
+    /// Uses saved permissions when available; otherwise applies the configured
+    /// default mode.  Does nothing when no permission config is set.
+    fn apply_final_permissions(
+        &self,
+        final_path: &Path,
+        saved_perms: &Option<std::fs::Permissions>,
+    ) -> Result<(), FileReplacementError> {
+        let Some(ref perm_config) = self.config.permission_config else {
+            return Ok(());
+        };
+
+        if let Some(perms) = saved_perms {
+            std::fs::set_permissions(final_path, perms.clone())?;
+            debug!(target: "file_replacement", path = %final_path.display(), "restored permissions on replaced file");
+        } else {
+            PermissionManager::apply_defaults(final_path, perm_config)
+                .map_err(|e| FileReplacementError::Io(std::io::Error::other(e.to_string())))?;
+            debug!(target: "file_replacement", path = %final_path.display(), "applied default permissions to replaced file");
+        }
+
+        Ok(())
     }
 
     /// Move or delete the existing file according to the backup policy.
@@ -368,6 +440,7 @@ mod tests {
         let svc = FileReplacementService::new(FileReplacementConfig {
             backup_replaced: true,
             backup_dir: Some(backup_dir.clone()),
+            ..Default::default()
         });
         let outcome = svc.replace_file(&existing, &new_file, &final_path).unwrap();
 
@@ -396,6 +469,7 @@ mod tests {
         let svc = FileReplacementService::new(FileReplacementConfig {
             backup_replaced: true,
             backup_dir: Some(backup_dir.clone()),
+            ..Default::default()
         });
         let outcome = svc.replace_file(&existing, &new_file, &final_path).unwrap();
 
@@ -471,6 +545,7 @@ mod tests {
         let svc = FileReplacementService::new(FileReplacementConfig {
             backup_replaced: true,
             backup_dir: None,
+            ..Default::default()
         });
         assert!(matches!(
             svc.replace_file(&existing, &new_file, &final_path),
@@ -491,6 +566,7 @@ mod tests {
         let svc = FileReplacementService::new(FileReplacementConfig {
             backup_replaced: true,
             backup_dir: None, // triggers BackupDirNotConfigured
+            ..Default::default()
         });
         let result = svc.replace_file(&existing, &new_file, &final_path);
 

--- a/crates/chorrosion-application/src/file_replacement.rs
+++ b/crates/chorrosion-application/src/file_replacement.rs
@@ -176,6 +176,21 @@ impl FileReplacementService {
             place_file(new_file_path, &staged)?;
             debug!(target: "file_replacement", staged = %staged.display(), "staged new file alongside destination");
 
+            // Apply permissions to the staged file *before* retiring the
+            // original.  If permission application fails the original is still
+            // intact (staged is cleaned up below on early return).
+            if let Err(perm_err) = self.apply_final_permissions(&staged, &saved_perms) {
+                if let Err(cleanup_err) = std::fs::remove_file(&staged) {
+                    warn!(
+                        target: "file_replacement",
+                        staged = %staged.display(),
+                        error = %cleanup_err,
+                        "failed to clean up staged file after permission error"
+                    );
+                }
+                return Err(perm_err);
+            }
+
             // Retire (backup/delete) the existing file.  If this fails, clean
             // up the staged file so we leave the original intact.
             let backed_up_to = match self.retire_existing(existing_path) {
@@ -193,11 +208,10 @@ impl FileReplacementService {
                 }
             };
 
-            // Move the staged candidate into the final location.
+            // Move the staged candidate into the final location.  The rename
+            // preserves permissions already applied to the staged file.
             place_file(&staged, final_path)?;
             debug!(target: "file_replacement", "moved staged file to final path");
-
-            self.apply_final_permissions(final_path, &saved_perms)?;
 
             Ok(ReplacementOutcome {
                 final_path: final_path.to_path_buf(),
@@ -206,7 +220,7 @@ impl FileReplacementService {
         } else {
             // ── Different-path upgrade ────────────────────────────────────────
             // Place the new file at final_path first (unless it is already
-            // there), then retire the old file.
+            // there), apply permissions, then retire the old file.
             if !paths_are_same(new_file_path, final_path) {
                 place_file(new_file_path, final_path)?;
                 debug!(target: "file_replacement", "placed new file at destination");
@@ -214,9 +228,11 @@ impl FileReplacementService {
                 debug!(target: "file_replacement", "source is already at final path, skipping move");
             }
 
-            let backed_up_to = self.retire_existing(existing_path)?;
-
+            // Apply permissions before retiring the original so that a
+            // permission failure leaves the original file untouched.
             self.apply_final_permissions(final_path, &saved_perms)?;
+
+            let backed_up_to = self.retire_existing(existing_path)?;
 
             Ok(ReplacementOutcome {
                 final_path: final_path.to_path_buf(),
@@ -228,8 +244,9 @@ impl FileReplacementService {
     /// Check that `path` is readable and, if permission preservation is
     /// enabled, save a snapshot of its permissions for later application.
     ///
-    /// Returns `None` when no permission config is set, and `Some(perms)` /
-    /// `Some(None)` depending on whether preservation is enabled.
+    /// Returns `Ok(None)` when no permission config is set or when permission
+    /// preservation is disabled, and `Ok(Some(perms))` when preservation is
+    /// enabled and the current permissions are successfully captured.
     fn check_and_snapshot_permissions(
         &self,
         path: &Path,
@@ -275,8 +292,12 @@ impl FileReplacementService {
             std::fs::set_permissions(final_path, perms.clone())?;
             debug!(target: "file_replacement", path = %final_path.display(), "restored permissions on replaced file");
         } else {
-            PermissionManager::apply_defaults(final_path, perm_config)
-                .map_err(|e| FileReplacementError::Io(std::io::Error::other(e.to_string())))?;
+            PermissionManager::apply_defaults(final_path, perm_config).map_err(|e| {
+                FileReplacementError::Io(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    e.to_string(),
+                ))
+            })?;
             debug!(target: "file_replacement", path = %final_path.display(), "applied default permissions to replaced file");
         }
 
@@ -584,5 +605,136 @@ mod tests {
 
         // The original file must still be intact.
         assert_eq!(read(&existing), b"original content");
+    }
+
+    // ---- replace_file — permission config (Unix only) ----
+
+    #[cfg(unix)]
+    mod permission_tests {
+        use super::*;
+        use std::os::unix::fs::PermissionsExt;
+
+        fn make_svc_with_preserve() -> FileReplacementService {
+            FileReplacementService::new(FileReplacementConfig {
+                permission_config: Some(crate::permission::PermissionConfig {
+                    preserve_permissions: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        }
+
+        fn make_svc_with_defaults(file_mode: u32) -> FileReplacementService {
+            FileReplacementService::new(FileReplacementConfig {
+                permission_config: Some(crate::permission::PermissionConfig {
+                    preserve_permissions: false,
+                    file_mode,
+                    dir_mode: 0o700,
+                }),
+                ..Default::default()
+            })
+        }
+
+        #[test]
+        fn readability_precheck_blocks_unreadable_source() {
+            let dir = tempfile::tempdir().unwrap();
+            let existing = write_temp(&dir, "track.mp3", b"old");
+            let new_file = write_temp(&dir, "new.flac", b"new");
+            let final_path = dir.path().join("track.flac");
+
+            // Make new_file unreadable.
+            std::fs::set_permissions(&new_file, std::fs::Permissions::from_mode(0o000))
+                .expect("set permissions");
+
+            let svc = make_svc_with_preserve();
+            let result = svc.replace_file(&existing, &new_file, &final_path);
+
+            // Restore so tempdir cleanup works.
+            std::fs::set_permissions(&new_file, std::fs::Permissions::from_mode(0o644)).ok();
+
+            assert!(
+                matches!(result, Err(FileReplacementError::Io(_))),
+                "expected Io error from readability check, got {:?}",
+                result
+            );
+        }
+
+        #[test]
+        fn in_place_upgrade_preserves_source_permissions() {
+            let dir = tempfile::tempdir().unwrap();
+            let existing = write_temp(&dir, "track.flac", b"old content");
+            let new_file = write_temp(&dir, "track_new.flac", b"new content");
+            let final_path = existing.clone();
+
+            std::fs::set_permissions(&new_file, std::fs::Permissions::from_mode(0o640))
+                .expect("set permissions on source");
+
+            let svc = make_svc_with_preserve();
+            let outcome = svc.replace_file(&existing, &new_file, &final_path).unwrap();
+
+            let mode = std::fs::metadata(&outcome.final_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o640, "final file should have source permissions");
+        }
+
+        #[test]
+        fn in_place_upgrade_applies_default_permissions() {
+            let dir = tempfile::tempdir().unwrap();
+            let existing = write_temp(&dir, "track.flac", b"old content");
+            let new_file = write_temp(&dir, "track_new.flac", b"new content");
+            let final_path = existing.clone();
+
+            let svc = make_svc_with_defaults(0o600);
+            let outcome = svc.replace_file(&existing, &new_file, &final_path).unwrap();
+
+            let mode = std::fs::metadata(&outcome.final_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600, "final file should have configured default mode");
+        }
+
+        #[test]
+        fn different_path_upgrade_preserves_source_permissions() {
+            let dir = tempfile::tempdir().unwrap();
+            let existing = write_temp(&dir, "old_track.flac", b"old");
+            let new_file = write_temp(&dir, "downloaded.flac", b"better");
+            let final_path = dir.path().join("new_track.flac");
+
+            std::fs::set_permissions(&new_file, std::fs::Permissions::from_mode(0o644))
+                .expect("set permissions on source");
+
+            let svc = make_svc_with_preserve();
+            let outcome = svc.replace_file(&existing, &new_file, &final_path).unwrap();
+
+            let mode = std::fs::metadata(&outcome.final_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o644, "final file should have source permissions");
+        }
+
+        #[test]
+        fn different_path_upgrade_applies_default_permissions() {
+            let dir = tempfile::tempdir().unwrap();
+            let existing = write_temp(&dir, "old_track.flac", b"old");
+            let new_file = write_temp(&dir, "downloaded.flac", b"better");
+            let final_path = dir.path().join("new_track.flac");
+
+            let svc = make_svc_with_defaults(0o664);
+            let outcome = svc.replace_file(&existing, &new_file, &final_path).unwrap();
+
+            let mode = std::fs::metadata(&outcome.final_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o664, "final file should have configured default mode");
+        }
     }
 }


### PR DESCRIPTION
## Summary
Wires the PermissionChecker and PermissionManager utilities (added in PR #338) into the file operation and file replacement paths.

## Changes
- **ile_organization.rs**: pply_file_operation now accepts an Option<&PermissionConfig> parameter. When provided, it checks source readability before the operation and applies/preserves permissions on the destination afterward. New Permission(String) error variant added. Unix-only permission tests added.
- **ile_replacement.rs**: FileReplacementConfig gains an optional permission_config field. FileReplacementService::replace_file checks source readability before staging and applies/preserves permissions after the file lands in the final location. Two private helpers check_and_snapshot_permissions and pply_final_permissions encapsulate the logic.
- **ROADMAP.md**: Phase 5.2 permission handling marked complete.

## Validation
- [x] cargo fmt --all --check
- [x] cargo build --workspace
- [x] cargo test --workspace
- [x] cargo clippy --workspace -- -D warnings
- [x] Rust 2024 compatibility check

Closes #336
Builds on #338
