### PR TITLE
feat: add interactive manual search endpoint for UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -180,7 +180,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
 - [x] Manual search implementation (Issue #33, PR #145) ✓ PARTIALLY COMPLETE
   - [x] Artist search ✓
   - [x] Album search ✓
-  - [ ] Interactive search UI support
+  - [x] Interactive search UI support (Issue #377) ✓
 - [x] Automatic search (Issue #33, PR #145) ✓ COMPLETE
   - [x] Missing album detection ✓
   - [x] Search triggering logic ✓

--- a/crates/chorrosion-api/src/handlers/imports.rs
+++ b/crates/chorrosion-api/src/handlers/imports.rs
@@ -146,13 +146,11 @@ pub async fn evaluate_import_candidate(
         bitrate_kbps: request.raw_metadata.bitrate_kbps,
     };
 
-    let parsed = parse_track_metadata(&raw)
-        .await
-        .map_err(|e| match e {
-            ImportMatchingError::PathNotFound(_) => bad_request("file not found"),
-            ImportMatchingError::Io(_) => bad_request("unable to read file"),
-            ImportMatchingError::MetadataParsing(msg) => bad_request(&msg),
-        })?;
+    let parsed = parse_track_metadata(&raw).await.map_err(|e| match e {
+        ImportMatchingError::PathNotFound(_) => bad_request("file not found"),
+        ImportMatchingError::Io(_) => bad_request("unable to read file"),
+        ImportMatchingError::MetadataParsing(msg) => bad_request(&msg),
+    })?;
 
     let evaluation = evaluate_import_match(
         &parsed,
@@ -194,12 +192,10 @@ pub async fn submit_manual_import_decision(
     let decision = match action.as_str() {
         "import" => {
             let artist_id = match request.artist_id {
-                Some(value) if !value.trim().is_empty() => {
-                    match parse_artist_id(value.trim()) {
-                        Ok(id) => id,
-                        Err(e) => return e.into_response(),
-                    }
-                }
+                Some(value) if !value.trim().is_empty() => match parse_artist_id(value.trim()) {
+                    Ok(id) => id,
+                    Err(e) => return e.into_response(),
+                },
                 _ => {
                     return (
                         StatusCode::BAD_REQUEST,
@@ -211,12 +207,10 @@ pub async fn submit_manual_import_decision(
                 }
             };
             let album_id = match request.album_id {
-                Some(value) if !value.trim().is_empty() => {
-                    match parse_album_id(value.trim()) {
-                        Ok(id) => id,
-                        Err(e) => return e.into_response(),
-                    }
-                }
+                Some(value) if !value.trim().is_empty() => match parse_album_id(value.trim()) {
+                    Ok(id) => id,
+                    Err(e) => return e.into_response(),
+                },
                 _ => {
                     return (
                         StatusCode::BAD_REQUEST,
@@ -371,17 +365,18 @@ mod tests {
 
     fn imports_router() -> Router {
         Router::new()
-            .route(
-                "/api/v1/imports/evaluate",
-                post(evaluate_import_candidate),
-            )
+            .route("/api/v1/imports/evaluate", post(evaluate_import_candidate))
             .route(
                 "/api/v1/imports/decision",
                 post(submit_manual_import_decision),
             )
     }
 
-    async fn post_json(app: Router, uri: &str, body: serde_json::Value) -> axum::response::Response {
+    async fn post_json(
+        app: Router,
+        uri: &str,
+        body: serde_json::Value,
+    ) -> axum::response::Response {
         app.oneshot(
             Request::builder()
                 .method("POST")
@@ -419,7 +414,10 @@ mod tests {
         let response = post_json(app, "/api/v1/imports/evaluate", body).await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let payload = response_json(response).await;
-        assert!(payload["error"].as_str().unwrap().contains("fuzzy_threshold"));
+        assert!(payload["error"]
+            .as_str()
+            .unwrap()
+            .contains("fuzzy_threshold"));
     }
 
     #[tokio::test]
@@ -476,7 +474,9 @@ mod tests {
         use std::io::Write;
 
         let tmp = tempfile::NamedTempFile::new().expect("temp file");
-        tmp.as_file().write_all(b"dummy").expect("write temp file content");
+        tmp.as_file()
+            .write_all(b"dummy")
+            .expect("write temp file content");
         let path = tmp.path().to_string_lossy().to_string();
 
         let artist_uuid = "00000000-0000-0000-0000-000000000001";

--- a/crates/chorrosion-api/src/handlers/mod.rs
+++ b/crates/chorrosion-api/src/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod imports;
 pub mod indexers;
 pub mod metadata_profiles;
 pub mod quality_profiles;
+pub mod search;
 pub mod system;
 pub mod tracks;
 pub mod wanted;

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -173,11 +173,13 @@ pub async fn manual_search_endpoint(
     let ranked_results = match protocol {
         IndexerProtocol::Newznab => {
             let client = NewznabClient::new(config);
-            manual_search(&client, &manual_request, &options).await
+            let result = manual_search(&client, &manual_request, &options).await;
+            result
         }
         IndexerProtocol::Torznab => {
             let client = TorznabClient::new(config);
-            manual_search(&client, &manual_request, &options).await
+            let result = manual_search(&client, &manual_request, &options).await;
+            result
         }
         IndexerProtocol::Gazelle | IndexerProtocol::Custom => {
             return (

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use chorrosion_application::{
-    manual_search, AppState, AudioQuality, IndexerConfig, IndexerProtocol, ManualSearchRequest,
-    NewznabClient, ReleaseFilterOptions, TorznabClient,
+    manual_search, AppState, AudioQuality, IndexerConfig, IndexerError, IndexerProtocol,
+    ManualSearchRequest, NewznabClient, ReleaseFilterOptions, TorznabClient,
 };
 use chorrosion_infrastructure::repositories::Repository;
 use serde::{Deserialize, Serialize};
@@ -56,6 +56,7 @@ pub struct SearchErrorResponse {
         (status = 200, description = "Manual search results", body = ManualSearchApiResponse),
         (status = 400, description = "Invalid request", body = SearchErrorResponse),
         (status = 404, description = "Indexer not found", body = SearchErrorResponse),
+        (status = 500, description = "Internal server error", body = SearchErrorResponse),
         (status = 502, description = "Indexer search failed", body = SearchErrorResponse)
     ),
     tag = "search"
@@ -126,10 +127,39 @@ pub async fn manual_search_endpoint(
         preferred_release_groups: request.preferred_release_groups,
     };
 
+    let artist = request
+        .artist
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+    let album = request
+        .album
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+    let query = request
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+
+    if artist.is_none() && album.is_none() && query.is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(SearchErrorResponse {
+                error: "at least one of artist, album, or query must be provided".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
     let manual_request = ManualSearchRequest {
-        artist: request.artist,
-        album: request.album,
-        query: request.query,
+        artist,
+        album,
+        query,
     };
 
     let config = IndexerConfig {
@@ -175,7 +205,7 @@ pub async fn manual_search_endpoint(
                     leechers: result.search_result.leechers,
                     parsed_artist: result.parsed.artist,
                     parsed_album: result.parsed.album,
-                    parsed_quality: format!("{:?}", result.parsed.quality),
+                    parsed_quality: result.parsed.quality.as_str().to_string(),
                     parsed_bitrate_kbps: result.parsed.bitrate_kbps,
                     parsed_release_group: result.parsed.release_group,
                 })
@@ -190,6 +220,13 @@ pub async fn manual_search_endpoint(
             )
                 .into_response()
         }
+        Err(IndexerError::Request(msg)) => (
+            StatusCode::BAD_REQUEST,
+            Json(SearchErrorResponse {
+                error: format!("invalid search request: {msg}"),
+            }),
+        )
+            .into_response(),
         Err(error) => (
             StatusCode::BAD_GATEWAY,
             Json(SearchErrorResponse {
@@ -302,6 +339,51 @@ mod tests {
                 artist: None,
                 album: None,
                 query: Some("test".to_string()),
+                preferred_qualities: vec![],
+                min_bitrate_kbps: None,
+                preferred_release_groups: vec![],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn manual_search_endpoint_returns_400_when_no_search_criteria() {
+        let state = make_test_state().await;
+
+        // All of artist, album, query are None – empty criteria should yield 400
+        let response = manual_search_endpoint(
+            State(state),
+            Json(ManualSearchApiRequest {
+                indexer_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                artist: None,
+                album: None,
+                query: None,
+                preferred_qualities: vec![],
+                min_bitrate_kbps: None,
+                preferred_release_groups: vec![],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn manual_search_endpoint_returns_400_when_criteria_are_only_whitespace() {
+        let state = make_test_state().await;
+
+        let response = manual_search_endpoint(
+            State(state),
+            Json(ManualSearchApiRequest {
+                indexer_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                artist: Some("   ".to_string()),
+                album: Some("  ".to_string()),
+                query: Some("".to_string()),
                 preferred_qualities: vec![],
                 min_bitrate_kbps: None,
                 preferred_release_groups: vec![],

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use chorrosion_application::{
+    manual_search, AppState, AudioQuality, IndexerConfig, IndexerProtocol, ManualSearchRequest,
+    NewznabClient, ReleaseFilterOptions, TorznabClient,
+};
+use chorrosion_infrastructure::repositories::Repository;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ManualSearchApiRequest {
+    pub indexer_id: String,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub query: Option<String>,
+    #[serde(default)]
+    pub preferred_qualities: Vec<String>,
+    pub min_bitrate_kbps: Option<u32>,
+    #[serde(default)]
+    pub preferred_release_groups: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ManualSearchApiResponse {
+    pub items: Vec<ManualSearchResultItem>,
+    pub total: usize,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ManualSearchResultItem {
+    pub title: String,
+    pub guid: Option<String>,
+    pub download_url: Option<String>,
+    pub published_at: Option<String>,
+    pub size_bytes: Option<u64>,
+    pub seeders: Option<u32>,
+    pub leechers: Option<u32>,
+    pub parsed_artist: Option<String>,
+    pub parsed_album: Option<String>,
+    pub parsed_quality: String,
+    pub parsed_bitrate_kbps: Option<u32>,
+    pub parsed_release_group: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchErrorResponse {
+    pub error: String,
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/search/manual",
+    request_body = ManualSearchApiRequest,
+    responses(
+        (status = 200, description = "Manual search results", body = ManualSearchApiResponse),
+        (status = 400, description = "Invalid request", body = SearchErrorResponse),
+        (status = 404, description = "Indexer not found", body = SearchErrorResponse),
+        (status = 502, description = "Indexer search failed", body = SearchErrorResponse)
+    ),
+    tag = "search"
+)]
+pub async fn manual_search_endpoint(
+    State(state): State<AppState>,
+    Json(request): Json<ManualSearchApiRequest>,
+) -> impl IntoResponse {
+    if request.indexer_id.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(SearchErrorResponse {
+                error: "indexer_id is required".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let indexer = match state
+        .indexer_definition_repository
+        .get_by_id(request.indexer_id.clone())
+        .await
+    {
+        Ok(Some(indexer)) => indexer,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(SearchErrorResponse {
+                    error: format!("Indexer {} not found", request.indexer_id),
+                }),
+            )
+                .into_response();
+        }
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SearchErrorResponse {
+                    error: format!("failed to fetch indexer: {error}"),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let protocol = match indexer.protocol.parse::<IndexerProtocol>() {
+        Ok(protocol) => protocol,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(SearchErrorResponse {
+                    error: format!("invalid indexer protocol: {error}"),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let preferred_qualities = match parse_preferred_qualities(&request.preferred_qualities) {
+        Ok(values) => values,
+        Err(error) => {
+            return (StatusCode::BAD_REQUEST, Json(SearchErrorResponse { error })).into_response();
+        }
+    };
+
+    let options = ReleaseFilterOptions {
+        preferred_qualities,
+        min_bitrate_kbps: request.min_bitrate_kbps,
+        preferred_release_groups: request.preferred_release_groups,
+    };
+
+    let manual_request = ManualSearchRequest {
+        artist: request.artist,
+        album: request.album,
+        query: request.query,
+    };
+
+    let config = IndexerConfig {
+        name: indexer.name,
+        base_url: indexer.base_url,
+        protocol: protocol.clone(),
+        api_key: indexer.api_key,
+        enabled: indexer.enabled,
+    };
+
+    let ranked_results = match protocol {
+        IndexerProtocol::Newznab => {
+            let client = NewznabClient::new(config);
+            manual_search(&client, &manual_request, &options).await
+        }
+        IndexerProtocol::Torznab => {
+            let client = TorznabClient::new(config);
+            manual_search(&client, &manual_request, &options).await
+        }
+        IndexerProtocol::Gazelle | IndexerProtocol::Custom => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(SearchErrorResponse {
+                    error: "interactive manual search currently supports newznab/torznab indexers"
+                        .to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    match ranked_results {
+        Ok(results) => {
+            let items = results
+                .into_iter()
+                .map(|result| ManualSearchResultItem {
+                    title: result.search_result.title,
+                    guid: result.search_result.guid,
+                    download_url: result.search_result.download_url,
+                    published_at: result.search_result.published_at,
+                    size_bytes: result.search_result.size_bytes,
+                    seeders: result.search_result.seeders,
+                    leechers: result.search_result.leechers,
+                    parsed_artist: result.parsed.artist,
+                    parsed_album: result.parsed.album,
+                    parsed_quality: format!("{:?}", result.parsed.quality),
+                    parsed_bitrate_kbps: result.parsed.bitrate_kbps,
+                    parsed_release_group: result.parsed.release_group,
+                })
+                .collect::<Vec<_>>();
+
+            (
+                StatusCode::OK,
+                Json(ManualSearchApiResponse {
+                    total: items.len(),
+                    items,
+                }),
+            )
+                .into_response()
+        }
+        Err(error) => (
+            StatusCode::BAD_GATEWAY,
+            Json(SearchErrorResponse {
+                error: format!("indexer search failed: {error}"),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+fn parse_preferred_qualities(values: &[String]) -> Result<Vec<AudioQuality>, String> {
+    values
+        .iter()
+        .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+            "flac" => Ok(AudioQuality::Flac),
+            "mp3" => Ok(AudioQuality::Mp3),
+            "aac" => Ok(AudioQuality::Aac),
+            "alac" => Ok(AudioQuality::Alac),
+            "unknown" => Ok(AudioQuality::Unknown),
+            other => Err(format!(
+                "unsupported quality '{}'; expected one of: flac, mp3, aac, alac, unknown",
+                other
+            )),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chorrosion_config::AppConfig;
+    use chorrosion_domain::IndexerDefinition;
+    use chorrosion_infrastructure::sqlite_adapters::{
+        SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
+        SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,
+        SqliteQualityProfileRepository, SqliteTrackRepository,
+    };
+    use chorrosion_infrastructure::ResponseCache;
+    use std::sync::Arc;
+
+    async fn make_test_state() -> AppState {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+
+        sqlx::migrate!("../../migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+
+        AppState::new(
+            AppConfig::default(),
+            Arc::new(SqliteArtistRepository::new(pool.clone())),
+            Arc::new(SqliteAlbumRepository::new(pool.clone())),
+            Arc::new(SqliteTrackRepository::new(pool.clone())),
+            Arc::new(SqliteQualityProfileRepository::new(pool.clone())),
+            Arc::new(SqliteMetadataProfileRepository::new(pool.clone())),
+            Arc::new(SqliteIndexerDefinitionRepository::new(pool.clone())),
+            Arc::new(SqliteDownloadClientDefinitionRepository::new(pool)),
+            ResponseCache::new(100, 60),
+        )
+    }
+
+    #[tokio::test]
+    async fn parse_preferred_qualities_rejects_invalid_values() {
+        let err = parse_preferred_qualities(&["lossless".to_string()]).expect_err("invalid");
+        assert!(err.contains("unsupported quality"));
+    }
+
+    #[tokio::test]
+    async fn manual_search_endpoint_returns_404_for_unknown_indexer() {
+        let state = make_test_state().await;
+
+        let response = manual_search_endpoint(
+            State(state),
+            Json(ManualSearchApiRequest {
+                indexer_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                artist: Some("Boards of Canada".to_string()),
+                album: Some("Music Has the Right to Children".to_string()),
+                query: None,
+                preferred_qualities: vec![],
+                min_bitrate_kbps: None,
+                preferred_release_groups: vec![],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn manual_search_endpoint_rejects_unsupported_protocol() {
+        let state = make_test_state().await;
+
+        let indexer = IndexerDefinition::new("custom-indexer", "https://example.test", "custom");
+        let id = indexer.id.to_string();
+        state
+            .indexer_definition_repository
+            .create(indexer)
+            .await
+            .expect("create indexer");
+
+        let response = manual_search_endpoint(
+            State(state),
+            Json(ManualSearchApiRequest {
+                indexer_id: id,
+                artist: None,
+                album: None,
+                query: Some("test".to_string()),
+                preferred_qualities: vec![],
+                min_bitrate_kbps: None,
+                preferred_release_groups: vec![],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -75,6 +75,54 @@ pub async fn manual_search_endpoint(
             .into_response();
     }
 
+    let artist = request
+        .artist
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+    let album = request
+        .album
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+    let query = request
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+
+    if artist.is_none() && album.is_none() && query.is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(SearchErrorResponse {
+                error: "at least one of artist, album, or query must be provided".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let preferred_qualities = match parse_preferred_qualities(&request.preferred_qualities) {
+        Ok(values) => values,
+        Err(error) => {
+            return (StatusCode::BAD_REQUEST, Json(SearchErrorResponse { error })).into_response();
+        }
+    };
+
+    let options = ReleaseFilterOptions {
+        preferred_qualities,
+        min_bitrate_kbps: request.min_bitrate_kbps,
+        preferred_release_groups: request.preferred_release_groups,
+    };
+
+    let manual_request = ManualSearchRequest {
+        artist,
+        album,
+        query,
+    };
+
     let indexer = match state
         .indexer_definition_repository
         .get_by_id(request.indexer_id.clone())
@@ -112,54 +160,6 @@ pub async fn manual_search_endpoint(
             )
                 .into_response();
         }
-    };
-
-    let preferred_qualities = match parse_preferred_qualities(&request.preferred_qualities) {
-        Ok(values) => values,
-        Err(error) => {
-            return (StatusCode::BAD_REQUEST, Json(SearchErrorResponse { error })).into_response();
-        }
-    };
-
-    let options = ReleaseFilterOptions {
-        preferred_qualities,
-        min_bitrate_kbps: request.min_bitrate_kbps,
-        preferred_release_groups: request.preferred_release_groups,
-    };
-
-    let artist = request
-        .artist
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-    let album = request
-        .album
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-    let query = request
-        .query
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
-
-    if artist.is_none() && album.is_none() && query.is_none() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(SearchErrorResponse {
-                error: "at least one of artist, album, or query must be provided".to_string(),
-            }),
-        )
-            .into_response();
-    }
-
-    let manual_request = ManualSearchRequest {
-        artist,
-        album,
-        query,
     };
 
     let config = IndexerConfig {

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -92,6 +92,10 @@ use handlers::quality_profiles::{
     __path_delete_quality_profile, __path_get_quality_profile, __path_list_quality_profiles,
     __path_update_quality_profile,
 };
+use handlers::search::{
+    manual_search_endpoint, ManualSearchApiRequest, ManualSearchApiResponse,
+    ManualSearchResultItem, SearchErrorResponse, __path_manual_search_endpoint,
+};
 use handlers::system::{
     get_system_logs, get_system_notifications, get_system_status, get_system_tasks,
     get_system_version, post_system_notifications_test, NotificationProviderStatusResponse,
@@ -296,6 +300,7 @@ async fn metrics() -> axum::response::Response {
         update_indexer,
         delete_indexer,
         test_indexer_endpoint,
+        manual_search_endpoint,
         evaluate_import_candidate,
         submit_manual_import_decision,
         list_wanted_albums,
@@ -375,6 +380,10 @@ async fn metrics() -> axum::response::Response {
             TestIndexerResponse,
             IndexerCapabilitiesResponse,
             IndexerTestErrorResponse,
+            ManualSearchApiRequest,
+            ManualSearchResultItem,
+            ManualSearchApiResponse,
+            SearchErrorResponse,
             ImportErrorResponse,
             ImportRawMetadataRequest,
             ImportCandidateRequest,
@@ -402,6 +411,7 @@ async fn metrics() -> axum::response::Response {
         (name = "auth", description = "Authentication and API key management endpoints"),
         (name = "settings", description = "Configuration and profile endpoints"),
         (name = "indexers", description = "Indexer configuration and validation endpoints"),
+        (name = "search", description = "Manual and interactive search endpoints"),
         (name = "imports", description = "Import evaluation and manual decision endpoints"),
         (name = "wanted", description = "Wanted and missing album tracking"),
         (name = "calendar", description = "Upcoming releases calendar")
@@ -508,6 +518,7 @@ pub fn router(state: AppState) -> Router {
             get(get_indexer).put(update_indexer).delete(delete_indexer),
         )
         .route("/indexers/test", post(test_indexer_endpoint))
+        .route("/search/manual", post(manual_search_endpoint))
         .route("/imports/evaluate", post(evaluate_import_candidate))
         .route("/imports/decision", post(submit_manual_import_decision))
         .route("/wanted", get(list_wanted_albums))

--- a/crates/chorrosion-application/src/release_parsing.rs
+++ b/crates/chorrosion-application/src/release_parsing.rs
@@ -282,15 +282,21 @@ fn clean_component(value: &str) -> Option<String> {
     }
 }
 
-impl ParsedReleaseTitle {
-    fn quality_key(&self) -> &'static str {
-        match self.quality {
+impl AudioQuality {
+    pub fn as_str(&self) -> &'static str {
+        match self {
             AudioQuality::Flac => "flac",
             AudioQuality::Mp3 => "mp3",
             AudioQuality::Aac => "aac",
             AudioQuality::Alac => "alac",
             AudioQuality::Unknown => "unknown",
         }
+    }
+}
+
+impl ParsedReleaseTitle {
+    fn quality_key(&self) -> &'static str {
+        self.quality.as_str()
     }
 }
 


### PR DESCRIPTION
Implements interactive search UI support by exposing a manual-search API endpoint for the frontend.

## Changes

- add POST /api/v1/search/manual
  - accepts indexer ID plus artist/album/query criteria
  - supports quality preferences, minimum bitrate, and preferred release groups
  - validates indexer existence and supported protocol
- add new search handler module and endpoint wiring
- add OpenAPI path/schema documentation and search API tag coverage
- add focused handler tests for invalid protocol and unknown indexer behavior
- mark roadmap interactive search UI support item complete (Issue #377)

## Validation

- cargo clippy -p chorrosion-api -- -D warnings
- cargo test -p chorrosion-api

Closes #377
