### PR TITLE
docs: require issue and milestone linkage in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 
 ## Related Issue
 
-- Closes #<!-- issue number, if applicable -->
+- Closes #<!-- issue number (create an issue first if one does not exist) -->
 
 ## Milestone
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,10 @@
 
 - Closes #<!-- issue number, if applicable -->
 
+## Milestone
+
+- Milestone: <!-- e.g. Phase 4: Download Client Integration -->
+
 ## Type of change
 
 - [ ] Feature
@@ -22,6 +26,8 @@
 
 ## Checklist
 
+- [ ] This PR links a related issue using `Closes #<issue>` / `Fixes #<issue>` / `Resolves #<issue>`
+- [ ] This PR has an assigned milestone that matches the roadmap phase
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I ran `cargo fmt` and `cargo clippy -- -D warnings` locally
 - [ ] I updated documentation (if required)


### PR DESCRIPTION
## Summary
- add a milestone section to the PR template
- require linking related issues with closing keywords
- require assigning the matching roadmap milestone

## Why
This enforces the process request that PRs are consistently linked to both issues and milestones.

## Testing
- docs-only template update

Closes #354