### PR TITLE
feat: implement download status tracking for activity queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -205,7 +205,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
 
 ### 4.3 Download Monitoring
 
-- [ ] Download status tracking
+- [x] Download status tracking (Issue #359) ✓
 - [ ] Completion detection
 - [ ] Failed download handling
 - [ ] Stalled download detection

--- a/crates/chorrosion-api/Cargo.toml
+++ b/crates/chorrosion-api/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { workspace = true, features = ["test-util"] }
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
 criterion = { version = "0.5", features = ["async_tokio"] }
+wiremock = "0.6"
 
 [[bench]]
 name = "api_workflow_benchmarks"

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use axum::{extract::State, Json};
-use chorrosion_application::AppState;
+use chorrosion_application::{
+    AppState, DelugeClient, DownloadClient, DownloadState, NzbgetClient, QBittorrentClient,
+    SabnzbdClient, TransmissionClient,
+};
+use chorrosion_domain::DownloadClientDefinition;
+use chorrosion_infrastructure::repositories::Repository;
 use serde::Serialize;
-use tracing::debug;
+use tracing::{debug, warn};
 use utoipa::ToSchema;
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -19,11 +24,102 @@ pub struct ActivityListResponse {
     pub total: i64,
 }
 
-pub(crate) async fn activity_queue_snapshot(_state: &AppState) -> ActivityListResponse {
-    // Placeholder until queue integration is wired from download clients.
+fn build_download_client(definition: &DownloadClientDefinition) -> Option<Box<dyn DownloadClient>> {
+    let client_type = definition.client_type.trim().to_lowercase();
+    match client_type.as_str() {
+        "qbittorrent" => Some(Box::new(QBittorrentClient::new(
+            definition.base_url.clone(),
+            definition.username.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        "transmission" => Some(Box::new(TransmissionClient::new(
+            definition.base_url.clone(),
+            definition.username.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        "deluge" => Some(Box::new(DelugeClient::new(
+            definition.base_url.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        "sabnzbd" => Some(Box::new(SabnzbdClient::new(
+            definition.base_url.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        "nzbget" => Some(Box::new(NzbgetClient::new(
+            definition.base_url.clone(),
+            definition.username.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        _ => None,
+    }
+}
+
+fn state_label(state: &DownloadState) -> &'static str {
+    match state {
+        DownloadState::Queued => "queued",
+        DownloadState::Downloading => "downloading",
+        DownloadState::Paused => "paused",
+        DownloadState::Completed => "completed",
+        DownloadState::Error => "error",
+        DownloadState::Unknown => "unknown",
+    }
+}
+
+pub(crate) async fn activity_queue_snapshot(state: &AppState) -> ActivityListResponse {
+    let definitions = match state
+        .download_client_definition_repository
+        .list(1000, 0)
+        .await
+    {
+        Ok(definitions) => definitions,
+        Err(error) => {
+            warn!(target: "api", ?error, "failed to list download client definitions");
+            return ActivityListResponse {
+                items: vec![],
+                total: 0,
+            };
+        }
+    };
+
+    let mut items = Vec::new();
+    for definition in definitions
+        .into_iter()
+        .filter(|definition| definition.enabled)
+    {
+        let Some(client) = build_download_client(&definition) else {
+            warn!(
+                target: "api",
+                client_name = %definition.name,
+                client_type = %definition.client_type,
+                "unsupported download client type while building activity snapshot"
+            );
+            continue;
+        };
+
+        match client.list_downloads().await {
+            Ok(downloads) => {
+                items.extend(downloads.into_iter().map(|download| ActivityItemResponse {
+                    id: format!("{}:{}", definition.name, download.hash),
+                    name: format!("{}: {}", definition.name, download.name),
+                    state: state_label(&download.state).to_string(),
+                    progress_percent: download.progress_percent,
+                }));
+            }
+            Err(error) => {
+                warn!(
+                    target: "api",
+                    client_name = %definition.name,
+                    client_type = %definition.client_type,
+                    ?error,
+                    "failed to retrieve downloads for activity queue snapshot"
+                );
+            }
+        }
+    }
+
     ActivityListResponse {
-        items: vec![],
-        total: 0,
+        total: items.len() as i64,
+        items,
     }
 }
 
@@ -89,6 +185,8 @@ mod tests {
         http::{Request, StatusCode},
     };
     use chorrosion_config::AppConfig;
+    use chorrosion_domain::DownloadClientDefinition;
+    use chorrosion_infrastructure::repositories::Repository;
     use chorrosion_infrastructure::sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
         SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,
@@ -97,6 +195,8 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
     use tower::util::ServiceExt;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     /// Build a test `AppState` with basic auth configured so that requests can
     /// be authenticated without touching the global API key store.
@@ -174,6 +274,64 @@ mod tests {
     async fn get_activity_processing_returns_empty_placeholder_payload() {
         let state = make_test_state().await;
         assert_empty_activity_response(state, "/api/v1/activity/processing").await;
+    }
+
+    #[tokio::test]
+    async fn get_activity_queue_returns_download_status_items() {
+        let state = make_test_state().await;
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[
+                    {
+                        "hash": "abc123",
+                        "name": "Album FLAC",
+                        "progress": 0.64,
+                        "state": "downloading",
+                        "category": "music"
+                    }
+                ]"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let created = state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "qbit-main",
+                "qbittorrent",
+                server.uri(),
+            ))
+            .await
+            .expect("create download client definition");
+        assert_eq!(created.name, "qbit-main");
+
+        let app = crate::router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/activity/queue")
+                    .header("Authorization", "Basic dXNlcjpwYXNz")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should be readable");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("body should be valid JSON");
+
+        assert_eq!(payload["total"], 1);
+        assert_eq!(payload["items"][0]["id"], "qbit-main:abc123");
+        assert_eq!(payload["items"][0]["name"], "qbit-main: Album FLAC");
+        assert_eq!(payload["items"][0]["state"], "downloading");
+        assert_eq!(payload["items"][0]["progress_percent"], 64);
     }
 
     #[tokio::test]

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-use axum::{extract::State, Json};
+use axum::{extract::State, http::StatusCode, Json};
 use chorrosion_application::{
     AppState, DelugeClient, DownloadClient, DownloadState, NzbgetClient, QBittorrentClient,
     SabnzbdClient, TransmissionClient,
 };
 use chorrosion_domain::DownloadClientDefinition;
 use chorrosion_infrastructure::repositories::Repository;
+use futures_util::future::join_all;
 use serde::Serialize;
 use tracing::{debug, warn};
 use utoipa::ToSchema;
@@ -65,46 +66,49 @@ fn state_label(state: &DownloadState) -> &'static str {
     }
 }
 
-pub(crate) async fn activity_queue_snapshot(state: &AppState) -> ActivityListResponse {
-    let definitions = match state
+pub(crate) async fn activity_queue_snapshot(
+    state: &AppState,
+) -> Result<ActivityListResponse, String> {
+    let definitions = state
         .download_client_definition_repository
         .list(1000, 0)
         .await
-    {
-        Ok(definitions) => definitions,
-        Err(error) => {
-            warn!(target: "api", ?error, "failed to list download client definitions");
-            return ActivityListResponse {
-                items: vec![],
-                total: 0,
-            };
-        }
-    };
+        .map_err(|e| {
+            warn!(target: "api", error = ?e, "failed to list download client definitions");
+            format!("failed to list download client definitions: {e}")
+        })?;
 
-    let mut items = Vec::new();
-    for definition in definitions
+    let enabled: Vec<_> = definitions.into_iter().filter(|d| d.enabled).collect();
+
+    // Build (definition, client) pairs, skipping unsupported types.
+    let pairs: Vec<_> = enabled
         .into_iter()
-        .filter(|definition| definition.enabled)
-    {
-        let Some(client) = build_download_client(&definition) else {
-            warn!(
-                target: "api",
-                client_name = %definition.name,
-                client_type = %definition.client_type,
-                "unsupported download client type while building activity snapshot"
-            );
-            continue;
-        };
+        .filter_map(|definition| {
+            let client = build_download_client(&definition);
+            if client.is_none() {
+                warn!(
+                    target: "api",
+                    client_name = %definition.name,
+                    client_type = %definition.client_type,
+                    "unsupported download client type while building activity snapshot"
+                );
+            }
+            client.map(|c| (definition, c))
+        })
+        .collect();
 
+    // Poll all clients concurrently.
+    let results = join_all(pairs.into_iter().map(|(definition, client)| async move {
         match client.list_downloads().await {
-            Ok(downloads) => {
-                items.extend(downloads.into_iter().map(|download| ActivityItemResponse {
-                    id: format!("{}:{}", definition.name, download.hash),
+            Ok(downloads) => downloads
+                .into_iter()
+                .map(|download| ActivityItemResponse {
+                    id: format!("{}:{}", definition.id, download.hash),
                     name: format!("{}: {}", definition.name, download.name),
                     state: state_label(&download.state).to_string(),
                     progress_percent: download.progress_percent,
-                }));
-            }
+                })
+                .collect::<Vec<_>>(),
             Err(error) => {
                 warn!(
                     target: "api",
@@ -113,14 +117,18 @@ pub(crate) async fn activity_queue_snapshot(state: &AppState) -> ActivityListRes
                     ?error,
                     "failed to retrieve downloads for activity queue snapshot"
                 );
+                Vec::new()
             }
         }
-    }
+    }))
+    .await;
 
-    ActivityListResponse {
+    let items: Vec<_> = results.into_iter().flatten().collect();
+
+    Ok(ActivityListResponse {
         total: items.len() as i64,
         items,
-    }
+    })
 }
 
 pub(crate) async fn activity_import_snapshot(_state: &AppState) -> ActivityListResponse {
@@ -131,18 +139,34 @@ pub(crate) async fn activity_import_snapshot(_state: &AppState) -> ActivityListR
     }
 }
 
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ActivityErrorResponse {
+    pub error: String,
+}
+
 #[utoipa::path(
     get,
     path = "/api/v1/activity/queue",
     responses(
-        (status = 200, description = "Current download queue", body = ActivityListResponse)
+        (status = 200, description = "Current download queue", body = ActivityListResponse),
+        (status = 500, description = "Internal server error", body = ActivityErrorResponse)
     ),
     tag = "activity"
 )]
-pub async fn get_activity_queue(State(state): State<AppState>) -> Json<ActivityListResponse> {
+pub async fn get_activity_queue(
+    State(state): State<AppState>,
+) -> Result<Json<ActivityListResponse>, (StatusCode, Json<ActivityErrorResponse>)> {
     debug!(target: "api", "fetching activity queue");
 
-    Json(activity_queue_snapshot(&state).await)
+    activity_queue_snapshot(&state)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ActivityErrorResponse { error: e }),
+            )
+        })
 }
 
 #[utoipa::path(
@@ -328,7 +352,19 @@ mod tests {
             serde_json::from_slice(&body).expect("body should be valid JSON");
 
         assert_eq!(payload["total"], 1);
-        assert_eq!(payload["items"][0]["id"], "qbit-main:abc123");
+        let id = payload["items"][0]["id"]
+            .as_str()
+            .expect("id should be a string");
+        assert!(
+            id.ends_with(":abc123"),
+            "id should end with download hash, got: {id}"
+        );
+        // The prefix is the definition UUID (stable, immutable).
+        let prefix = id.strip_suffix(":abc123").unwrap();
+        assert!(
+            uuid::Uuid::parse_str(prefix).is_ok(),
+            "id prefix should be a valid UUID, got: {prefix}"
+        );
         assert_eq!(payload["items"][0]["name"], "qbit-main: Album FLAC");
         assert_eq!(payload["items"][0]["state"], "downloading");
         assert_eq!(payload["items"][0]["progress_percent"], 64);
@@ -351,5 +387,151 @@ mod tests {
             .expect("request should succeed");
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// One supported client returns a download item while a second definition
+    /// uses an unsupported client type. The endpoint must still return the
+    /// successful client's items and report the correct total.
+    #[tokio::test]
+    async fn get_activity_queue_skips_unsupported_client_and_returns_others() {
+        let state = make_test_state().await;
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[{
+                    "hash": "def456",
+                    "name": "Resilience Album",
+                    "progress": 1.0,
+                    "state": "completed",
+                    "category": "music"
+                }]"#,
+            ))
+            .mount(&server)
+            .await;
+
+        // Supported client.
+        state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "qbit-ok",
+                "qbittorrent",
+                server.uri(),
+            ))
+            .await
+            .expect("create qbittorrent definition");
+
+        // Unsupported client type – should be silently skipped.
+        state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "unknown-client",
+                "not_a_real_client",
+                "http://localhost:1",
+            ))
+            .await
+            .expect("create unsupported definition");
+
+        let app = crate::router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/activity/queue")
+                    .header("Authorization", "Basic dXNlcjpwYXNz")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should be readable");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("body should be valid JSON");
+
+        // Only the qBittorrent item should appear; the unsupported client is skipped.
+        assert_eq!(payload["total"], 1);
+        assert_eq!(payload["items"][0]["name"], "qbit-ok: Resilience Album");
+        assert_eq!(payload["items"][0]["state"], "completed");
+        assert_eq!(payload["items"][0]["progress_percent"], 100);
+    }
+
+    /// When a supported client returns an HTTP error (500), the endpoint should
+    /// still succeed and return items from healthy clients.
+    #[tokio::test]
+    async fn get_activity_queue_skips_failing_client_and_returns_others() {
+        let state = make_test_state().await;
+
+        // Healthy client.
+        let healthy_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[{
+                    "hash": "aaa111",
+                    "name": "Good Album",
+                    "progress": 0.50,
+                    "state": "downloading",
+                    "category": "music"
+                }]"#,
+            ))
+            .mount(&healthy_server)
+            .await;
+
+        state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "qbit-healthy",
+                "qbittorrent",
+                healthy_server.uri(),
+            ))
+            .await
+            .expect("create healthy definition");
+
+        // Failing client – returns 500.
+        let failing_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&failing_server)
+            .await;
+
+        state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "qbit-broken",
+                "qbittorrent",
+                failing_server.uri(),
+            ))
+            .await
+            .expect("create failing definition");
+
+        let app = crate::router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/activity/queue")
+                    .header("Authorization", "Basic dXNlcjpwYXNz")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should be readable");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("body should be valid JSON");
+
+        // Only the healthy client's item should appear.
+        assert_eq!(payload["total"], 1);
+        assert_eq!(payload["items"][0]["name"], "qbit-healthy: Good Album");
+        assert_eq!(payload["items"][0]["state"], "downloading");
+        assert_eq!(payload["items"][0]["progress_percent"], 50);
     }
 }

--- a/crates/chorrosion-api/src/handlers/events.rs
+++ b/crates/chorrosion-api/src/handlers/events.rs
@@ -19,7 +19,7 @@ use std::{
     time::Duration,
 };
 use tokio::sync::broadcast;
-use tracing::debug;
+use tracing::{debug, warn};
 use utoipa::ToSchema;
 
 const SSE_EVENT_INTERVAL_SECS: u64 = 5;
@@ -306,7 +306,13 @@ pub async fn stream_download_progress_events(
 
             tokio::time::sleep(Duration::from_secs(SSE_EVENT_INTERVAL_SECS)).await;
 
-            let queue = activity_queue_snapshot(&state).await;
+            let queue = activity_queue_snapshot(&state).await.unwrap_or_else(|e| {
+                warn!(target: "api", error = %e, "SSE: failed to build activity queue snapshot");
+                ActivityListResponse {
+                    items: vec![],
+                    total: 0,
+                }
+            });
             let payload = DownloadProgressEventPayload { sequence, queue };
             let data = serde_json::to_string(&payload)
                 .expect("DownloadProgressEventPayload is always serializable");

--- a/crates/chorrosion-api/src/handlers/events.rs
+++ b/crates/chorrosion-api/src/handlers/events.rs
@@ -517,20 +517,21 @@ mod tests {
     ///
     /// With `tokio::time::pause()`, keepalive timers can race with real async
     /// I/O (e.g. SQLite queries inside `activity_queue_snapshot`) causing a
-    /// keepalive to arrive before the expected data event.
+    /// keepalive to arrive before the expected data event.  The function skips
+    /// up to 50 consecutive keepalive frames to avoid hanging indefinitely.
     async fn read_next_data_event<S, E>(stream: &mut std::pin::Pin<Box<S>>) -> String
     where
         S: futures_util::Stream<Item = Result<axum::body::Bytes, E>> + Send,
         E: std::fmt::Debug,
     {
-        loop {
+        const MAX_KEEPALIVES: usize = 50;
+        for _ in 0..MAX_KEEPALIVES {
             let text = read_next_sse_event(stream).await;
-            // SSE keepalives are sent as comments (": keepalive\n\n").
-            // Skip them and return only real events.
             if !text.trim().starts_with(": keepalive") {
                 return text;
             }
         }
+        panic!("exceeded {MAX_KEEPALIVES} consecutive keepalive frames without receiving a data event");
     }
 
     /// Drives the `stream_events` handler end-to-end: checks the SSE content-type header,

--- a/crates/chorrosion-api/src/handlers/events.rs
+++ b/crates/chorrosion-api/src/handlers/events.rs
@@ -513,6 +513,26 @@ mod tests {
         buf
     }
 
+    /// Like [`read_next_sse_event`] but skips SSE keepalive comments.
+    ///
+    /// With `tokio::time::pause()`, keepalive timers can race with real async
+    /// I/O (e.g. SQLite queries inside `activity_queue_snapshot`) causing a
+    /// keepalive to arrive before the expected data event.
+    async fn read_next_data_event<S, E>(stream: &mut std::pin::Pin<Box<S>>) -> String
+    where
+        S: futures_util::Stream<Item = Result<axum::body::Bytes, E>> + Send,
+        E: std::fmt::Debug,
+    {
+        loop {
+            let text = read_next_sse_event(stream).await;
+            // SSE keepalives are sent as comments (": keepalive\n\n").
+            // Skip them and return only real events.
+            if !text.trim().starts_with(": keepalive") {
+                return text;
+            }
+        }
+    }
+
     /// Drives the `stream_events` handler end-to-end: checks the SSE content-type header,
     /// validates the initial `connected` event, and confirms that the event name rotates
     /// deterministically across ticks.  Time is paused after state setup so the runtime
@@ -595,7 +615,7 @@ mod tests {
             "expected connected event, got: {connected}"
         );
 
-        let text = read_next_sse_event(&mut data_stream).await;
+        let text = read_next_data_event(&mut data_stream).await;
         assert!(
             text.contains("event: download_queue_snapshot"),
             "expected download_queue_snapshot event, got: {text}"

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -18,9 +18,9 @@ use chorrosion_application::AppState;
 use chorrosion_config::PermissionLevel;
 use chorrosion_infrastructure::repositories::Repository;
 use handlers::activity::{
-    get_activity_history, get_activity_processing, get_activity_queue, ActivityItemResponse,
-    ActivityListResponse, __path_get_activity_history, __path_get_activity_processing,
-    __path_get_activity_queue,
+    get_activity_history, get_activity_processing, get_activity_queue, ActivityErrorResponse,
+    ActivityItemResponse, ActivityListResponse, __path_get_activity_history,
+    __path_get_activity_processing, __path_get_activity_queue,
 };
 use handlers::albums::{
     create_album, delete_album, get_album, list_albums, list_albums_by_artist,
@@ -337,6 +337,7 @@ async fn metrics() -> axum::response::Response {
             NotificationTestResponse,
             ActivityItemResponse,
             ActivityListResponse,
+            ActivityErrorResponse,
             BroadcastErrorResponse,
             SseConnectionsResponse,
             ListQualityProfilesResponse,


### PR DESCRIPTION
## Summary
- replace activity queue placeholder with live polling across enabled download clients
- aggregate statuses from qBittorrent, Transmission, Deluge, SABnzbd, and NZBGet
- keep endpoint resilient by skipping unsupported/failing clients while returning available data
- add authenticated API test verifying populated queue response

## Validation
- cargo test -p chorrosion-api activity -- --nocapture
- cargo clippy -p chorrosion-api -- -D warnings

Closes #359