### PR TITLE
feat: retain download history across activity polls

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -209,7 +209,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
 - [x] Completion detection (Issue #361) ✓
 - [x] Failed download handling (Issue #363) ✓
 - [x] Stalled download detection (Issue #365) ✓
-- [ ] Download history
+- [x] Download history (Issue #367) ✓
 
 ---
 

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -142,6 +142,7 @@ async fn poll_cached_snapshot(state: &AppState) -> Result<PolledActivitySnapshot
 
     let items: Vec<_> = results.into_iter().flatten().collect();
 
+    state.activity_history_store.observe_terminal(&items);
     state.activity_stall_tracker.observe(&items);
 
     // Store in cache for subsequent requests within the TTL window.
@@ -187,14 +188,11 @@ pub(crate) async fn activity_import_snapshot(_state: &AppState) -> ActivityListR
 pub(crate) async fn activity_history_snapshot(
     state: &AppState,
 ) -> Result<ActivityListResponse, String> {
-    let snapshot = poll_cached_snapshot(state).await?;
-    let filtered: Vec<_> = snapshot
-        .items
-        .into_iter()
-        .filter(|item| item.download.state == DownloadState::Completed)
-        .collect();
-
-    Ok(snapshot_to_response(filtered))
+    // Ensure we refresh history state when cache is stale.
+    let _ = poll_cached_snapshot(state).await?;
+    Ok(snapshot_to_response(
+        state.activity_history_store.snapshot(),
+    ))
 }
 
 pub(crate) async fn activity_failed_snapshot(
@@ -511,6 +509,61 @@ mod tests {
         assert_eq!(payload["total"], 1);
         assert_eq!(payload["items"][0]["state"], "completed");
         assert_eq!(payload["items"][0]["name"], "qbit-main: Album Done");
+    }
+
+    #[tokio::test]
+    async fn get_activity_history_persists_after_item_leaves_queue() {
+        let state = make_test_state().await;
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[
+                    {
+                        "hash": "completed1",
+                        "name": "Album Done",
+                        "progress": 1.0,
+                        "state": "uploading",
+                        "category": "music"
+                    }
+                ]"#,
+            ))
+            .mount(&server)
+            .await;
+
+        state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "qbit-main",
+                "qbittorrent",
+                server.uri(),
+            ))
+            .await
+            .expect("create download client definition");
+
+        let first = activity_history_snapshot(&state)
+            .await
+            .expect("first history snapshot should succeed");
+        assert_eq!(first.total, 1);
+        assert_eq!(first.items[0].state, "completed");
+
+        server.reset().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v2/torrents/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("[]"))
+            .mount(&server)
+            .await;
+
+        state.activity_snapshot_cache.clear();
+
+        let second = activity_history_snapshot(&state)
+            .await
+            .expect("second history snapshot should succeed");
+
+        assert_eq!(second.total, 1);
+        assert_eq!(second.items[0].state, "completed");
+        assert_eq!(second.items[0].name, "qbit-main: Album Done");
     }
 
     #[tokio::test]

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -155,6 +155,81 @@ impl Default for ActivitySnapshotCache {
 }
 
 #[derive(Clone, Debug)]
+struct ActivityHistoryRecord {
+    item: CachedActivityItem,
+    last_seen: Instant,
+}
+
+/// In-memory history of terminal download states observed across fresh polls.
+#[derive(Clone, Debug)]
+pub struct ActivityHistoryStore {
+    max_entries: usize,
+    inner: Arc<Mutex<HashMap<String, ActivityHistoryRecord>>>,
+}
+
+/// Default maximum number of download history records to retain.
+const ACTIVITY_HISTORY_MAX_ENTRIES: usize = 500;
+
+impl ActivityHistoryStore {
+    /// Create a new in-memory store with bounded capacity.
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries: max_entries.max(1),
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Record terminal items (completed or error) from a fresh poll.
+    pub fn observe_terminal(&self, items: &[CachedActivityItem]) {
+        let now = Instant::now();
+        let mut records = self.inner.lock().expect("activity history store lock");
+
+        for item in items {
+            if !matches!(
+                item.download.state,
+                DownloadState::Completed | DownloadState::Error
+            ) {
+                continue;
+            }
+
+            let id = format!("{}:{}", item.definition_id, item.download.hash);
+            records.insert(
+                id,
+                ActivityHistoryRecord {
+                    item: item.clone(),
+                    last_seen: now,
+                },
+            );
+        }
+
+        while records.len() > self.max_entries {
+            let Some(evict_id) = records
+                .iter()
+                .min_by_key(|(_, record)| record.last_seen)
+                .map(|(id, _)| id.clone())
+            else {
+                break;
+            };
+            records.remove(&evict_id);
+        }
+    }
+
+    /// Return history items sorted by latest observation first.
+    pub fn snapshot(&self) -> Vec<CachedActivityItem> {
+        let records = self.inner.lock().expect("activity history store lock");
+        let mut sorted: Vec<_> = records.values().cloned().collect();
+        sorted.sort_by(|a, b| b.last_seen.cmp(&a.last_seen));
+        sorted.into_iter().map(|record| record.item).collect()
+    }
+}
+
+impl Default for ActivityHistoryStore {
+    fn default() -> Self {
+        Self::new(ACTIVITY_HISTORY_MAX_ENTRIES)
+    }
+}
+
+#[derive(Clone, Debug)]
 struct TrackedActivityProgress {
     progress_percent: u8,
     last_progress_at: Instant,
@@ -270,6 +345,8 @@ pub struct AppState {
     pub response_cache: ResponseCache,
     /// Short-lived cache for the polled download-client activity snapshot.
     pub activity_snapshot_cache: ActivitySnapshotCache,
+    /// In-memory terminal-state history accumulated across fresh polls.
+    pub activity_history_store: ActivityHistoryStore,
     /// In-memory tracker used to detect downloads that stop making progress.
     pub activity_stall_tracker: ActivityStallTracker,
 }
@@ -289,9 +366,8 @@ impl AppState {
     ) -> Self {
         Self {
             activity_snapshot_cache: ActivitySnapshotCache::default(),
-            activity_stall_tracker: ActivityStallTracker::new(
-                config.activity.stall_after_seconds,
-            ),
+            activity_history_store: ActivityHistoryStore::default(),
+            activity_stall_tracker: ActivityStallTracker::new(config.activity.stall_after_seconds),
             config,
             artist_repository,
             album_repository,


### PR DESCRIPTION
Implements Phase 4.3 download history.

## Changes

- add an in-memory activity history store in application state
- capture completed/error items during fresh activity polls
- update /api/v1/activity/history to return accumulated terminal history instead of only current queue-completed items
- add test coverage proving history remains after an item leaves the live queue
- update ROADMAP.md to mark download history complete

Closes #367
