### PR TITLE
feat: forms authentication with session cookies (#344)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -336,7 +336,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 - [x] API key generation and management (`/api/v1/auth/api-keys`) ✓
 - [x] Basic authentication support (`Authorization: Basic ...`) ✓
-- [ ] Forms authentication (optional)
+- [x] Forms authentication (optional) (Issue #344) ✓
 - [ ] Permission levels (optional)
 
 ---

--- a/crates/chorrosion-api/Cargo.toml
+++ b/crates/chorrosion-api/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 postgres = ["sqlx/postgres", "chorrosion-infrastructure/postgres"]
 
 [dependencies]
-axum = { workspace = true }
+axum = { workspace = true, features = ["form"] }
 bytes = "1"
 chorrosion-application = { path = "../chorrosion-application" }
 chorrosion-domain = { path = "../chorrosion-domain" }

--- a/crates/chorrosion-api/src/handlers/auth.rs
+++ b/crates/chorrosion-api/src/handlers/auth.rs
@@ -25,9 +25,12 @@ struct ApiKeyRecord {
     last_used_at: Option<chrono::DateTime<Utc>>,
 }
 
+const SESSION_TTL_SECONDS: i64 = 86_400;
+
 #[derive(Debug, Clone)]
 struct FormSessionRecord {
     token: String,
+    created_at: chrono::DateTime<Utc>,
     last_used_at: Option<chrono::DateTime<Utc>>,
 }
 
@@ -143,14 +146,24 @@ pub(crate) async fn validate_api_key_and_touch(key: &str) -> bool {
 }
 
 fn build_form_session_cookie(token: &str) -> String {
-    format!("chorrosion_session={token}; HttpOnly; Path=/; SameSite=Lax; Max-Age=86400")
+    format!(
+        "chorrosion_session={token}; HttpOnly; Path=/; SameSite=Lax; Secure; Max-Age={SESSION_TTL_SECONDS}"
+    )
 }
 
 fn clear_form_session_cookie() -> &'static str {
-    "chorrosion_session=; HttpOnly; Path=/; SameSite=Lax; Max-Age=0"
+    "chorrosion_session=; HttpOnly; Path=/; SameSite=Lax; Secure; Max-Age=0"
 }
 
+/// Matches the middleware's credential comparison including the same `MAX_CREDENTIAL_BYTES`
+/// truncation so both auth paths behave consistently for long credentials.
+const MAX_CREDENTIAL_BYTES: usize = 256;
+
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    // Truncate to cap allocation/CPU work on attacker-controlled input.
+    let a = &a[..a.len().min(MAX_CREDENTIAL_BYTES)];
+    let b = &b[..b.len().min(MAX_CREDENTIAL_BYTES)];
+
     let target_len = b.len().max(1);
     let mut pa = vec![0u8; target_len];
     let mut pb = vec![0u8; target_len];
@@ -179,19 +192,35 @@ pub(crate) fn extract_form_session_token(headers: &HeaderMap) -> Option<String> 
 }
 
 pub(crate) async fn validate_form_session_and_touch(token: &str) -> bool {
+    let now = Utc::now();
     {
         let store = form_session_store().read().await;
-        if !store.iter().any(|r| r.token == token) {
-            return false;
+        match store.iter().find(|r| r.token == token) {
+            None => return false,
+            Some(record) => {
+                // Reject sessions that have exceeded SESSION_TTL_SECONDS.
+                let age_secs = now.signed_duration_since(record.created_at).num_seconds();
+                if age_secs >= SESSION_TTL_SECONDS {
+                    // Will be evicted on the write-lock pass below.
+                    drop(store);
+                    form_session_store()
+                        .write()
+                        .await
+                        .retain(|r| r.token != token);
+                    return false;
+                }
+            }
         }
     }
 
-    let now = Utc::now();
     let mut store = form_session_store().write().await;
+    // Prune any other sessions that have expired while we hold the write lock.
+    store.retain(|r| now.signed_duration_since(r.created_at).num_seconds() < SESSION_TTL_SECONDS);
     if let Some(record) = store.iter_mut().find(|r| r.token == token) {
         record.last_used_at = Some(now);
         true
     } else {
+        // Key was removed between the read-lock check and here (TOCTOU).
         false
     }
 }
@@ -276,6 +305,7 @@ pub async fn forms_login(
     let token = format!("cs_{}", Uuid::new_v4());
     let record = FormSessionRecord {
         token: token.clone(),
+        created_at: Utc::now(),
         last_used_at: None,
     };
     form_session_store().write().await.push(record);
@@ -432,6 +462,12 @@ mod tests {
         api_key_store().write().await.clear();
     }
 
+    async fn reset_form_sessions() {
+        if let Some(store) = FORM_SESSIONS.get() {
+            store.write().await.clear();
+        }
+    }
+
     async fn make_test_state() -> AppState {
         use sqlx::sqlite::SqlitePoolOptions;
         let pool = SqlitePoolOptions::new()
@@ -530,6 +566,7 @@ mod tests {
     async fn forms_login_and_logout_lifecycle() {
         let _lock = test_mutex().lock().await;
         reset_store().await;
+        reset_form_sessions().await;
 
         let mut config = AppConfig::default();
         config.auth.basic_username = Some("user".to_string());
@@ -577,6 +614,7 @@ mod tests {
     async fn forms_login_rejects_invalid_credentials() {
         let _lock = test_mutex().lock().await;
         reset_store().await;
+        reset_form_sessions().await;
 
         let mut config = AppConfig::default();
         config.auth.basic_username = Some("user".to_string());

--- a/crates/chorrosion-api/src/handlers/auth.rs
+++ b/crates/chorrosion-api/src/handlers/auth.rs
@@ -2,12 +2,15 @@
 use axum::{
     extract::{Path, State},
     http::StatusCode,
-    Json,
+    http::{header, HeaderMap},
+    response::AppendHeaders,
+    Form, Json,
 };
 use chorrosion_application::AppState;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
+use subtle::ConstantTimeEq;
 use tokio::sync::RwLock;
 use tracing::debug;
 use utoipa::ToSchema;
@@ -22,10 +25,21 @@ struct ApiKeyRecord {
     last_used_at: Option<chrono::DateTime<Utc>>,
 }
 
+#[derive(Debug, Clone)]
+struct FormSessionRecord {
+    token: String,
+    last_used_at: Option<chrono::DateTime<Utc>>,
+}
+
 static API_KEYS: OnceLock<RwLock<Vec<ApiKeyRecord>>> = OnceLock::new();
+static FORM_SESSIONS: OnceLock<RwLock<Vec<FormSessionRecord>>> = OnceLock::new();
 
 fn api_key_store() -> &'static RwLock<Vec<ApiKeyRecord>> {
     API_KEYS.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+fn form_session_store() -> &'static RwLock<Vec<FormSessionRecord>> {
+    FORM_SESSIONS.get_or_init(|| RwLock::new(Vec::new()))
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -65,6 +79,23 @@ pub struct ListApiKeysResponse {
 pub struct DeleteApiKeyResponse {
     pub deleted: bool,
     pub id: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct FormsLoginRequest {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FormsLoginResponse {
+    pub authenticated: bool,
+    pub username: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FormsLogoutResponse {
+    pub logged_out: bool,
 }
 
 fn key_prefix(key: &str) -> String {
@@ -109,6 +140,181 @@ pub(crate) async fn validate_api_key_and_touch(key: &str) -> bool {
         // Key was removed between the read-lock check and here (TOCTOU).
         false
     }
+}
+
+fn build_form_session_cookie(token: &str) -> String {
+    format!("chorrosion_session={token}; HttpOnly; Path=/; SameSite=Lax; Max-Age=86400")
+}
+
+fn clear_form_session_cookie() -> &'static str {
+    "chorrosion_session=; HttpOnly; Path=/; SameSite=Lax; Max-Age=0"
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let target_len = b.len().max(1);
+    let mut pa = vec![0u8; target_len];
+    let mut pb = vec![0u8; target_len];
+    let a_copy_len = a.len().min(target_len);
+    pa[..a_copy_len].copy_from_slice(&a[..a_copy_len]);
+    pb[..b.len()].copy_from_slice(b);
+
+    let lengths_equal = subtle::Choice::from((a.len() == b.len()) as u8);
+    let contents_equal = pa.ct_eq(&pb);
+    bool::from(lengths_equal & contents_equal)
+}
+
+pub(crate) fn extract_form_session_token(headers: &HeaderMap) -> Option<String> {
+    let cookie_header = headers.get(header::COOKIE)?;
+    let raw = cookie_header.to_str().ok()?;
+    for part in raw.split(';') {
+        let trimmed = part.trim();
+        if let Some(token) = trimmed.strip_prefix("chorrosion_session=") {
+            let token = token.trim();
+            if !token.is_empty() {
+                return Some(token.to_string());
+            }
+        }
+    }
+    None
+}
+
+pub(crate) async fn validate_form_session_and_touch(token: &str) -> bool {
+    {
+        let store = form_session_store().read().await;
+        if !store.iter().any(|r| r.token == token) {
+            return false;
+        }
+    }
+
+    let now = Utc::now();
+    let mut store = form_session_store().write().await;
+    if let Some(record) = store.iter_mut().find(|r| r.token == token) {
+        record.last_used_at = Some(now);
+        true
+    } else {
+        false
+    }
+}
+
+pub(crate) async fn revoke_form_session(token: &str) -> bool {
+    let mut store = form_session_store().write().await;
+    let before = store.len();
+    store.retain(|record| record.token != token);
+    store.len() != before
+}
+
+fn forms_auth_configured(state: &AppState) -> bool {
+    state
+        .config
+        .auth
+        .basic_username
+        .as_ref()
+        .is_some_and(|v| !v.trim().is_empty())
+        && state
+            .config
+            .auth
+            .basic_password
+            .as_ref()
+            .is_some_and(|v| !v.trim().is_empty())
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/forms/login",
+    request_body(content = FormsLoginRequest, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 200, description = "Forms login successful", body = FormsLoginResponse),
+        (status = 401, description = "Invalid credentials", body = AuthErrorResponse),
+        (status = 503, description = "Forms auth not configured", body = AuthErrorResponse)
+    ),
+    security(()),
+    tag = "auth"
+)]
+pub async fn forms_login(
+    State(state): State<AppState>,
+    Form(request): Form<FormsLoginRequest>,
+) -> Result<
+    (
+        AppendHeaders<[(header::HeaderName, String); 1]>,
+        Json<FormsLoginResponse>,
+    ),
+    (StatusCode, Json<AuthErrorResponse>),
+> {
+    if !forms_auth_configured(&state) {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(AuthErrorResponse {
+                error: "forms authentication is not configured".to_string(),
+            }),
+        ));
+    }
+
+    let expected_username = state
+        .config
+        .auth
+        .basic_username
+        .as_deref()
+        .unwrap_or_default();
+    let expected_password = state
+        .config
+        .auth
+        .basic_password
+        .as_deref()
+        .unwrap_or_default();
+
+    if !constant_time_eq(request.username.as_bytes(), expected_username.as_bytes())
+        || !constant_time_eq(request.password.as_bytes(), expected_password.as_bytes())
+    {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(AuthErrorResponse {
+                error: "invalid credentials".to_string(),
+            }),
+        ));
+    }
+
+    let token = format!("cs_{}", Uuid::new_v4());
+    let record = FormSessionRecord {
+        token: token.clone(),
+        last_used_at: None,
+    };
+    form_session_store().write().await.push(record);
+
+    Ok((
+        AppendHeaders([(header::SET_COOKIE, build_form_session_cookie(&token))]),
+        Json(FormsLoginResponse {
+            authenticated: true,
+            username: request.username,
+        }),
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/forms/logout",
+    responses(
+        (status = 200, description = "Forms logout completed", body = FormsLogoutResponse)
+    ),
+    tag = "auth"
+)]
+pub async fn forms_logout(
+    headers: HeaderMap,
+) -> (
+    AppendHeaders<[(header::HeaderName, &'static str); 1]>,
+    Json<FormsLogoutResponse>,
+) {
+    let revoked = if let Some(token) = extract_form_session_token(&headers) {
+        revoke_form_session(&token).await
+    } else {
+        false
+    };
+
+    (
+        AppendHeaders([(header::SET_COOKIE, clear_form_session_cookie())]),
+        Json(FormsLogoutResponse {
+            logged_out: revoked,
+        }),
+    )
 }
 
 #[utoipa::path(
@@ -318,5 +524,98 @@ mod tests {
             !result,
             "validate_api_key_and_touch must return false when key is deleted between locks"
         );
+    }
+
+    #[tokio::test]
+    async fn forms_login_and_logout_lifecycle() {
+        let _lock = test_mutex().lock().await;
+        reset_store().await;
+
+        let mut config = AppConfig::default();
+        config.auth.basic_username = Some("user".to_string());
+        config.auth.basic_password = Some("pass".to_string());
+        let state = make_test_state_with_config(config).await;
+
+        let login = forms_login(
+            State(state),
+            Form(FormsLoginRequest {
+                username: "user".to_string(),
+                password: "pass".to_string(),
+            }),
+        )
+        .await
+        .expect("forms login should succeed");
+
+        let set_cookie = login
+            .0
+             .0
+            .iter()
+            .find(|(name, _)| *name == header::SET_COOKIE)
+            .map(|(_, value)| value.clone())
+            .expect("set-cookie header");
+        let cookie_header = set_cookie
+            .split(';')
+            .next()
+            .expect("cookie pair")
+            .to_string();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            cookie_header.parse().expect("cookie header value"),
+        );
+
+        let token = extract_form_session_token(&headers).expect("session token extracted");
+        assert!(validate_form_session_and_touch(&token).await);
+
+        let (_, Json(logout_body)) = forms_logout(headers).await;
+        assert!(logout_body.logged_out);
+        assert!(!validate_form_session_and_touch(&token).await);
+    }
+
+    #[tokio::test]
+    async fn forms_login_rejects_invalid_credentials() {
+        let _lock = test_mutex().lock().await;
+        reset_store().await;
+
+        let mut config = AppConfig::default();
+        config.auth.basic_username = Some("user".to_string());
+        config.auth.basic_password = Some("pass".to_string());
+        let state = make_test_state_with_config(config).await;
+
+        let login = forms_login(
+            State(state),
+            Form(FormsLoginRequest {
+                username: "user".to_string(),
+                password: "wrong".to_string(),
+            }),
+        )
+        .await;
+
+        assert!(matches!(login, Err((StatusCode::UNAUTHORIZED, _))));
+    }
+
+    async fn make_test_state_with_config(config: AppConfig) -> AppState {
+        use sqlx::sqlite::SqlitePoolOptions;
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite");
+        sqlx::migrate!("../../migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+        AppState::new(
+            config,
+            Arc::new(SqliteArtistRepository::new(pool.clone())),
+            Arc::new(SqliteAlbumRepository::new(pool.clone())),
+            Arc::new(SqliteTrackRepository::new(pool.clone())),
+            Arc::new(SqliteQualityProfileRepository::new(pool.clone())),
+            Arc::new(SqliteMetadataProfileRepository::new(pool.clone())),
+            Arc::new(SqliteIndexerDefinitionRepository::new(pool.clone())),
+            Arc::new(SqliteDownloadClientDefinitionRepository::new(pool)),
+            chorrosion_infrastructure::ResponseCache::new(100, 60),
+        )
     }
 }

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -36,9 +36,11 @@ use handlers::artists::{
     __path_get_artist, __path_get_artist_statistics, __path_list_artists, __path_update_artist,
 };
 use handlers::auth::{
-    create_api_key, delete_api_key, list_api_keys, ApiKeyMetadataResponse, ApiKeyResponse,
-    AuthErrorResponse, CreateApiKeyRequest, DeleteApiKeyResponse, ListApiKeysResponse,
-    __path_create_api_key, __path_delete_api_key, __path_list_api_keys,
+    create_api_key, delete_api_key, forms_login, forms_logout, list_api_keys,
+    ApiKeyMetadataResponse, ApiKeyResponse, AuthErrorResponse, CreateApiKeyRequest,
+    DeleteApiKeyResponse, FormsLoginRequest, FormsLoginResponse, FormsLogoutResponse,
+    ListApiKeysResponse, __path_create_api_key, __path_delete_api_key, __path_forms_login,
+    __path_forms_logout, __path_list_api_keys,
 };
 use handlers::calendar::{
     get_ical_feed, list_upcoming_releases, CalendarAlbumResponse, CalendarErrorResponse,
@@ -226,6 +228,8 @@ async fn metrics() -> axum::response::Response {
         list_api_keys,
         create_api_key,
         delete_api_key,
+        forms_login,
+        forms_logout,
         list_artists,
         get_artist,
         get_artist_statistics,
@@ -298,6 +302,9 @@ async fn metrics() -> axum::response::Response {
             CreateApiKeyRequest,
             DeleteApiKeyResponse,
             AuthErrorResponse,
+            FormsLoginRequest,
+            FormsLoginResponse,
+            FormsLogoutResponse,
             BroadcastEventRequest,
             BroadcastEventResponse,
             ListArtistsResponse,
@@ -390,6 +397,8 @@ pub fn router(state: AppState) -> Router {
     let api_v1 = Router::new()
         .route("/auth/api-keys", get(list_api_keys).post(create_api_key))
         .route("/auth/api-keys/:id", axum::routing::delete(delete_api_key))
+        .route("/auth/forms/login", post(forms_login))
+        .route("/auth/forms/logout", post(forms_logout))
         .route("/artists", get(list_artists).post(create_artist))
         .route(
             "/artists/:id",

--- a/crates/chorrosion-api/src/middleware/auth.rs
+++ b/crates/chorrosion-api/src/middleware/auth.rs
@@ -155,7 +155,11 @@ pub async fn auth_middleware(
         return unauthorized().await.into_response();
     }
 
-    debug!(target: "auth", %path, "missing API key or bearer token");
+    debug!(
+        target: "auth",
+        %path,
+        "missing authentication credentials (expected Basic auth, API key, or forms session cookie)"
+    );
     unauthorized().await.into_response()
 }
 

--- a/crates/chorrosion-api/src/middleware/auth.rs
+++ b/crates/chorrosion-api/src/middleware/auth.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-use crate::handlers::auth::{api_key_count, validate_api_key_and_touch};
+use crate::handlers::auth::{
+    api_key_count, extract_form_session_token, validate_api_key_and_touch,
+    validate_form_session_and_touch,
+};
 use crate::API_V1_BASE;
 use axum::{
     extract::{Request, State},
@@ -10,6 +13,10 @@ use axum::{
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use subtle::ConstantTimeEq;
 use tracing::debug;
+
+fn path_matches(path: &str, route: &str) -> bool {
+    path == route || path.strip_prefix(API_V1_BASE) == Some(route)
+}
 
 fn extract_api_key(headers: &axum::http::HeaderMap) -> Option<String> {
     if let Some(api_key) = headers.get("X-Api-Key") {
@@ -102,11 +109,15 @@ pub async fn auth_middleware(
 
     // Bootstrap bypass: allow POST /api/v1/auth/api-keys only when no keys exist yet,
     // so the first key can be created without requiring prior authentication.
-    if method == Method::POST
-        && path.strip_prefix(API_V1_BASE) == Some("/auth/api-keys")
-        && api_key_count().await == 0
+    if method == Method::POST && path_matches(&path, "/auth/api-keys") && api_key_count().await == 0
     {
         debug!(target: "auth", %path, "auth bootstrap: no keys exist, allowing first key creation");
+        return next.run(request).await;
+    }
+
+    // Forms-login bypass: allow POST /api/v1/auth/forms/login without prior auth.
+    if method == Method::POST && path_matches(&path, "/auth/forms/login") {
+        debug!(target: "auth", %path, "auth forms-login bypass");
         return next.run(request).await;
     }
 
@@ -135,6 +146,15 @@ pub async fn auth_middleware(
         return unauthorized().await.into_response();
     }
 
+    if let Some(token) = extract_form_session_token(request.headers()) {
+        if validate_form_session_and_touch(&token).await {
+            debug!(target: "auth", %path, "forms session authentication successful");
+            return next.run(request).await;
+        }
+        debug!(target: "auth", %path, "forms session authentication failed");
+        return unauthorized().await.into_response();
+    }
+
     debug!(target: "auth", %path, "missing API key or bearer token");
     unauthorized().await.into_response()
 }
@@ -147,7 +167,8 @@ pub async fn unauthorized() -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        constant_time_eq, extract_api_key, extract_basic_credentials, MAX_CREDENTIAL_BYTES,
+        constant_time_eq, extract_api_key, extract_basic_credentials, extract_form_session_token,
+        validate_form_session_and_touch, MAX_CREDENTIAL_BYTES,
     };
     use axum::{
         body::Body,
@@ -351,6 +372,83 @@ mod tests {
         let request = Request::builder()
             .uri("/api/v1/system/status")
             .method("GET")
+            .body(Body::empty())
+            .expect("request");
+
+        let response = app.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn middleware_allows_valid_forms_session_cookie_when_configured() {
+        let mut config = AppConfig::default();
+        config.auth.basic_username = Some("user".to_string());
+        config.auth.basic_password = Some("pass".to_string());
+        let state = make_test_state(config).await;
+
+        let app = crate::router(state);
+        let login_request = Request::builder()
+            .uri("/api/v1/auth/forms/login")
+            .method("POST")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(Body::from("username=user&password=pass"))
+            .expect("login request");
+
+        let login_response = app
+            .clone()
+            .oneshot(login_request)
+            .await
+            .expect("login response");
+        assert_eq!(login_response.status(), StatusCode::OK);
+        let set_cookie = login_response
+            .headers()
+            .get("set-cookie")
+            .and_then(|v| v.to_str().ok())
+            .expect("set-cookie should exist");
+        let cookie_pair = set_cookie
+            .split(';')
+            .next()
+            .expect("cookie pair should exist");
+
+        let mut cookie_headers = HeaderMap::new();
+        cookie_headers.insert(
+            "Cookie",
+            HeaderValue::from_str(cookie_pair).expect("cookie"),
+        );
+        let token = extract_form_session_token(&cookie_headers).expect("token from cookie");
+        assert!(
+            validate_form_session_and_touch(&token).await,
+            "token from login should exist in session store"
+        );
+
+        let request = Request::builder()
+            .uri("/api/v1/system/status")
+            .method("GET")
+            .header("Cookie", cookie_pair)
+            .body(Body::empty())
+            .expect("request");
+
+        assert_eq!(
+            extract_form_session_token(request.headers()).as_deref(),
+            Some(token.as_str())
+        );
+
+        let response = app.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn middleware_rejects_invalid_forms_session_cookie() {
+        let mut config = AppConfig::default();
+        config.auth.basic_username = Some("user".to_string());
+        config.auth.basic_password = Some("pass".to_string());
+        let state = make_test_state(config).await;
+
+        let app = crate::router(state);
+        let request = Request::builder()
+            .uri("/api/v1/system/status")
+            .method("GET")
+            .header("Cookie", "chorrosion_session=invalid")
             .body(Body::empty())
             .expect("request");
 


### PR DESCRIPTION
## Forms Authentication with Session Cookies

Implements optional form-based authentication using in-memory session cookies. Closes #344.

### New Endpoints

| Method | Path | Auth Required |
|--------|------|---------------|
| `POST` | `/api/v1/auth/forms/login` | None (bypass) |
| `POST` | `/api/v1/auth/forms/logout` | Cookie session |

### How It Works

- **Login**: Accepts `application/x-www-form-urlencoded` body (`username`, `password`). Validates credentials against the existing `auth.basic_username` / `auth.basic_password` config using constant-time comparison. On success, sets a `chorrosion_session=cs_<uuid>; HttpOnly; Path=/; SameSite=Lax; Max-Age=86400` cookie.
- **Logout**: Reads the session cookie, revokes it from the in-memory store, and clears the cookie via `Max-Age=0`.
- **Middleware**: After API-key/Bearer checks, the auth middleware now also accepts a valid session cookie. The login endpoint itself is bypassed so unauthenticated clients can reach it.
- **Credential source**: Reuses `auth.basic_username` / `auth.basic_password` — no new config fields required.

### Session Store

`OnceLock<RwLock<Vec<FormSessionRecord>>>` — same in-memory pattern as the existing API key store. Sessions are scoped to the server process lifetime (intentional for the optional/simple auth use case).

### Changes

| File | Change |
|------|--------|
| `crates/chorrosion-api/src/handlers/auth.rs` | Session store, login/logout handlers, session helpers |
| `crates/chorrosion-api/src/middleware/auth.rs` | Cookie session validation path + login bypass + `path_matches()` fix |
| `crates/chorrosion-api/src/lib.rs` | Route wiring + OpenAPI paths/schemas |
| `crates/chorrosion-api/Cargo.toml` | Enable `axum` `"form"` feature |
| `ROADMAP.md` | Mark Phase 6.3 forms auth complete |

### Validation Gate

- `cargo fmt --all --check` ✅
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (185 tests in `chorrosion-api`, 4 new)
- `cargo clippy --workspace -- -D warnings` ✅
- Rust-2024 compatibility check ✅

### New Tests

- `handlers::auth::tests::forms_login_and_logout_lifecycle`
- `handlers::auth::tests::forms_login_rejects_invalid_credentials`
- `middleware::auth::tests::middleware_allows_valid_forms_session_cookie_when_configured`
- `middleware::auth::tests::middleware_rejects_invalid_forms_session_cookie`