### PR TITLE
feat: implement completion detection for activity history

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -206,7 +206,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
 ### 4.3 Download Monitoring
 
 - [x] Download status tracking (Issue #359) ✓
-- [ ] Completion detection
+- [x] Completion detection (Issue #361) ✓
 - [ ] Failed download handling
 - [ ] Stalled download detection
 - [ ] Download history

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -146,7 +146,7 @@ pub(crate) async fn activity_history_snapshot(
     let items: Vec<ActivityItemResponse> = queue
         .items
         .into_iter()
-        .filter(|item| item.state == "completed")
+        .filter(|item| item.state == state_label(&DownloadState::Completed))
         .collect();
 
     Ok(ActivityListResponse {

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -139,6 +139,22 @@ pub(crate) async fn activity_import_snapshot(_state: &AppState) -> ActivityListR
     }
 }
 
+pub(crate) async fn activity_history_snapshot(
+    state: &AppState,
+) -> Result<ActivityListResponse, String> {
+    let queue = activity_queue_snapshot(state).await?;
+    let items: Vec<ActivityItemResponse> = queue
+        .items
+        .into_iter()
+        .filter(|item| item.state == "completed")
+        .collect();
+
+    Ok(ActivityListResponse {
+        total: items.len() as i64,
+        items,
+    })
+}
+
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ActivityErrorResponse {
     pub error: String,
@@ -173,18 +189,25 @@ pub async fn get_activity_queue(
     get,
     path = "/api/v1/activity/history",
     responses(
-        (status = 200, description = "Activity history", body = ActivityListResponse)
+        (status = 200, description = "Activity history", body = ActivityListResponse),
+        (status = 500, description = "Internal server error", body = ActivityErrorResponse)
     ),
     tag = "activity"
 )]
-pub async fn get_activity_history(State(_state): State<AppState>) -> Json<ActivityListResponse> {
+pub async fn get_activity_history(
+    State(state): State<AppState>,
+) -> Result<Json<ActivityListResponse>, (StatusCode, Json<ActivityErrorResponse>)> {
     debug!(target: "api", "fetching activity history");
 
-    // Placeholder until history persistence/querying is implemented.
-    Json(ActivityListResponse {
-        items: vec![],
-        total: 0,
-    })
+    activity_history_snapshot(&state)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ActivityErrorResponse { error: e }),
+            )
+        })
 }
 
 #[utoipa::path(
@@ -292,6 +315,69 @@ mod tests {
     async fn get_activity_history_returns_empty_placeholder_payload() {
         let state = make_test_state().await;
         assert_empty_activity_response(state, "/api/v1/activity/history").await;
+    }
+
+    #[tokio::test]
+    async fn get_activity_history_returns_only_completed_items() {
+        let state = make_test_state().await;
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[
+                    {
+                        "hash": "completed1",
+                        "name": "Album Done",
+                        "progress": 1.0,
+                        "state": "uploading",
+                        "category": "music"
+                    },
+                    {
+                        "hash": "active1",
+                        "name": "Album Active",
+                        "progress": 0.4,
+                        "state": "downloading",
+                        "category": "music"
+                    }
+                ]"#,
+            ))
+            .mount(&server)
+            .await;
+
+        state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "qbit-main",
+                "qbittorrent",
+                server.uri(),
+            ))
+            .await
+            .expect("create download client definition");
+
+        let app = crate::router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/activity/history")
+                    .header("Authorization", "Basic dXNlcjpwYXNz")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should be readable");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("body should be valid JSON");
+
+        assert_eq!(payload["total"], 1);
+        assert_eq!(payload["items"][0]["state"], "completed");
+        assert_eq!(payload["items"][0]["name"], "qbit-main: Album Done");
     }
 
     #[tokio::test]

--- a/crates/chorrosion-api/src/handlers/events.rs
+++ b/crates/chorrosion-api/src/handlers/events.rs
@@ -531,7 +531,9 @@ mod tests {
                 return text;
             }
         }
-        panic!("exceeded {MAX_KEEPALIVES} consecutive keepalive frames without receiving a data event");
+        panic!(
+            "exceeded {MAX_KEEPALIVES} consecutive keepalive frames without receiving a data event"
+        );
     }
 
     /// Drives the `stream_events` handler end-to-end: checks the SSE content-type header,


### PR DESCRIPTION
## Summary
- add activity history snapshot derived from live queue snapshots
- detect completed items by filtering queue entries with state completed
- update /api/v1/activity/history to return detected completed downloads
- add endpoint test proving completed-only filtering behavior

## Validation
- cargo test -p chorrosion-api activity -- --nocapture
- cargo clippy -p chorrosion-api -- -D warnings

Closes #361