### PR TITLE
feat: detect stalled downloads in activity endpoint

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,7 +208,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
 - [x] Download status tracking (Issue #359) ✓
 - [x] Completion detection (Issue #361) ✓
 - [x] Failed download handling (Issue #363) ✓
-- [ ] Stalled download detection
+- [x] Stalled download detection (Issue #365) ✓
 - [ ] Download history
 
 ---

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -225,14 +225,12 @@ pub(crate) async fn activity_stalled_snapshot(
     let filtered: Vec<_> = snapshot
         .items
         .into_iter()
+        .filter(|item| item.download.state == DownloadState::Downloading)
         .map(|item| {
             let item_id = format!("{}:{}", item.definition_id, item.download.hash);
             (item_id, item)
         })
-        .filter(|(item_id, item)| {
-            item.download.state == DownloadState::Downloading
-                && stalled_ids.contains(item_id)
-        })
+        .filter(|(item_id, _)| stalled_ids.contains(item_id))
         .map(|(_, item)| item)
         .collect();
 

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -8,8 +8,14 @@ use chorrosion_domain::DownloadClientDefinition;
 use chorrosion_infrastructure::repositories::Repository;
 use futures_util::future::join_all;
 use serde::Serialize;
+use std::collections::HashSet;
 use tracing::{debug, warn};
 use utoipa::ToSchema;
+
+struct PolledActivitySnapshot {
+    items: Vec<CachedActivityItem>,
+    was_cached: bool,
+}
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ActivityItemResponse {
@@ -69,11 +75,14 @@ fn state_label(state: &DownloadState) -> &'static str {
 /// Poll download clients and return the raw snapshot, using a short-lived
 /// TTL cache to avoid redundant network calls when multiple activity
 /// endpoints are fetched in quick succession.
-async fn poll_cached_snapshot(state: &AppState) -> Result<Vec<CachedActivityItem>, String> {
+async fn poll_cached_snapshot(state: &AppState) -> Result<PolledActivitySnapshot, String> {
     // Fast path: return cached snapshot if still within TTL.
     if let Some(cached) = state.activity_snapshot_cache.get() {
         debug!(target: "api", "activity snapshot cache HIT");
-        return Ok(cached);
+        return Ok(PolledActivitySnapshot {
+            items: cached,
+            was_cached: true,
+        });
     }
 
     debug!(target: "api", "activity snapshot cache MISS – polling download clients");
@@ -133,10 +142,15 @@ async fn poll_cached_snapshot(state: &AppState) -> Result<Vec<CachedActivityItem
 
     let items: Vec<_> = results.into_iter().flatten().collect();
 
+    state.activity_stall_tracker.observe(&items);
+
     // Store in cache for subsequent requests within the TTL window.
     state.activity_snapshot_cache.set(items.clone());
 
-    Ok(items)
+    Ok(PolledActivitySnapshot {
+        items,
+        was_cached: false,
+    })
 }
 
 fn snapshot_to_response(items: Vec<CachedActivityItem>) -> ActivityListResponse {
@@ -158,8 +172,8 @@ fn snapshot_to_response(items: Vec<CachedActivityItem>) -> ActivityListResponse 
 pub(crate) async fn activity_queue_snapshot(
     state: &AppState,
 ) -> Result<ActivityListResponse, String> {
-    let items = poll_cached_snapshot(state).await?;
-    Ok(snapshot_to_response(items))
+    let snapshot = poll_cached_snapshot(state).await?;
+    Ok(snapshot_to_response(snapshot.items))
 }
 
 pub(crate) async fn activity_import_snapshot(_state: &AppState) -> ActivityListResponse {
@@ -173,8 +187,9 @@ pub(crate) async fn activity_import_snapshot(_state: &AppState) -> ActivityListR
 pub(crate) async fn activity_history_snapshot(
     state: &AppState,
 ) -> Result<ActivityListResponse, String> {
-    let items = poll_cached_snapshot(state).await?;
-    let filtered: Vec<_> = items
+    let snapshot = poll_cached_snapshot(state).await?;
+    let filtered: Vec<_> = snapshot
+        .items
         .into_iter()
         .filter(|item| item.download.state == DownloadState::Completed)
         .collect();
@@ -185,10 +200,35 @@ pub(crate) async fn activity_history_snapshot(
 pub(crate) async fn activity_failed_snapshot(
     state: &AppState,
 ) -> Result<ActivityListResponse, String> {
-    let items = poll_cached_snapshot(state).await?;
-    let filtered: Vec<_> = items
+    let snapshot = poll_cached_snapshot(state).await?;
+    let filtered: Vec<_> = snapshot
+        .items
         .into_iter()
         .filter(|item| item.download.state == DownloadState::Error)
+        .collect();
+
+    Ok(snapshot_to_response(filtered))
+}
+
+pub(crate) async fn activity_stalled_snapshot(
+    state: &AppState,
+) -> Result<ActivityListResponse, String> {
+    let snapshot = poll_cached_snapshot(state).await?;
+    debug!(target: "api", was_cached = snapshot.was_cached, "evaluating stalled downloads");
+
+    let stalled_ids: HashSet<_> = state
+        .activity_stall_tracker
+        .stalled_ids(&snapshot.items)
+        .into_iter()
+        .collect();
+
+    let filtered: Vec<_> = snapshot
+        .items
+        .into_iter()
+        .filter(|item| {
+            item.download.state == DownloadState::Downloading
+                && stalled_ids.contains(&format!("{}:{}", item.definition_id, item.download.hash))
+        })
         .collect();
 
     Ok(snapshot_to_response(filtered))
@@ -276,6 +316,31 @@ pub async fn get_activity_failed(
 
 #[utoipa::path(
     get,
+    path = "/api/v1/activity/stalled",
+    responses(
+        (status = 200, description = "Stalled downloads", body = ActivityListResponse),
+        (status = 500, description = "Internal server error", body = ActivityErrorResponse)
+    ),
+    tag = "activity"
+)]
+pub async fn get_activity_stalled(
+    State(state): State<AppState>,
+) -> Result<Json<ActivityListResponse>, (StatusCode, Json<ActivityErrorResponse>)> {
+    debug!(target: "api", "fetching stalled downloads");
+
+    activity_stalled_snapshot(&state)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ActivityErrorResponse { error: e }),
+            )
+        })
+}
+
+#[utoipa::path(
+    get,
     path = "/api/v1/activity/processing",
     responses(
         (status = 200, description = "Currently processing items", body = ActivityListResponse)
@@ -295,6 +360,7 @@ mod tests {
         body::{to_bytes, Body},
         http::{Request, StatusCode},
     };
+    use chorrosion_application::ActivityStallTracker;
     use chorrosion_config::AppConfig;
     use chorrosion_domain::DownloadClientDefinition;
     use chorrosion_infrastructure::repositories::Repository;
@@ -448,6 +514,12 @@ mod tests {
     async fn get_activity_processing_returns_empty_placeholder_payload() {
         let state = make_test_state().await;
         assert_empty_activity_response(state, "/api/v1/activity/processing").await;
+    }
+
+    #[tokio::test]
+    async fn get_activity_stalled_returns_empty_placeholder_payload() {
+        let state = make_test_state().await;
+        assert_empty_activity_response(state, "/api/v1/activity/stalled").await;
     }
 
     #[tokio::test]
@@ -746,5 +818,62 @@ mod tests {
         assert_eq!(payload["total"], 1);
         assert_eq!(payload["items"][0]["state"], "error");
         assert_eq!(payload["items"][0]["name"], "qbit-main: Broken Album");
+    }
+
+    #[tokio::test]
+    async fn get_activity_stalled_returns_only_repeated_non_progressing_downloads() {
+        let mut state = make_test_state().await;
+        state.activity_stall_tracker = ActivityStallTracker::new(0);
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[
+                    {
+                        "hash": "stall1",
+                        "name": "Slow Album",
+                        "progress": 0.35,
+                        "state": "downloading",
+                        "category": "music"
+                    },
+                    {
+                        "hash": "done1",
+                        "name": "Done Album",
+                        "progress": 1.0,
+                        "state": "completed",
+                        "category": "music"
+                    }
+                ]"#,
+            ))
+            .mount(&server)
+            .await;
+
+        state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "qbit-main",
+                "qbittorrent",
+                server.uri(),
+            ))
+            .await
+            .expect("create download client definition");
+
+        let first_payload = activity_stalled_snapshot(&state)
+            .await
+            .expect("first stalled snapshot should succeed");
+        assert_eq!(first_payload.total, 0);
+        assert!(first_payload.items.is_empty());
+
+        state.activity_snapshot_cache.clear();
+
+        let second_payload = activity_stalled_snapshot(&state)
+            .await
+            .expect("second stalled snapshot should succeed");
+
+        assert_eq!(second_payload.total, 1);
+        assert_eq!(second_payload.items[0].state, "downloading");
+        assert_eq!(second_payload.items[0].name, "qbit-main: Slow Album");
     }
 }

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -225,10 +225,15 @@ pub(crate) async fn activity_stalled_snapshot(
     let filtered: Vec<_> = snapshot
         .items
         .into_iter()
-        .filter(|item| {
-            item.download.state == DownloadState::Downloading
-                && stalled_ids.contains(&format!("{}:{}", item.definition_id, item.download.hash))
+        .map(|item| {
+            let item_id = format!("{}:{}", item.definition_id, item.download.hash);
+            (item_id, item)
         })
+        .filter(|(item_id, item)| {
+            item.download.state == DownloadState::Downloading
+                && stalled_ids.contains(item_id)
+        })
+        .map(|(_, item)| item)
         .collect();
 
     Ok(snapshot_to_response(filtered))
@@ -875,5 +880,59 @@ mod tests {
         assert_eq!(second_payload.total, 1);
         assert_eq!(second_payload.items[0].state, "downloading");
         assert_eq!(second_payload.items[0].name, "qbit-main: Slow Album");
+    }
+
+    /// Repeated requests that hit the snapshot cache (no explicit `clear()` between
+    /// calls) must NOT advance the stall tracker.  A download should only be
+    /// considered stalled once at least two *fresh* polls observe the same progress.
+    #[tokio::test]
+    async fn get_activity_stalled_cache_hit_does_not_advance_tracker() {
+        let mut state = make_test_state().await;
+        // Zero-second stall window so any two fresh observations immediately qualify.
+        state.activity_stall_tracker = ActivityStallTracker::new(0);
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[{
+                    "hash": "no_stall",
+                    "name": "Slow Album",
+                    "progress": 0.20,
+                    "state": "downloading",
+                    "category": "music"
+                }]"#,
+            ))
+            .mount(&server)
+            .await;
+
+        state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "qbit-main",
+                "qbittorrent",
+                server.uri(),
+            ))
+            .await
+            .expect("create download client definition");
+
+        // First call: fresh poll — one observation recorded (repeated_samples = 1).
+        // Not stalled yet (needs >= 2 samples).
+        let first = activity_stalled_snapshot(&state)
+            .await
+            .expect("first call should succeed");
+        assert_eq!(first.total, 0, "should not be stalled after one fresh poll");
+
+        // Second call: snapshot is still cached (no clear()), so the stall tracker
+        // must NOT be advanced.  Even with a zero stall window the download should
+        // still not appear as stalled because repeated_samples never reached 2.
+        let second = activity_stalled_snapshot(&state)
+            .await
+            .expect("second call (cache HIT) should succeed");
+        assert_eq!(
+            second.total, 0,
+            "cache-HIT request must not advance the stall tracker"
+        );
     }
 }

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -19,8 +19,9 @@ use chorrosion_config::PermissionLevel;
 use chorrosion_infrastructure::repositories::Repository;
 use handlers::activity::{
     get_activity_failed, get_activity_history, get_activity_processing, get_activity_queue,
-    ActivityErrorResponse, ActivityItemResponse, ActivityListResponse, __path_get_activity_failed,
-    __path_get_activity_history, __path_get_activity_processing, __path_get_activity_queue,
+    get_activity_stalled, ActivityErrorResponse, ActivityItemResponse, ActivityListResponse,
+    __path_get_activity_failed, __path_get_activity_history, __path_get_activity_processing,
+    __path_get_activity_queue, __path_get_activity_stalled,
 };
 use handlers::albums::{
     create_album, delete_album, get_album, list_albums, list_albums_by_artist,
@@ -260,6 +261,7 @@ async fn metrics() -> axum::response::Response {
         get_activity_queue,
         get_activity_history,
         get_activity_failed,
+        get_activity_stalled,
         get_activity_processing,
         stream_events,
         get_sse_connections,
@@ -435,6 +437,7 @@ pub fn router(state: AppState) -> Router {
         .route("/activity/queue", get(get_activity_queue))
         .route("/activity/history", get(get_activity_history))
         .route("/activity/failed", get(get_activity_failed))
+        .route("/activity/stalled", get(get_activity_stalled))
         .route("/activity/processing", get(get_activity_processing))
         .route("/events", get(stream_events))
         .route("/events/connections", get(get_sse_connections))

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -9,8 +9,10 @@ use chorrosion_infrastructure::{
     ResponseCache,
 };
 use moka::sync::Cache;
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 pub mod download_clients;
 pub mod embedded_tags;
 pub mod events;
@@ -139,11 +141,121 @@ impl ActivitySnapshotCache {
     pub fn set(&self, items: Vec<CachedActivityItem>) {
         self.inner.insert((), items);
     }
+
+    /// Clear the cached snapshot so the next request performs a fresh poll.
+    pub fn clear(&self) {
+        self.inner.invalidate(&());
+    }
 }
 
 impl Default for ActivitySnapshotCache {
     fn default() -> Self {
         Self::new(ACTIVITY_SNAPSHOT_TTL_SECONDS)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TrackedActivityProgress {
+    progress_percent: u8,
+    last_progress_at: Instant,
+    repeated_samples: u32,
+}
+
+/// Tracks whether active downloads have stopped making progress across fresh polls.
+#[derive(Clone, Debug)]
+pub struct ActivityStallTracker {
+    stall_after: Duration,
+    inner: Arc<Mutex<HashMap<String, TrackedActivityProgress>>>,
+}
+
+/// Default stall detection window in seconds.
+const ACTIVITY_STALL_AFTER_SECONDS: u64 = 300;
+
+impl ActivityStallTracker {
+    /// Create a new tracker with the given stall window (clamped to ≥ 0 s).
+    pub fn new(stall_after_seconds: u64) -> Self {
+        Self {
+            stall_after: Duration::from_secs(stall_after_seconds),
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Record a fresh poll observation for the current download items.
+    pub fn observe(&self, items: &[CachedActivityItem]) {
+        self.observe_at(items, Instant::now());
+    }
+
+    /// Return the IDs currently considered stalled.
+    pub fn stalled_ids(&self, items: &[CachedActivityItem]) -> Vec<String> {
+        self.stalled_ids_at(items, Instant::now())
+    }
+
+    fn observe_at(&self, items: &[CachedActivityItem], now: Instant) {
+        let mut tracked = self.inner.lock().expect("activity stall tracker lock");
+        let mut active_ids = Vec::new();
+
+        for item in items {
+            let id = format!("{}:{}", item.definition_id, item.download.hash);
+
+            if item.download.state != DownloadState::Downloading {
+                tracked.remove(&id);
+                continue;
+            }
+
+            let progress_percent = item.download.progress_percent;
+            match tracked.get_mut(&id) {
+                Some(entry) if entry.progress_percent == progress_percent => {
+                    entry.repeated_samples += 1;
+                }
+                Some(entry) => {
+                    entry.progress_percent = progress_percent;
+                    entry.last_progress_at = now;
+                    entry.repeated_samples = 1;
+                }
+                None => {
+                    tracked.insert(
+                        id.clone(),
+                        TrackedActivityProgress {
+                            progress_percent,
+                            last_progress_at: now,
+                            repeated_samples: 1,
+                        },
+                    );
+                }
+            }
+
+            active_ids.push(id);
+        }
+
+        tracked.retain(|id, _| active_ids.iter().any(|active_id| active_id == id));
+    }
+
+    fn stalled_ids_at(&self, items: &[CachedActivityItem], now: Instant) -> Vec<String> {
+        let tracked = self.inner.lock().expect("activity stall tracker lock");
+
+        items
+            .iter()
+            .filter(|item| item.download.state == DownloadState::Downloading)
+            .filter_map(|item| {
+                let id = format!("{}:{}", item.definition_id, item.download.hash);
+                tracked.get(&id).and_then(|entry| {
+                    if entry.progress_percent == item.download.progress_percent
+                        && entry.repeated_samples >= 2
+                        && now.duration_since(entry.last_progress_at) >= self.stall_after
+                    {
+                        Some(id)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect()
+    }
+}
+
+impl Default for ActivityStallTracker {
+    fn default() -> Self {
+        Self::new(ACTIVITY_STALL_AFTER_SECONDS)
     }
 }
 
@@ -161,6 +273,8 @@ pub struct AppState {
     pub response_cache: ResponseCache,
     /// Short-lived cache for the polled download-client activity snapshot.
     pub activity_snapshot_cache: ActivitySnapshotCache,
+    /// In-memory tracker used to detect downloads that stop making progress.
+    pub activity_stall_tracker: ActivityStallTracker,
 }
 
 impl AppState {
@@ -187,6 +301,7 @@ impl AppState {
             download_client_definition_repository,
             response_cache,
             activity_snapshot_cache: ActivitySnapshotCache::default(),
+            activity_stall_tracker: ActivityStallTracker::default(),
         }
     }
 

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -168,9 +168,6 @@ pub struct ActivityStallTracker {
     inner: Arc<Mutex<HashMap<String, TrackedActivityProgress>>>,
 }
 
-/// Default stall detection window in seconds.
-const ACTIVITY_STALL_AFTER_SECONDS: u64 = 300;
-
 impl ActivityStallTracker {
     /// Create a new tracker with the given stall window.
     pub fn new(stall_after_seconds: u64) -> Self {
@@ -255,7 +252,7 @@ impl ActivityStallTracker {
 
 impl Default for ActivityStallTracker {
     fn default() -> Self {
-        Self::new(ACTIVITY_STALL_AFTER_SECONDS)
+        Self::new(300)
     }
 }
 

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -9,7 +9,7 @@ use chorrosion_infrastructure::{
     ResponseCache,
 };
 use moka::sync::Cache;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -172,7 +172,7 @@ pub struct ActivityStallTracker {
 const ACTIVITY_STALL_AFTER_SECONDS: u64 = 300;
 
 impl ActivityStallTracker {
-    /// Create a new tracker with the given stall window (clamped to ≥ 0 s).
+    /// Create a new tracker with the given stall window.
     pub fn new(stall_after_seconds: u64) -> Self {
         Self {
             stall_after: Duration::from_secs(stall_after_seconds),
@@ -192,7 +192,7 @@ impl ActivityStallTracker {
 
     fn observe_at(&self, items: &[CachedActivityItem], now: Instant) {
         let mut tracked = self.inner.lock().expect("activity stall tracker lock");
-        let mut active_ids = Vec::new();
+        let mut active_ids: HashSet<String> = HashSet::new();
 
         for item in items {
             let id = format!("{}:{}", item.definition_id, item.download.hash);
@@ -224,10 +224,10 @@ impl ActivityStallTracker {
                 }
             }
 
-            active_ids.push(id);
+            active_ids.insert(id);
         }
 
-        tracked.retain(|id, _| active_ids.iter().any(|active_id| active_id == id));
+        tracked.retain(|id, _| active_ids.contains(id));
     }
 
     fn stalled_ids_at(&self, items: &[CachedActivityItem], now: Instant) -> Vec<String> {
@@ -291,6 +291,10 @@ impl AppState {
         response_cache: ResponseCache,
     ) -> Self {
         Self {
+            activity_snapshot_cache: ActivitySnapshotCache::default(),
+            activity_stall_tracker: ActivityStallTracker::new(
+                config.activity.stall_after_seconds,
+            ),
             config,
             artist_repository,
             album_repository,
@@ -300,8 +304,6 @@ impl AppState {
             indexer_definition_repository,
             download_client_definition_repository,
             response_cache,
-            activity_snapshot_cache: ActivitySnapshotCache::default(),
-            activity_stall_tracker: ActivityStallTracker::default(),
         }
     }
 

--- a/crates/chorrosion-config/src/lib.rs
+++ b/crates/chorrosion-config/src/lib.rs
@@ -347,6 +347,23 @@ impl Default for CacheConfig {
     }
 }
 
+/// Configuration for the activity monitoring subsystem.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityConfig {
+    /// Number of seconds without progress before a download is considered stalled.
+    ///
+    /// Env override: `CHORROSION_ACTIVITY__STALL_AFTER_SECONDS`.
+    pub stall_after_seconds: u64,
+}
+
+impl Default for ActivityConfig {
+    fn default() -> Self {
+        Self {
+            stall_after_seconds: 300,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AppConfig {
     pub database: DatabaseConfig,
@@ -358,6 +375,7 @@ pub struct AppConfig {
     pub metadata: MetadataConfig,
     pub notifications: NotificationsConfig,
     pub lists: ListsConfig,
+    pub activity: ActivityConfig,
 }
 
 /// Load configuration from defaults, optional TOML file, and environment overrides (prefix: CHORROSION_).


### PR DESCRIPTION
Implements Phase 4.3 stalled download detection.

## Changes

- add an in-memory activity stall tracker to application state
- update activity polling so the stall tracker is only advanced on fresh download-client polls
- expose GET /api/v1/activity/stalled with OpenAPI wiring
- add coverage for empty stalled responses and repeat non-progressing downloads
- update ROADMAP.md to mark the item complete

Closes #365
