### PR TITLE
feat: derive import bitrate from audio stream metadata

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -223,7 +223,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
   - [x] Duration read from file system metadata ✓
   - [x] Bitrate extraction from filename heuristics (BITRATE_REGEX) ✓
   - [x] Library-based tag reading (ID3/FLAC/Vorbis/APEv2) (Issue #369) ✓
-  - [ ] Bitrate from audio codec/stream data (not just filename)
+  - [x] Bitrate from audio codec/stream data (not just filename) (Issue #371) ✓
 - [x] **Fingerprint generation during import** (Issue #67) ✓
   - [x] Generate Chromaprint fingerprint ✓
   - [x] Cache in database (Issue #66) ✓

--- a/crates/chorrosion-application/src/embedded_tags.rs
+++ b/crates/chorrosion-application/src/embedded_tags.rs
@@ -184,46 +184,8 @@ impl EmbeddedTagMatchingService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::{MINIMAL_FLAC, MINIMAL_MP3};
     use std::fs;
-
-    // ── Minimal valid audio fixtures ─────────────────────────────────────────
-    //
-    // Identical to those used in tag_embedding.rs; duplicated here so this
-    // module stays self-contained and both sets of tests remain independent.
-
-    /// Minimal valid MPEG/MP3 file (two MPEG1-L3 frames at 32 kbps/44100 Hz).
-    const MINIMAL_MP3: &[u8] = &{
-        const FRAME_HDR: [u8; 4] = [0xFF, 0xFB, 0x10, 0x44];
-        let mut b = [0u8; 218]; // 10-byte ID3 header + 2 × 104-byte MPEG frames
-        // ID3v2.4 header at offset 0 (10 bytes, size field = 0)
-        b[0] = b'I';
-        b[1] = b'D';
-        b[2] = b'3';
-        b[3] = 4; // version: ID3v2.4
-        // Frame 1 at offset 10 (frame_length = floor(1152×32000/(8×44100)) = 104 bytes)
-        b[10] = FRAME_HDR[0];
-        b[11] = FRAME_HDR[1];
-        b[12] = FRAME_HDR[2];
-        b[13] = FRAME_HDR[3];
-        // Frame 2 at offset 10 + 104 = 114
-        b[114] = FRAME_HDR[0];
-        b[115] = FRAME_HDR[1];
-        b[116] = FRAME_HDR[2];
-        b[117] = FRAME_HDR[3];
-        b
-    };
-
-    /// Minimal valid FLAC stream (STREAMINFO + empty PADDING block).
-    const MINIMAL_FLAC: &[u8] = &[
-        b'f', b'L', b'a', b'C',
-        0x00, 0x00, 0x00, 0x22,
-        0x00, 0x10, 0x00, 0x10,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x0A, 0xC4, 0x40, 0xF0, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x81, 0x00, 0x00, 0x00,
-    ];
 
     fn write_fixture(dir: &tempfile::TempDir, name: &str, bytes: &[u8]) -> PathBuf {
         let path = dir.path().join(name);
@@ -300,7 +262,10 @@ mod tests {
         embed_known_tags(&path);
 
         let svc = EmbeddedTagMatchingService;
-        let tags = svc.extract_tags(&path).await.expect("extract should succeed");
+        let tags = svc
+            .extract_tags(&path)
+            .await
+            .expect("extract should succeed");
 
         assert_eq!(tags.artist.as_deref(), Some("Test Artist"));
         assert_eq!(tags.album.as_deref(), Some("Test Album"));
@@ -315,7 +280,10 @@ mod tests {
         embed_known_tags(&path);
 
         let svc = EmbeddedTagMatchingService;
-        let tags = svc.extract_tags(&path).await.expect("extract should succeed");
+        let tags = svc
+            .extract_tags(&path)
+            .await
+            .expect("extract should succeed");
 
         assert_eq!(tags.artist.as_deref(), Some("Test Artist"));
         assert_eq!(tags.album.as_deref(), Some("Test Album"));

--- a/crates/chorrosion-application/src/import_matching.rs
+++ b/crates/chorrosion-application/src/import_matching.rs
@@ -483,7 +483,7 @@ fn extract_bitrate_from_filename(path: &Path) -> Option<u32> {
 
 async fn extract_bitrate_from_audio_stream(path: &Path) -> Option<u32> {
     let owned = path.to_path_buf();
-    tokio::task::spawn_blocking(move || {
+    match tokio::task::spawn_blocking(move || {
         let metadata = lofty::read_from_path(&owned).ok()?;
         let properties = metadata.properties();
         properties
@@ -492,7 +492,13 @@ async fn extract_bitrate_from_audio_stream(path: &Path) -> Option<u32> {
             .filter(|bitrate| *bitrate > 0)
     })
     .await
-    .unwrap_or(None)
+    {
+        Ok(result) => result,
+        Err(e) => {
+            warn!(target: "import", error = %e, "audio stream bitrate task panicked");
+            None
+        }
+    }
 }
 
 fn resolve_track_file_quality(track_file: &TrackFile, profile: &QualityProfile) -> Option<String> {

--- a/crates/chorrosion-application/src/import_matching.rs
+++ b/crates/chorrosion-application/src/import_matching.rs
@@ -138,7 +138,7 @@ pub fn scan_audio_files(
     Ok(scanned)
 }
 
-pub fn parse_track_metadata(
+pub async fn parse_track_metadata(
     raw: &RawTrackMetadata,
 ) -> Result<ParsedTrackMetadata, ImportMatchingError> {
     if !raw.file_path.exists() {
@@ -160,7 +160,7 @@ pub fn parse_track_metadata(
             album,
             title,
             duration_seconds: raw.duration_seconds,
-            bitrate_kbps: resolve_bitrate(raw),
+            bitrate_kbps: resolve_bitrate(raw).await,
             source: MetadataSource::EmbeddedTags,
         });
     }
@@ -213,15 +213,19 @@ pub fn parse_track_metadata(
         album,
         title,
         duration_seconds: raw.duration_seconds,
-        bitrate_kbps: resolve_bitrate(raw),
+        bitrate_kbps: resolve_bitrate(raw).await,
         source: MetadataSource::FilenameHeuristics,
     })
 }
 
-fn resolve_bitrate(raw: &RawTrackMetadata) -> Option<u32> {
-    raw.bitrate_kbps
-        .or_else(|| extract_bitrate_from_audio_stream(&raw.file_path))
-        .or_else(|| extract_bitrate_from_filename(&raw.file_path))
+async fn resolve_bitrate(raw: &RawTrackMetadata) -> Option<u32> {
+    if let Some(kbps) = raw.bitrate_kbps {
+        return Some(kbps);
+    }
+    if let Some(kbps) = extract_bitrate_from_audio_stream(&raw.file_path).await {
+        return Some(kbps);
+    }
+    extract_bitrate_from_filename(&raw.file_path)
 }
 
 pub fn evaluate_import_match(
@@ -477,13 +481,18 @@ fn extract_bitrate_from_filename(path: &Path) -> Option<u32> {
         .and_then(|value| value.as_str().parse::<u32>().ok())
 }
 
-fn extract_bitrate_from_audio_stream(path: &Path) -> Option<u32> {
-    let metadata = lofty::read_from_path(path).ok()?;
-    let properties = metadata.properties();
-    properties
-        .audio_bitrate()
-        .or_else(|| properties.overall_bitrate())
-        .filter(|bitrate| *bitrate > 0)
+async fn extract_bitrate_from_audio_stream(path: &Path) -> Option<u32> {
+    let owned = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let metadata = lofty::read_from_path(&owned).ok()?;
+        let properties = metadata.properties();
+        properties
+            .audio_bitrate()
+            .or_else(|| properties.overall_bitrate())
+            .filter(|bitrate| *bitrate > 0)
+    })
+    .await
+    .unwrap_or(None)
 }
 
 fn resolve_track_file_quality(track_file: &TrackFile, profile: &QualityProfile) -> Option<String> {
@@ -646,27 +655,9 @@ fn levenshtein_distance(left: &str, right: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::MINIMAL_MP3;
     use chorrosion_domain::{ProfileId, TrackId};
     use chrono::Utc;
-
-    /// Minimal valid MPEG/MP3 file (two MPEG1-L3 frames at 32 kbps/44100 Hz).
-    const MINIMAL_MP3: &[u8] = &{
-        const FRAME_HDR: [u8; 4] = [0xFF, 0xFB, 0x10, 0x44];
-        let mut b = [0u8; 218];
-        b[0] = b'I';
-        b[1] = b'D';
-        b[2] = b'3';
-        b[3] = 4;
-        b[10] = FRAME_HDR[0];
-        b[11] = FRAME_HDR[1];
-        b[12] = FRAME_HDR[2];
-        b[13] = FRAME_HDR[3];
-        b[114] = FRAME_HDR[0];
-        b[115] = FRAME_HDR[1];
-        b[116] = FRAME_HDR[2];
-        b[117] = FRAME_HDR[3];
-        b
-    };
 
     #[test]
     fn scan_audio_files_recursively_filters_supported_extensions() {
@@ -686,8 +677,8 @@ mod tests {
         assert_eq!(scanned[0].extension, "mp3");
     }
 
-    #[test]
-    fn parse_track_metadata_prefers_embedded_tags() {
+    #[tokio::test]
+    async fn parse_track_metadata_prefers_embedded_tags() {
         let root = tempfile::tempdir().expect("temp dir should be created");
         let file = root.path().join("any.mp3");
         fs::write(&file, b"audio-data").expect("file should exist");
@@ -700,6 +691,7 @@ mod tests {
             duration_seconds: Some(321),
             bitrate_kbps: Some(320),
         })
+        .await
         .expect("metadata parsing should succeed");
 
         assert_eq!(parsed.artist, "Autechre");
@@ -708,8 +700,8 @@ mod tests {
         assert_eq!(parsed.source, MetadataSource::EmbeddedTags);
     }
 
-    #[test]
-    fn parse_track_metadata_falls_back_to_filename_heuristics() {
+    #[tokio::test]
+    async fn parse_track_metadata_falls_back_to_filename_heuristics() {
         let root = tempfile::tempdir().expect("temp dir should be created");
         let album_dir = root
             .path()
@@ -728,6 +720,7 @@ mod tests {
             duration_seconds: None,
             bitrate_kbps: None,
         })
+        .await
         .expect("fallback parsing should succeed");
 
         assert_eq!(parsed.artist, "Boards of Canada");
@@ -736,8 +729,8 @@ mod tests {
         assert_eq!(parsed.bitrate_kbps, Some(320));
     }
 
-    #[test]
-    fn parse_track_metadata_reads_bitrate_from_audio_stream_with_embedded_tags() {
+    #[tokio::test]
+    async fn parse_track_metadata_reads_bitrate_from_audio_stream_with_embedded_tags() {
         let root = tempfile::tempdir().expect("temp dir should be created");
         let file = root.path().join("no-bitrate-name.mp3");
         fs::write(&file, MINIMAL_MP3).expect("file should exist");
@@ -750,14 +743,15 @@ mod tests {
             duration_seconds: Some(321),
             bitrate_kbps: None,
         })
+        .await
         .expect("metadata parsing should succeed");
 
         assert_eq!(parsed.source, MetadataSource::EmbeddedTags);
-        assert!(parsed.bitrate_kbps.is_some());
+        assert_eq!(parsed.bitrate_kbps, Some(32));
     }
 
-    #[test]
-    fn parse_track_metadata_reads_bitrate_from_audio_stream_before_filename_fallback() {
+    #[tokio::test]
+    async fn parse_track_metadata_reads_bitrate_from_audio_stream_before_filename_fallback() {
         let root = tempfile::tempdir().expect("temp dir should be created");
         let album_dir = root
             .path()
@@ -776,10 +770,47 @@ mod tests {
             duration_seconds: None,
             bitrate_kbps: None,
         })
+        .await
         .expect("fallback parsing should succeed");
 
         assert_eq!(parsed.source, MetadataSource::FilenameHeuristics);
-        assert!(parsed.bitrate_kbps.is_some());
+        assert_eq!(parsed.bitrate_kbps, Some(32));
+    }
+
+    /// Stream bitrate must win over a conflicting filename token.
+    ///
+    /// The fixture is 32 kbps (from MPEG frame headers) but the filename
+    /// contains "320kbps".  The precedence order is:
+    ///   explicit RawTrackMetadata.bitrate_kbps → audio stream → filename token
+    /// so the result must be 32, not 320.
+    #[tokio::test]
+    async fn parse_track_metadata_stream_bitrate_takes_precedence_over_filename_token() {
+        let root = tempfile::tempdir().expect("temp dir should be created");
+        let album_dir = root
+            .path()
+            .join("Boards of Canada")
+            .join("Music Has the Right to Children");
+        fs::create_dir_all(&album_dir).expect("nested dir should exist");
+
+        // Filename claims 320 kbps; actual MPEG frames are 32 kbps.
+        let file = album_dir.join("Boards of Canada - 01 - Wildlife Analysis 320kbps.mp3");
+        fs::write(&file, MINIMAL_MP3).expect("file should exist");
+
+        let parsed = parse_track_metadata(&RawTrackMetadata {
+            file_path: file,
+            embedded_artist: None,
+            embedded_album: None,
+            embedded_title: None,
+            duration_seconds: None,
+            bitrate_kbps: None,
+        })
+        .await
+        .expect("fallback parsing should succeed");
+
+        assert_eq!(parsed.source, MetadataSource::FilenameHeuristics);
+        // Stream bitrate (32 kbps from MPEG headers) must win over the
+        // "320kbps" token in the filename.
+        assert_eq!(parsed.bitrate_kbps, Some(32));
     }
 
     #[test]

--- a/crates/chorrosion-application/src/import_matching.rs
+++ b/crates/chorrosion-application/src/import_matching.rs
@@ -4,6 +4,7 @@ use crate::filename_heuristics::FilenameHeuristicsService;
 use crate::quality_upgrade::{QualityUpgradeService, UpgradeReason};
 use chorrosion_domain::{AlbumId, ArtistId, QualityProfile, TrackFile};
 use lazy_static::lazy_static;
+use lofty::file::AudioFile;
 use regex::Regex;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -159,9 +160,7 @@ pub fn parse_track_metadata(
             album,
             title,
             duration_seconds: raw.duration_seconds,
-            bitrate_kbps: raw
-                .bitrate_kbps
-                .or_else(|| extract_bitrate_from_filename(&raw.file_path)),
+            bitrate_kbps: resolve_bitrate(raw),
             source: MetadataSource::EmbeddedTags,
         });
     }
@@ -214,11 +213,15 @@ pub fn parse_track_metadata(
         album,
         title,
         duration_seconds: raw.duration_seconds,
-        bitrate_kbps: raw
-            .bitrate_kbps
-            .or_else(|| extract_bitrate_from_filename(&raw.file_path)),
+        bitrate_kbps: resolve_bitrate(raw),
         source: MetadataSource::FilenameHeuristics,
     })
+}
+
+fn resolve_bitrate(raw: &RawTrackMetadata) -> Option<u32> {
+    raw.bitrate_kbps
+        .or_else(|| extract_bitrate_from_audio_stream(&raw.file_path))
+        .or_else(|| extract_bitrate_from_filename(&raw.file_path))
 }
 
 pub fn evaluate_import_match(
@@ -474,6 +477,15 @@ fn extract_bitrate_from_filename(path: &Path) -> Option<u32> {
         .and_then(|value| value.as_str().parse::<u32>().ok())
 }
 
+fn extract_bitrate_from_audio_stream(path: &Path) -> Option<u32> {
+    let metadata = lofty::read_from_path(path).ok()?;
+    let properties = metadata.properties();
+    properties
+        .audio_bitrate()
+        .or_else(|| properties.overall_bitrate())
+        .filter(|bitrate| *bitrate > 0)
+}
+
 fn resolve_track_file_quality(track_file: &TrackFile, profile: &QualityProfile) -> Option<String> {
     if let Some(quality) = track_file.quality.as_deref() {
         if let Some(resolved) = find_allowed_quality(quality, profile) {
@@ -637,6 +649,25 @@ mod tests {
     use chorrosion_domain::{ProfileId, TrackId};
     use chrono::Utc;
 
+    /// Minimal valid MPEG/MP3 file (two MPEG1-L3 frames at 32 kbps/44100 Hz).
+    const MINIMAL_MP3: &[u8] = &{
+        const FRAME_HDR: [u8; 4] = [0xFF, 0xFB, 0x10, 0x44];
+        let mut b = [0u8; 218];
+        b[0] = b'I';
+        b[1] = b'D';
+        b[2] = b'3';
+        b[3] = 4;
+        b[10] = FRAME_HDR[0];
+        b[11] = FRAME_HDR[1];
+        b[12] = FRAME_HDR[2];
+        b[13] = FRAME_HDR[3];
+        b[114] = FRAME_HDR[0];
+        b[115] = FRAME_HDR[1];
+        b[116] = FRAME_HDR[2];
+        b[117] = FRAME_HDR[3];
+        b
+    };
+
     #[test]
     fn scan_audio_files_recursively_filters_supported_extensions() {
         let root = tempfile::tempdir().expect("temp dir should be created");
@@ -703,6 +734,52 @@ mod tests {
         assert_eq!(parsed.album, "Music Has the Right to Children");
         assert_eq!(parsed.source, MetadataSource::FilenameHeuristics);
         assert_eq!(parsed.bitrate_kbps, Some(320));
+    }
+
+    #[test]
+    fn parse_track_metadata_reads_bitrate_from_audio_stream_with_embedded_tags() {
+        let root = tempfile::tempdir().expect("temp dir should be created");
+        let file = root.path().join("no-bitrate-name.mp3");
+        fs::write(&file, MINIMAL_MP3).expect("file should exist");
+
+        let parsed = parse_track_metadata(&RawTrackMetadata {
+            file_path: file,
+            embedded_artist: Some("Autechre".to_string()),
+            embedded_album: Some("Amber".to_string()),
+            embedded_title: Some("Foil".to_string()),
+            duration_seconds: Some(321),
+            bitrate_kbps: None,
+        })
+        .expect("metadata parsing should succeed");
+
+        assert_eq!(parsed.source, MetadataSource::EmbeddedTags);
+        assert!(parsed.bitrate_kbps.is_some());
+    }
+
+    #[test]
+    fn parse_track_metadata_reads_bitrate_from_audio_stream_before_filename_fallback() {
+        let root = tempfile::tempdir().expect("temp dir should be created");
+        let album_dir = root
+            .path()
+            .join("Boards of Canada")
+            .join("Music Has the Right to Children");
+        fs::create_dir_all(&album_dir).expect("nested dir should exist");
+
+        let file = album_dir.join("01 - Wildlife Analysis.mp3");
+        fs::write(&file, MINIMAL_MP3).expect("file should exist");
+
+        let parsed = parse_track_metadata(&RawTrackMetadata {
+            file_path: file,
+            embedded_artist: None,
+            embedded_album: None,
+            embedded_title: None,
+            duration_seconds: None,
+            bitrate_kbps: None,
+        })
+        .expect("fallback parsing should succeed");
+
+        assert_eq!(parsed.source, MetadataSource::FilenameHeuristics);
+        assert!(parsed.bitrate_kbps.is_some());
     }
 
     #[test]

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -34,6 +34,8 @@ pub mod scan_cache;
 pub mod search_automation;
 pub mod tag_embedding;
 pub mod tag_sanitation;
+#[cfg(test)]
+pub(crate) mod test_fixtures;
 
 pub use download_clients::{
     AddTorrentRequest, DelugeClient, DownloadClient, DownloadClientError, DownloadItem,

--- a/crates/chorrosion-application/src/tag_embedding.rs
+++ b/crates/chorrosion-application/src/tag_embedding.rs
@@ -854,55 +854,7 @@ mod tests {
 
     // ── LoftyTagEmbeddingBackend integration tests ────────────────────────────
 
-    /// Minimal valid MPEG/MP3 file: ID3v2.4 header followed by two identical
-    /// MPEG1 Layer-3 frames at 32 kbps / 44100 Hz / Joint Stereo (104 bytes
-    /// each).  Two frames are required so that lofty's `cmp_header` cross-check
-    /// succeeds and the file type is positively identified as MPEG during the
-    /// write path.
-    ///
-    /// Frame header bytes [0xFF, 0xFB, 0x10, 0x44]:
-    ///   sync=0xFFE, MPEG1, Layer3, 32 kbps, 44100 Hz, no padding, Joint Stereo
-    ///   frame_length = floor(1152 × 32000 / (8 × 44100)) = 104 bytes
-    ///
-    /// Layout: [0..10) ID3v2 header | [10..114) frame-1 | [114..218) frame-2
-    const MINIMAL_MP3: &[u8] = &{
-        const FRAME_HDR: [u8; 4] = [0xFF, 0xFB, 0x10, 0x44];
-        let mut b = [0u8; 218];
-        // ID3v2.4 header at offset 0 (10 bytes, empty tag – size field = 0)
-        b[0] = b'I';
-        b[1] = b'D';
-        b[2] = b'3';
-        b[3] = 4;
-        // Frame 1 header at offset 10 (frame_length = 104 bytes)
-        b[10] = FRAME_HDR[0];
-        b[11] = FRAME_HDR[1];
-        b[12] = FRAME_HDR[2];
-        b[13] = FRAME_HDR[3];
-        // Frame 2 header at offset 10 + 104 = 114
-        b[114] = FRAME_HDR[0];
-        b[115] = FRAME_HDR[1];
-        b[116] = FRAME_HDR[2];
-        b[117] = FRAME_HDR[3];
-        b
-    };
-
-    /// Minimal valid FLAC stream: 4-byte stream marker + STREAMINFO metadata
-    /// block (NOT the last-block, 34 bytes of well-formed but silent data) +
-    /// an empty PADDING block (last-block flag set, size=0).
-    ///
-    /// The PADDING block is required to prevent an index-out-of-bounds panic in
-    /// lofty's FLAC writer when it tries to add padding to a file whose only
-    /// existing block is STREAMINFO.
-    const MINIMAL_FLAC: &[u8] = &[
-        b'f', b'L', b'a', b'C', // stream marker
-        0x00, 0x00, 0x00, 0x22, // NOT last block + STREAMINFO type 0 + size=34
-        0x00, 0x10, 0x00, 0x10, // min/max block size = 16
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // min/max frame size = 0 (unknown)
-        0x0A, 0xC4, 0x40, 0xF0, 0x00, 0x00, 0x00, 0x00, // 44100 Hz, 1ch, 16-bit, 0 samples
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // MD5 signature (bytes 1–8)
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // MD5 signature (bytes 9–16)
-        0x81, 0x00, 0x00, 0x00, // last block + PADDING type 1 + size=0
-    ];
+    use crate::test_fixtures::{MINIMAL_FLAC, MINIMAL_MP3};
 
     fn write_fixture(dir: &tempfile::TempDir, name: &str, bytes: &[u8]) -> PathBuf {
         let path = dir.path().join(name);

--- a/crates/chorrosion-application/src/test_fixtures.rs
+++ b/crates/chorrosion-application/src/test_fixtures.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Shared audio byte fixtures for unit tests across the application crate.
+//!
+//! Centralised here to prevent drift when the fixtures need to be adjusted
+//! (e.g. when a lofty version update changes what a "valid" file must look
+//! like).  All test modules that need real audio bytes should import from
+//! this module instead of duplicating the constants.
+
+/// Minimal valid MPEG/MP3 file: ID3v2.4 header followed by two identical
+/// MPEG1 Layer-3 frames at 32 kbps / 44100 Hz / Joint Stereo (104 bytes
+/// each).  Two frames are required so that lofty's `cmp_header` cross-check
+/// succeeds and the file type is positively identified as MPEG during the
+/// write path.
+///
+/// Frame header bytes `[0xFF, 0xFB, 0x10, 0x44]`:
+///   sync=0xFFE, MPEG1, Layer3, 32 kbps, 44100 Hz, no padding, Joint Stereo
+///   frame_length = floor(1152 × 32000 / (8 × 44100)) = 104 bytes
+///
+/// Layout: [0..10) ID3v2 header | [10..114) frame-1 | [114..218) frame-2
+pub(crate) const MINIMAL_MP3: &[u8] = &{
+    const FRAME_HDR: [u8; 4] = [0xFF, 0xFB, 0x10, 0x44];
+    let mut b = [0u8; 218];
+    // ID3v2.4 header at offset 0 (10 bytes, empty tag – size field = 0)
+    b[0] = b'I';
+    b[1] = b'D';
+    b[2] = b'3';
+    b[3] = 4; // version: ID3v2.4
+              // Frame 1 header at offset 10 (frame_length = 104 bytes)
+    b[10] = FRAME_HDR[0];
+    b[11] = FRAME_HDR[1];
+    b[12] = FRAME_HDR[2];
+    b[13] = FRAME_HDR[3];
+    // Frame 2 header at offset 10 + 104 = 114
+    b[114] = FRAME_HDR[0];
+    b[115] = FRAME_HDR[1];
+    b[116] = FRAME_HDR[2];
+    b[117] = FRAME_HDR[3];
+    b
+};
+
+/// Minimal valid FLAC stream: 4-byte stream marker + STREAMINFO metadata
+/// block (NOT the last-block, 34 bytes of well-formed but silent data) +
+/// an empty PADDING block (last-block flag set, size=0).
+///
+/// The PADDING block is required to prevent an index-out-of-bounds panic in
+/// lofty's FLAC writer when it tries to add padding to a file whose only
+/// existing block is STREAMINFO.
+pub(crate) const MINIMAL_FLAC: &[u8] = &[
+    b'f', b'L', b'a', b'C', // stream marker
+    0x00, 0x00, 0x00, 0x22, // NOT last block + STREAMINFO type 0 + size=34
+    0x00, 0x10, 0x00, 0x10, // min/max block size = 16
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // min/max frame size = 0 (unknown)
+    0x0A, 0xC4, 0x40, 0xF0, 0x00, 0x00, 0x00, 0x00, // 44100 Hz, 1ch, 16-bit, 0 samples
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // MD5 signature (bytes 1–8)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // MD5 signature (bytes 9–16)
+    0x81, 0x00, 0x00, 0x00, // last block + PADDING type 1 + size=0
+];


### PR DESCRIPTION
Implements the next Phase 5.1 import-system item: deriving bitrate from actual audio stream metadata.

## Changes

- add stream-based bitrate extraction in import matching using lofty file properties
- bitrate precedence is now:
  1. explicit RawTrackMetadata.bitrate_kbps
  2. parsed audio stream bitrate (udio_bitrate / overall_bitrate)
  3. filename heuristic (320kbps token)
- apply this precedence in both embedded-tag and filename-heuristic metadata paths
- add regression tests proving bitrate is extracted even when filename has no bitrate token
- update ROADMAP to mark this item complete

## Validation

- cargo test -p chorrosion-application parse_track_metadata -- --nocapture
- cargo test -p chorrosion-application
- cargo clippy -p chorrosion-application -- -D warnings

Closes #371
