### PR TITLE
refactor: abstract AppState repositories behind traits (#381)

### DIFF
--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -5,7 +5,6 @@ use chorrosion_application::{
     QBittorrentClient, SabnzbdClient, TransmissionClient,
 };
 use chorrosion_domain::DownloadClientDefinition;
-use chorrosion_infrastructure::repositories::Repository;
 use futures_util::future::join_all;
 use serde::Serialize;
 use std::collections::HashSet;
@@ -364,7 +363,6 @@ mod tests {
     use chorrosion_application::ActivityStallTracker;
     use chorrosion_config::AppConfig;
     use chorrosion_domain::DownloadClientDefinition;
-    use chorrosion_infrastructure::repositories::Repository;
     use chorrosion_infrastructure::sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
         SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,

--- a/crates/chorrosion-api/src/handlers/albums.rs
+++ b/crates/chorrosion-api/src/handlers/albums.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use chorrosion_application::AppState;
 use chorrosion_domain::{Album, AlbumStatus};
-use chorrosion_infrastructure::repositories::{AlbumRepository, Repository};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use utoipa::{IntoParams, ToSchema};

--- a/crates/chorrosion-api/src/handlers/albums.rs
+++ b/crates/chorrosion-api/src/handlers/albums.rs
@@ -239,7 +239,7 @@ pub async fn list_albums_by_artist(
 
     let artist = state
         .artist_repository
-        .get_by_id(artist_id.clone())
+        .get_by_id(&artist_id)
         .await
         .map_err(|error| {
             (
@@ -312,7 +312,7 @@ pub async fn list_albums_by_artist(
 pub async fn get_album(State(state): State<AppState>, Path(id): Path<String>) -> impl IntoResponse {
     debug!(target: "api", %id, "fetching album");
 
-    match state.album_repository.get_by_id(id.clone()).await {
+    match state.album_repository.get_by_id(&id).await {
         Ok(Some(album)) => (StatusCode::OK, Json(AlbumResponse::from(album))).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -350,7 +350,7 @@ pub async fn trigger_album_search(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "triggering album search");
 
-    let album = match state.album_repository.get_by_id(id.clone()).await {
+    let album = match state.album_repository.get_by_id(&id).await {
         Ok(Some(album)) => album,
         Ok(None) => {
             return (
@@ -374,7 +374,7 @@ pub async fn trigger_album_search(
 
     let artist_name = match state
         .artist_repository
-        .get_by_id(album.artist_id.to_string())
+        .get_by_id(&album.artist_id.to_string())
         .await
     {
         Ok(Some(artist)) => artist.name,
@@ -423,11 +423,7 @@ pub async fn create_album(
 ) -> impl IntoResponse {
     debug!(target: "api", ?request, "creating album");
 
-    let artist = match state
-        .artist_repository
-        .get_by_id(request.artist_id.clone())
-        .await
-    {
+    let artist = match state.artist_repository.get_by_id(&request.artist_id).await {
         Ok(Some(artist)) => artist,
         Ok(None) => {
             return (
@@ -502,7 +498,7 @@ pub async fn update_album(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, ?request, "updating album");
 
-    let mut album = match state.album_repository.get_by_id(id.clone()).await {
+    let mut album = match state.album_repository.get_by_id(&id).await {
         Ok(Some(album)) => album,
         Ok(None) => {
             return (
@@ -525,7 +521,7 @@ pub async fn update_album(
     };
 
     if let Some(artist_id) = request.artist_id {
-        match state.artist_repository.get_by_id(artist_id.clone()).await {
+        match state.artist_repository.get_by_id(&artist_id).await {
             Ok(Some(artist)) => {
                 album.artist_id = artist.id;
             }
@@ -606,13 +602,13 @@ pub async fn delete_album(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "deleting album");
 
-    match state.album_repository.get_by_id(id.clone()).await {
+    match state.album_repository.get_by_id(&id).await {
         Ok(Some(_)) => {
-            match state.album_repository.delete(id.clone()).await {
+            match state.album_repository.delete(&id).await {
                 Ok(_) => StatusCode::NO_CONTENT.into_response(),
                 Err(delete_error) => {
                     // Check if the album was concurrently deleted before we could.
-                    match state.album_repository.get_by_id(id.clone()).await {
+                    match state.album_repository.get_by_id(&id).await {
                         Ok(None) => (
                             StatusCode::NOT_FOUND,
                             Json(ErrorResponse {

--- a/crates/chorrosion-api/src/handlers/artists.rs
+++ b/crates/chorrosion-api/src/handlers/artists.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use chorrosion_application::AppState;
 use chorrosion_domain::{Artist, ArtistStatus};
-use chorrosion_infrastructure::repositories::{AlbumRepository, Repository, TrackRepository};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use utoipa::{IntoParams, ToSchema};

--- a/crates/chorrosion-api/src/handlers/artists.rs
+++ b/crates/chorrosion-api/src/handlers/artists.rs
@@ -334,7 +334,7 @@ pub async fn get_artist(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "fetching artist");
 
-    match state.artist_repository.get_by_id(id.clone()).await {
+    match state.artist_repository.get_by_id(&id).await {
         Ok(Some(artist)) => (StatusCode::OK, Json(ArtistResponse::from(artist))).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -373,7 +373,7 @@ pub async fn get_artist_statistics(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "fetching artist statistics");
 
-    let artist = match state.artist_repository.get_by_id(id.clone()).await {
+    let artist = match state.artist_repository.get_by_id(&id).await {
         Ok(Some(artist)) => artist,
         Ok(None) => {
             return (
@@ -559,7 +559,7 @@ pub async fn update_artist(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, ?request, "updating artist");
 
-    let mut artist = match state.artist_repository.get_by_id(id.clone()).await {
+    let mut artist = match state.artist_repository.get_by_id(&id).await {
         Ok(Some(a)) => a,
         Ok(None) => {
             return (
@@ -632,13 +632,13 @@ pub async fn delete_artist(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "deleting artist");
 
-    match state.artist_repository.get_by_id(id.clone()).await {
+    match state.artist_repository.get_by_id(&id).await {
         Ok(Some(_)) => {
-            match state.artist_repository.delete(id.clone()).await {
+            match state.artist_repository.delete(&id).await {
                 Ok(_) => StatusCode::NO_CONTENT.into_response(),
                 Err(delete_error) => {
                     // Check if the artist was concurrently deleted before we could.
-                    match state.artist_repository.get_by_id(id.clone()).await {
+                    match state.artist_repository.get_by_id(&id).await {
                         Ok(None) => (
                             StatusCode::NOT_FOUND,
                             Json(ErrorResponse {

--- a/crates/chorrosion-api/src/handlers/calendar.rs
+++ b/crates/chorrosion-api/src/handlers/calendar.rs
@@ -175,7 +175,7 @@ pub async fn list_upcoming_releases(
             Entry::Vacant(e) => {
                 let name = state
                     .artist_repository
-                    .get_by_id(e.key().clone())
+                    .get_by_id(e.key())
                     .await
                     .map_err(|e| {
                         (
@@ -283,7 +283,7 @@ X-WR-CALNAME:Chorrosion Music Releases\r\n",
         let artist_name = match artist_cache.entry(artist_id_str) {
             Entry::Occupied(e) => e.get().clone(),
             Entry::Vacant(e) => {
-                let name = match state.artist_repository.get_by_id(e.key().clone()).await {
+                let name = match state.artist_repository.get_by_id(e.key()).await {
                     Ok(artist) => artist
                         .map(|a| a.name)
                         .unwrap_or_else(|| "Unknown Artist".to_string()),

--- a/crates/chorrosion-api/src/handlers/calendar.rs
+++ b/crates/chorrosion-api/src/handlers/calendar.rs
@@ -6,7 +6,6 @@ use axum::{
     Json,
 };
 use chorrosion_application::AppState;
-use chorrosion_infrastructure::repositories::{AlbumRepository, Repository};
 use chrono::{NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
@@ -351,7 +350,6 @@ mod tests {
     use axum::body::to_bytes;
     use chorrosion_config::AppConfig;
     use chorrosion_domain::{Album, AlbumStatus, Artist, ArtistId};
-    use chorrosion_infrastructure::repositories::Repository;
     use chorrosion_infrastructure::sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
         SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,

--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -248,7 +248,7 @@ pub async fn get_download_client(
 ) -> impl IntoResponse {
     match state
         .download_client_definition_repository
-        .get_by_id(id.clone())
+        .get_by_id(&id)
         .await
     {
         Ok(Some(client)) => {
@@ -388,7 +388,7 @@ pub async fn update_download_client(
 ) -> impl IntoResponse {
     let mut client = match state
         .download_client_definition_repository
-        .get_by_id(id.clone())
+        .get_by_id(&id)
         .await
     {
         Ok(Some(client)) => client,
@@ -516,13 +516,13 @@ pub async fn delete_download_client(
 ) -> impl IntoResponse {
     match state
         .download_client_definition_repository
-        .get_by_id(id.clone())
+        .get_by_id(&id)
         .await
     {
         Ok(Some(_)) => {
             match state
                 .download_client_definition_repository
-                .delete(id.clone())
+                .delete(&id)
                 .await
             {
                 Ok(_) => StatusCode::NO_CONTENT.into_response(),
@@ -531,7 +531,7 @@ pub async fn delete_download_client(
                     // from a transient delete failure (500).
                     match state
                         .download_client_definition_repository
-                        .get_by_id(id.clone())
+                        .get_by_id(&id)
                         .await
                     {
                         Ok(None) => (
@@ -770,7 +770,7 @@ mod tests {
 
         let updated = state
             .download_client_definition_repository
-            .get_by_id(created.id.to_string())
+            .get_by_id(&created.id.to_string())
             .await
             .expect("fetch")
             .expect("exists");

--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use chorrosion_application::AppState;
 use chorrosion_domain::DownloadClientDefinition;
-use chorrosion_infrastructure::repositories::{DownloadClientDefinitionRepository, Repository};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -254,11 +254,7 @@ pub async fn get_indexer(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match state
-        .indexer_definition_repository
-        .get_by_id(id.clone())
-        .await
-    {
+    match state.indexer_definition_repository.get_by_id(&id).await {
         Ok(Some(indexer)) => (StatusCode::OK, Json(IndexerResponse::from(indexer))).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -391,11 +387,7 @@ pub async fn update_indexer(
     Path(id): Path<String>,
     Json(request): Json<UpdateIndexerRequest>,
 ) -> impl IntoResponse {
-    let mut indexer = match state
-        .indexer_definition_repository
-        .get_by_id(id.clone())
-        .await
-    {
+    let mut indexer = match state.indexer_definition_repository.get_by_id(&id).await {
         Ok(Some(indexer)) => indexer,
         Ok(None) => {
             return (
@@ -508,22 +500,14 @@ pub async fn delete_indexer(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match state
-        .indexer_definition_repository
-        .get_by_id(id.clone())
-        .await
-    {
+    match state.indexer_definition_repository.get_by_id(&id).await {
         Ok(Some(_)) => {
-            match state.indexer_definition_repository.delete(id.clone()).await {
+            match state.indexer_definition_repository.delete(&id).await {
                 Ok(_) => StatusCode::NO_CONTENT.into_response(),
                 Err(delete_error) => {
                     // Recheck existence to distinguish concurrent deletion (404)
                     // from a transient delete failure (500).
-                    match state
-                        .indexer_definition_repository
-                        .get_by_id(id.clone())
-                        .await
-                    {
+                    match state.indexer_definition_repository.get_by_id(&id).await {
                         Ok(None) => (
                             StatusCode::NOT_FOUND,
                             Json(IndexerErrorResponse {
@@ -779,7 +763,7 @@ mod tests {
 
         let fetched = state
             .indexer_definition_repository
-            .get_by_id(created.id.to_string())
+            .get_by_id(&created.id.to_string())
             .await
             .expect("get indexer")
             .expect("indexer exists");

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use chorrosion_application::{AppState, IndexerCapabilities, IndexerProtocol};
 use chorrosion_domain::IndexerDefinition;
-use chorrosion_infrastructure::repositories::{IndexerDefinitionRepository, Repository};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};

--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -191,11 +191,7 @@ pub async fn get_metadata_profile(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "fetching metadata profile");
 
-    match state
-        .metadata_profile_repository
-        .get_by_id(id.clone())
-        .await
-    {
+    match state.metadata_profile_repository.get_by_id(&id).await {
         Ok(Some(profile)) => {
             (StatusCode::OK, Json(MetadataProfileResponse::from(profile))).into_response()
         }
@@ -284,11 +280,7 @@ pub async fn update_metadata_profile(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, ?request, "updating metadata profile");
 
-    let mut profile = match state
-        .metadata_profile_repository
-        .get_by_id(id.clone())
-        .await
-    {
+    let mut profile = match state.metadata_profile_repository.get_by_id(&id).await {
         Ok(Some(profile)) => profile,
         Ok(None) => {
             return (
@@ -358,22 +350,14 @@ pub async fn delete_metadata_profile(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "deleting metadata profile");
 
-    match state
-        .metadata_profile_repository
-        .get_by_id(id.clone())
-        .await
-    {
+    match state.metadata_profile_repository.get_by_id(&id).await {
         Ok(Some(_)) => {
-            match state.metadata_profile_repository.delete(id.clone()).await {
+            match state.metadata_profile_repository.delete(&id).await {
                 Ok(_) => StatusCode::NO_CONTENT.into_response(),
                 Err(delete_error) => {
                     // Recheck existence to distinguish concurrent deletion (404)
                     // from a transient delete failure (500).
-                    match state
-                        .metadata_profile_repository
-                        .get_by_id(id.clone())
-                        .await
-                    {
+                    match state.metadata_profile_repository.get_by_id(&id).await {
                         Ok(None) => (
                             StatusCode::NOT_FOUND,
                             Json(ErrorResponse {
@@ -620,7 +604,7 @@ mod tests {
 
             let persisted = state
                 .metadata_profile_repository
-                .get_by_id(profile.id.to_string())
+                .get_by_id(&profile.id.to_string())
                 .await
                 .expect("get_by_id succeeds")
                 .expect("profile still exists");

--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use chorrosion_application::AppState;
 use chorrosion_domain::MetadataProfile;
-use chorrosion_infrastructure::repositories::Repository;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tracing::debug;

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -204,7 +204,7 @@ pub async fn get_quality_profile(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "fetching quality profile");
 
-    match state.quality_profile_repository.get_by_id(id.clone()).await {
+    match state.quality_profile_repository.get_by_id(&id).await {
         Ok(Some(profile)) => {
             (StatusCode::OK, Json(QualityProfileResponse::from(profile))).into_response()
         }
@@ -289,7 +289,7 @@ pub async fn update_quality_profile(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, ?request, "updating quality profile");
 
-    let mut profile = match state.quality_profile_repository.get_by_id(id.clone()).await {
+    let mut profile = match state.quality_profile_repository.get_by_id(&id).await {
         Ok(Some(profile)) => profile,
         Ok(None) => {
             return (
@@ -361,14 +361,14 @@ pub async fn delete_quality_profile(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "deleting quality profile");
 
-    match state.quality_profile_repository.get_by_id(id.clone()).await {
+    match state.quality_profile_repository.get_by_id(&id).await {
         Ok(Some(_)) => {
-            match state.quality_profile_repository.delete(id.clone()).await {
+            match state.quality_profile_repository.delete(&id).await {
                 Ok(_) => StatusCode::NO_CONTENT.into_response(),
                 Err(delete_error) => {
                     // Recheck existence to distinguish concurrent deletion (404)
                     // from a transient delete failure (500).
-                    match state.quality_profile_repository.get_by_id(id.clone()).await {
+                    match state.quality_profile_repository.get_by_id(&id).await {
                         Ok(None) => (
                             StatusCode::NOT_FOUND,
                             Json(ErrorResponse {

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use chorrosion_application::AppState;
 use chorrosion_domain::QualityProfile;
-use chorrosion_infrastructure::repositories::Repository;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use utoipa::{IntoParams, ToSchema};

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -124,7 +124,7 @@ pub async fn manual_search_endpoint(
 
     let indexer = match state
         .indexer_definition_repository
-        .get_by_id(request.indexer_id.clone())
+        .get_by_id(&request.indexer_id)
         .await
     {
         Ok(Some(indexer)) => indexer,

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -4,7 +4,6 @@ use chorrosion_application::{
     manual_search, AppState, AudioQuality, IndexerConfig, IndexerError, IndexerProtocol,
     ManualSearchRequest, NewznabClient, ReleaseFilterOptions, TorznabClient,
 };
-use chorrosion_infrastructure::repositories::Repository;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/crates/chorrosion-api/src/handlers/tracks.rs
+++ b/crates/chorrosion-api/src/handlers/tracks.rs
@@ -214,7 +214,7 @@ pub async fn list_tracks_by_album(
 
     let album = state
         .album_repository
-        .get_by_id(album_id.clone())
+        .get_by_id(&album_id)
         .await
         .map_err(|error| {
             (
@@ -316,7 +316,7 @@ pub async fn list_tracks_by_artist(
 
     let artist = state
         .artist_repository
-        .get_by_id(artist_id.clone())
+        .get_by_id(&artist_id)
         .await
         .map_err(|error| {
             (
@@ -392,7 +392,7 @@ pub async fn list_tracks_by_artist(
 pub async fn get_track(State(state): State<AppState>, Path(id): Path<String>) -> impl IntoResponse {
     debug!(target: "api", %id, "fetching track");
 
-    match state.track_repository.get_by_id(id.clone()).await {
+    match state.track_repository.get_by_id(&id).await {
         Ok(Some(track)) => (StatusCode::OK, Json(TrackResponse::from(track))).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -429,11 +429,7 @@ pub async fn create_track(
 ) -> impl IntoResponse {
     debug!(target: "api", ?request, "creating track");
 
-    let album = match state
-        .album_repository
-        .get_by_id(request.album_id.clone())
-        .await
-    {
+    let album = match state.album_repository.get_by_id(&request.album_id).await {
         Ok(Some(album)) => album,
         Ok(None) => {
             return (
@@ -455,11 +451,7 @@ pub async fn create_track(
         }
     };
 
-    let artist = match state
-        .artist_repository
-        .get_by_id(request.artist_id.clone())
-        .await
-    {
+    let artist = match state.artist_repository.get_by_id(&request.artist_id).await {
         Ok(Some(artist)) => artist,
         Ok(None) => {
             return (
@@ -543,7 +535,7 @@ pub async fn update_track(
         monitored,
     } = request;
 
-    let mut track = match state.track_repository.get_by_id(id.clone()).await {
+    let mut track = match state.track_repository.get_by_id(&id).await {
         Ok(Some(track)) => track,
         Ok(None) => {
             return (
@@ -574,7 +566,7 @@ pub async fn update_track(
     let mut fetched_album_artist_id: Option<ArtistId> = None;
 
     if let Some(album_id) = album_id {
-        match state.album_repository.get_by_id(album_id.clone()).await {
+        match state.album_repository.get_by_id(&album_id).await {
             Ok(Some(album)) => {
                 fetched_album_artist_id = Some(album.artist_id);
                 track.album_id = album.id;
@@ -604,7 +596,7 @@ pub async fn update_track(
     }
 
     if let Some(artist_id) = artist_id {
-        match state.artist_repository.get_by_id(artist_id.clone()).await {
+        match state.artist_repository.get_by_id(&artist_id).await {
             Ok(Some(artist)) => {
                 track.artist_id = artist.id;
             }
@@ -639,7 +631,7 @@ pub async fn update_track(
                 // Only artist_id changed; fetch the album to get its artist_id.
                 match state
                     .album_repository
-                    .get_by_id(track.album_id.to_string())
+                    .get_by_id(&track.album_id.to_string())
                     .await
                 {
                     Ok(Some(album)) => album.artist_id,
@@ -725,13 +717,13 @@ pub async fn delete_track(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "deleting track");
 
-    match state.track_repository.get_by_id(id.clone()).await {
+    match state.track_repository.get_by_id(&id).await {
         Ok(Some(_)) => {
-            match state.track_repository.delete(id.clone()).await {
+            match state.track_repository.delete(&id).await {
                 Ok(_) => StatusCode::NO_CONTENT.into_response(),
                 Err(delete_error) => {
                     // Check if the track was concurrently deleted before we could.
-                    match state.track_repository.get_by_id(id.clone()).await {
+                    match state.track_repository.get_by_id(&id).await {
                         Ok(None) => (
                             StatusCode::NOT_FOUND,
                             Json(ErrorResponse {

--- a/crates/chorrosion-api/src/handlers/tracks.rs
+++ b/crates/chorrosion-api/src/handlers/tracks.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use chorrosion_application::AppState;
 use chorrosion_domain::{ArtistId, Track};
-use chorrosion_infrastructure::repositories::{Repository, TrackRepository};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use utoipa::{IntoParams, ToSchema};

--- a/crates/chorrosion-api/src/handlers/wanted.rs
+++ b/crates/chorrosion-api/src/handlers/wanted.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use chorrosion_application::AppState;
 use chorrosion_domain::{Album, AlbumStatus};
-use chorrosion_infrastructure::repositories::{AlbumRepository, Repository};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use utoipa::{IntoParams, ToSchema};
@@ -364,7 +363,6 @@ mod tests {
     use super::*;
     use axum::extract::Path;
     use chorrosion_config::AppConfig;
-    use chorrosion_infrastructure::repositories::Repository;
     use chorrosion_infrastructure::sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
         SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,

--- a/crates/chorrosion-api/src/handlers/wanted.rs
+++ b/crates/chorrosion-api/src/handlers/wanted.rs
@@ -281,7 +281,7 @@ pub async fn trigger_wanted_album_search(
 ) -> impl IntoResponse {
     debug!(target: "api", %id, "triggering wanted album search");
 
-    let album = match state.album_repository.get_by_id(id.clone()).await {
+    let album = match state.album_repository.get_by_id(&id).await {
         Ok(Some(album)) => album,
         Ok(None) => {
             return (
@@ -318,7 +318,7 @@ pub async fn trigger_wanted_album_search(
 
     let artist_name = match state
         .artist_repository
-        .get_by_id(album.artist_id.to_string())
+        .get_by_id(&album.artist_id.to_string())
         .await
     {
         Ok(Some(artist)) => artist.name,
@@ -363,6 +363,7 @@ mod tests {
     use super::*;
     use axum::extract::Path;
     use chorrosion_config::AppConfig;
+    use chorrosion_infrastructure::repositories::Repository;
     use chorrosion_infrastructure::sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
         SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -16,7 +16,6 @@ use axum::{
 };
 use chorrosion_application::AppState;
 use chorrosion_config::PermissionLevel;
-use chorrosion_infrastructure::repositories::Repository;
 use handlers::activity::{
     get_activity_failed, get_activity_history, get_activity_processing, get_activity_queue,
     get_activity_stalled, ActivityErrorResponse, ActivityItemResponse, ActivityListResponse,

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use chorrosion_config::AppConfig;
 use chorrosion_infrastructure::{
-    sqlite_adapters::{
-        SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
-        SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,
-        SqliteQualityProfileRepository, SqliteTrackRepository,
+    repositories::{
+        AlbumRepository, ArtistRepository, DownloadClientDefinitionRepository,
+        IndexerDefinitionRepository, MetadataProfileRepository, QualityProfileRepository,
+        TrackRepository,
     },
     ResponseCache,
 };
@@ -336,13 +336,13 @@ impl Default for ActivityStallTracker {
 #[derive(Clone)]
 pub struct AppState {
     pub config: AppConfig,
-    pub artist_repository: Arc<SqliteArtistRepository>,
-    pub album_repository: Arc<SqliteAlbumRepository>,
-    pub track_repository: Arc<SqliteTrackRepository>,
-    pub quality_profile_repository: Arc<SqliteQualityProfileRepository>,
-    pub metadata_profile_repository: Arc<SqliteMetadataProfileRepository>,
-    pub indexer_definition_repository: Arc<SqliteIndexerDefinitionRepository>,
-    pub download_client_definition_repository: Arc<SqliteDownloadClientDefinitionRepository>,
+    pub artist_repository: Arc<dyn ArtistRepository>,
+    pub album_repository: Arc<dyn AlbumRepository>,
+    pub track_repository: Arc<dyn TrackRepository>,
+    pub quality_profile_repository: Arc<dyn QualityProfileRepository>,
+    pub metadata_profile_repository: Arc<dyn MetadataProfileRepository>,
+    pub indexer_definition_repository: Arc<dyn IndexerDefinitionRepository>,
+    pub download_client_definition_repository: Arc<dyn DownloadClientDefinitionRepository>,
     /// In-memory cache for serialized API GET responses.
     pub response_cache: ResponseCache,
     /// Short-lived cache for the polled download-client activity snapshot.
@@ -357,13 +357,13 @@ impl AppState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: AppConfig,
-        artist_repository: Arc<SqliteArtistRepository>,
-        album_repository: Arc<SqliteAlbumRepository>,
-        track_repository: Arc<SqliteTrackRepository>,
-        quality_profile_repository: Arc<SqliteQualityProfileRepository>,
-        metadata_profile_repository: Arc<SqliteMetadataProfileRepository>,
-        indexer_definition_repository: Arc<SqliteIndexerDefinitionRepository>,
-        download_client_definition_repository: Arc<SqliteDownloadClientDefinitionRepository>,
+        artist_repository: Arc<dyn ArtistRepository>,
+        album_repository: Arc<dyn AlbumRepository>,
+        track_repository: Arc<dyn TrackRepository>,
+        quality_profile_repository: Arc<dyn QualityProfileRepository>,
+        metadata_profile_repository: Arc<dyn MetadataProfileRepository>,
+        indexer_definition_repository: Arc<dyn IndexerDefinitionRepository>,
+        download_client_definition_repository: Arc<dyn DownloadClientDefinitionRepository>,
         response_cache: ResponseCache,
     ) -> Self {
         Self {

--- a/crates/chorrosion-application/src/lists.rs
+++ b/crates/chorrosion-application/src/lists.rs
@@ -793,8 +793,7 @@ mod tests {
             Ok(entity)
         }
 
-        async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<Artist>> {
-            let id = id.into();
+        async fn get_by_id(&self, id: &str) -> Result<Option<Artist>> {
             Ok(self
                 .artists
                 .lock()
@@ -822,8 +821,7 @@ mod tests {
             Ok(entity)
         }
 
-        async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-            let id = id.into();
+        async fn delete(&self, id: &str) -> Result<()> {
             let mut artists = self.artists.lock().unwrap();
             artists.retain(|artist| artist.id.to_string() != id);
             Ok(())
@@ -892,8 +890,7 @@ mod tests {
             Ok(entity)
         }
 
-        async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<Album>> {
-            let id = id.into();
+        async fn get_by_id(&self, id: &str) -> Result<Option<Album>> {
             Ok(self
                 .albums
                 .lock()
@@ -921,8 +918,7 @@ mod tests {
             Ok(entity)
         }
 
-        async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-            let id = id.into();
+        async fn delete(&self, id: &str) -> Result<()> {
             let mut albums = self.albums.lock().unwrap();
             albums.retain(|album| album.id.to_string() != id);
             Ok(())

--- a/crates/chorrosion-infrastructure/src/repositories.rs
+++ b/crates/chorrosion-infrastructure/src/repositories.rs
@@ -15,10 +15,10 @@ use chrono::NaiveDate;
 #[async_trait::async_trait]
 pub trait Repository<T>: Send + Sync {
     async fn create(&self, entity: T) -> Result<T>;
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<T>>;
+    async fn get_by_id(&self, id: String) -> Result<Option<T>>;
     async fn list(&self, limit: i64, offset: i64) -> Result<Vec<T>>;
     async fn update(&self, entity: T) -> Result<T>;
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()>;
+    async fn delete(&self, id: String) -> Result<()>;
 }
 
 /// Artist repository with specialized queries

--- a/crates/chorrosion-infrastructure/src/repositories.rs
+++ b/crates/chorrosion-infrastructure/src/repositories.rs
@@ -15,10 +15,10 @@ use chrono::NaiveDate;
 #[async_trait::async_trait]
 pub trait Repository<T>: Send + Sync {
     async fn create(&self, entity: T) -> Result<T>;
-    async fn get_by_id(&self, id: String) -> Result<Option<T>>;
+    async fn get_by_id(&self, id: &str) -> Result<Option<T>>;
     async fn list(&self, limit: i64, offset: i64) -> Result<Vec<T>>;
     async fn update(&self, entity: T) -> Result<T>;
-    async fn delete(&self, id: String) -> Result<()>;
+    async fn delete(&self, id: &str) -> Result<()>;
 }
 
 /// Artist repository with specialized queries

--- a/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
@@ -2278,7 +2278,7 @@ mod tests {
         assert_eq!(created.id, id);
 
         let fetched = repo
-            .get_by_id(id.to_string())
+            .get_by_id(&id.to_string())
             .await
             .expect("fetch artist")
             .expect("artist exists");
@@ -2408,13 +2408,13 @@ mod tests {
         assert_eq!(updated.name, "After");
         assert!(!updated.monitored);
 
-        let fetched = repo.get_by_id(id.to_string()).await.unwrap().unwrap();
+        let fetched = repo.get_by_id(&id.to_string()).await.unwrap().unwrap();
         assert_eq!(fetched.name, "After");
         assert_eq!(fetched.path.as_deref(), Some("/music/after"));
 
         // Delete and ensure gone
-        repo.delete(id.to_string()).await.expect("delete");
-        let absent = repo.get_by_id(id.to_string()).await.expect("get");
+        repo.delete(&id.to_string()).await.expect("delete");
+        let absent = repo.get_by_id(&id.to_string()).await.expect("get");
         assert!(absent.is_none());
     }
 
@@ -2480,7 +2480,7 @@ mod tests {
 
         // Fetch and verify
         let fetched = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .expect("fetch album")
             .expect("album exists");
@@ -2746,7 +2746,7 @@ mod tests {
         assert!(!updated.monitored);
 
         let fetched = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -2759,11 +2759,11 @@ mod tests {
 
         // Delete and ensure gone
         album_repo
-            .delete(album_id.to_string())
+            .delete(&album_id.to_string())
             .await
             .expect("delete");
         let absent = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .expect("get");
         assert!(absent.is_none());
@@ -2835,19 +2835,19 @@ mod tests {
 
         // Delete artist (should cascade to albums due to FK constraint)
         artist_repo
-            .delete(artist_id.to_string())
+            .delete(&artist_id.to_string())
             .await
             .expect("delete artist");
 
         // Verify albums are also deleted
         let absent1 = album_repo
-            .get_by_id(album1_id.to_string())
+            .get_by_id(&album1_id.to_string())
             .await
             .expect("get1");
         assert!(absent1.is_none());
 
         let absent2 = album_repo
-            .get_by_id(album2_id.to_string())
+            .get_by_id(&album2_id.to_string())
             .await
             .expect("get2");
         assert!(absent2.is_none());
@@ -2884,7 +2884,7 @@ mod tests {
         assert_eq!(created.track_number, Some(1));
 
         let fetched = track_repo
-            .get_by_id(track.id.to_string())
+            .get_by_id(&track.id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -3081,7 +3081,7 @@ mod tests {
         assert_eq!(updated.title, "After");
 
         let fetched = track_repo
-            .get_by_id(track_id.to_string())
+            .get_by_id(&track_id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -3093,11 +3093,11 @@ mod tests {
 
         // Delete and ensure gone
         track_repo
-            .delete(track_id.to_string())
+            .delete(&track_id.to_string())
             .await
             .expect("delete");
         let absent = track_repo
-            .get_by_id(track_id.to_string())
+            .get_by_id(&track_id.to_string())
             .await
             .expect("get");
         assert!(absent.is_none());
@@ -3170,16 +3170,16 @@ mod tests {
         track_repo.create(track).await.expect("create track");
 
         // Verify track exists
-        let exists = track_repo.get_by_id(track_id.to_string()).await.unwrap();
+        let exists = track_repo.get_by_id(&track_id.to_string()).await.unwrap();
         assert!(exists.is_some());
 
         // Delete album should cascade to tracks
         album_repo
-            .delete(album_id.to_string())
+            .delete(&album_id.to_string())
             .await
             .expect("delete album");
         let track_check = track_repo
-            .get_by_id(track_id.to_string())
+            .get_by_id(&track_id.to_string())
             .await
             .expect("query");
         assert!(
@@ -3208,16 +3208,16 @@ mod tests {
         track_repo.create(track).await.expect("create track");
 
         // Verify track exists
-        let exists = track_repo.get_by_id(track_id.to_string()).await.unwrap();
+        let exists = track_repo.get_by_id(&track_id.to_string()).await.unwrap();
         assert!(exists.is_some());
 
         // Delete artist should cascade to both albums and tracks
         artist_repo
-            .delete(artist_id.to_string())
+            .delete(&artist_id.to_string())
             .await
             .expect("delete artist");
         let track_check = track_repo
-            .get_by_id(track_id.to_string())
+            .get_by_id(&track_id.to_string())
             .await
             .expect("query");
         assert!(
@@ -3248,7 +3248,7 @@ mod tests {
         assert!(created.upgrade_allowed);
 
         let fetched = profile_repo
-            .get_by_id(profile.id.to_string())
+            .get_by_id(&profile.id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -3302,7 +3302,7 @@ mod tests {
         assert_eq!(updated.allowed_qualities.len(), 2);
 
         let fetched = profile_repo
-            .get_by_id(profile_id.to_string())
+            .get_by_id(&profile_id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -3310,11 +3310,11 @@ mod tests {
 
         // Delete
         profile_repo
-            .delete(profile_id.to_string())
+            .delete(&profile_id.to_string())
             .await
             .expect("delete");
         let absent = profile_repo
-            .get_by_id(profile_id.to_string())
+            .get_by_id(&profile_id.to_string())
             .await
             .unwrap();
         assert!(absent.is_none());
@@ -3381,7 +3381,7 @@ mod tests {
         assert_eq!(created.release_statuses.len(), 2);
 
         let fetched = profile_repo
-            .get_by_id(profile.id.to_string())
+            .get_by_id(&profile.id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -3437,7 +3437,7 @@ mod tests {
         assert_eq!(updated.release_statuses.len(), 1);
 
         let fetched = profile_repo
-            .get_by_id(profile_id.to_string())
+            .get_by_id(&profile_id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -3445,11 +3445,11 @@ mod tests {
 
         // Delete
         profile_repo
-            .delete(profile_id.to_string())
+            .delete(&profile_id.to_string())
             .await
             .expect("delete");
         let absent = profile_repo
-            .get_by_id(profile_id.to_string())
+            .get_by_id(&profile_id.to_string())
             .await
             .unwrap();
         assert!(absent.is_none());
@@ -3485,7 +3485,7 @@ mod tests {
         assert!(created.release_statuses.is_empty());
 
         let fetched = profile_repo
-            .get_by_id(profile.id.to_string())
+            .get_by_id(&profile.id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -3531,7 +3531,7 @@ mod tests {
         repo.update(updated).await.expect("update indexer");
 
         let fetched = repo
-            .get_by_id(indexer_id.to_string())
+            .get_by_id(&indexer_id.to_string())
             .await
             .expect("get_by_id")
             .expect("indexer exists");
@@ -3546,11 +3546,11 @@ mod tests {
             .expect("old name lookup");
         assert!(absent.is_none());
 
-        repo.delete(indexer_id.to_string())
+        repo.delete(&indexer_id.to_string())
             .await
             .expect("delete indexer");
         let deleted = repo
-            .get_by_id(indexer_id.to_string())
+            .get_by_id(&indexer_id.to_string())
             .await
             .expect("get_by_id after delete");
         assert!(deleted.is_none());
@@ -3615,7 +3615,7 @@ mod tests {
         repo.update(updated).await.expect("update client");
 
         let fetched = repo
-            .get_by_id(client_id.to_string())
+            .get_by_id(&client_id.to_string())
             .await
             .expect("get_by_id")
             .expect("client exists");
@@ -3636,11 +3636,11 @@ mod tests {
             .expect("old name lookup");
         assert!(absent.is_none());
 
-        repo.delete(client_id.to_string())
+        repo.delete(&client_id.to_string())
             .await
             .expect("delete client");
         let deleted = repo
-            .get_by_id(client_id.to_string())
+            .get_by_id(&client_id.to_string())
             .await
             .expect("get_by_id after delete");
         assert!(deleted.is_none());
@@ -3714,7 +3714,7 @@ mod tests {
 
         // Get by id
         let fetched = track_file_repo
-            .get_by_id(track_file_id.to_string())
+            .get_by_id(&track_file_id.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -3739,11 +3739,11 @@ mod tests {
 
         // Delete
         track_file_repo
-            .delete(track_file_id.to_string())
+            .delete(&track_file_id.to_string())
             .await
             .expect("delete");
         let absent = track_file_repo
-            .get_by_id(track_file_id.to_string())
+            .get_by_id(&track_file_id.to_string())
             .await
             .unwrap();
         assert!(absent.is_none());
@@ -3973,7 +3973,7 @@ mod tests {
         repo.create(artist).await.expect("create artist");
 
         let fetched = repo
-            .get_by_id(artist_id.to_string())
+            .get_by_id(&artist_id.to_string())
             .await
             .expect("fetch artist")
             .expect("artist exists");
@@ -3998,7 +3998,7 @@ mod tests {
         repo.create(artist).await.expect("create");
 
         let mut updated = repo
-            .get_by_id(artist_id.to_string())
+            .get_by_id(&artist_id.to_string())
             .await
             .expect("fetch")
             .expect("exists");
@@ -4009,7 +4009,7 @@ mod tests {
         repo.update(updated.clone()).await.expect("update");
 
         let fetched = repo
-            .get_by_id(artist_id.to_string())
+            .get_by_id(&artist_id.to_string())
             .await
             .expect("fetch")
             .expect("exists");
@@ -4040,7 +4040,7 @@ mod tests {
         album_repo.create(album).await.expect("create album");
 
         let fetched = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .expect("fetch album")
             .expect("album exists");
@@ -4073,7 +4073,7 @@ mod tests {
         album_repo.create(album).await.expect("create");
 
         let mut updated = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .expect("fetch")
             .expect("exists");
@@ -4085,7 +4085,7 @@ mod tests {
         album_repo.update(updated.clone()).await.expect("update");
 
         let fetched = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .expect("fetch")
             .expect("exists");
@@ -4111,7 +4111,7 @@ mod tests {
         repo.create(artist).await.expect("create artist");
 
         let fetched = repo
-            .get_by_id(artist_id.to_string())
+            .get_by_id(&artist_id.to_string())
             .await
             .expect("fetch artist")
             .expect("artist exists");
@@ -4130,7 +4130,7 @@ mod tests {
         repo.create(artist).await.expect("create");
 
         let mut updated = repo
-            .get_by_id(artist_id.to_string())
+            .get_by_id(&artist_id.to_string())
             .await
             .expect("fetch")
             .expect("exists");
@@ -4146,7 +4146,7 @@ mod tests {
         repo.update(updated.clone()).await.expect("update");
 
         let fetched = repo
-            .get_by_id(artist_id.to_string())
+            .get_by_id(&artist_id.to_string())
             .await
             .expect("fetch")
             .expect("exists");
@@ -4173,7 +4173,7 @@ mod tests {
         album_repo.create(album).await.expect("create album");
 
         let fetched = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .expect("fetch album")
             .expect("album exists");
@@ -4200,7 +4200,7 @@ mod tests {
         album_repo.create(album).await.expect("create");
 
         let mut updated = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .expect("fetch")
             .expect("exists");
@@ -4216,7 +4216,7 @@ mod tests {
         album_repo.update(updated.clone()).await.expect("update");
 
         let fetched = album_repo
-            .get_by_id(album_id.to_string())
+            .get_by_id(&album_id.to_string())
             .await
             .expect("fetch")
             .expect("exists");
@@ -4250,7 +4250,7 @@ mod tests {
             .expect("create relationship");
 
         let fetched = rel_repo
-            .get_by_id(rel_id.to_string())
+            .get_by_id(&rel_id.to_string())
             .await
             .expect("fetch relationship")
             .expect("relationship exists");

--- a/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
@@ -84,8 +84,7 @@ impl Repository<Artist> for SqliteArtistRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<Artist>> {
-        let id = id.into();
+    async fn get_by_id(&self, id: String) -> Result<Option<Artist>> {
         debug!(target: "repository", %id, "fetching artist by id");
         let row = self
             .profiler
@@ -165,8 +164,7 @@ impl Repository<Artist> for SqliteArtistRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id = id.into();
+    async fn delete(&self, id: String) -> Result<()> {
         debug!(target: "repository", %id, "deleting artist");
         let result = sqlx::query("DELETE FROM artists WHERE id = ?")
             .bind(&id)
@@ -519,8 +517,7 @@ impl Repository<Album> for SqliteAlbumRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<Album>> {
-        let id = id.into();
+    async fn get_by_id(&self, id: String) -> Result<Option<Album>> {
         debug!(target: "repository", %id, "fetching album by id");
         let row = self
             .profiler
@@ -604,8 +601,7 @@ impl Repository<Album> for SqliteAlbumRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id = id.into();
+    async fn delete(&self, id: String) -> Result<()> {
         debug!(target: "repository", %id, "deleting album");
         let result = sqlx::query("DELETE FROM albums WHERE id = ?")
             .bind(&id)
@@ -937,8 +933,7 @@ impl Repository<Track> for SqliteTrackRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<Track>> {
-        let id = id.into();
+    async fn get_by_id(&self, id: String) -> Result<Option<Track>> {
         debug!(target: "repository", %id, "fetching track by id");
         let row = self
             .profiler
@@ -1006,8 +1001,7 @@ impl Repository<Track> for SqliteTrackRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id = id.into();
+    async fn delete(&self, id: String) -> Result<()> {
         debug!(target: "repository", %id, "deleting track");
         let result = sqlx::query("DELETE FROM tracks WHERE id = ?")
             .bind(&id)
@@ -1283,8 +1277,7 @@ impl Repository<QualityProfile> for SqliteQualityProfileRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<QualityProfile>> {
-        let id = id.into();
+    async fn get_by_id(&self, id: String) -> Result<Option<QualityProfile>> {
         debug!(target: "repository", %id, "fetching quality profile by id");
         let row = sqlx::query("SELECT * FROM quality_profiles WHERE id = ? LIMIT 1")
             .bind(&id)
@@ -1338,8 +1331,7 @@ impl Repository<QualityProfile> for SqliteQualityProfileRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id = id.into();
+    async fn delete(&self, id: String) -> Result<()> {
         debug!(target: "repository", %id, "deleting quality profile");
         let result = sqlx::query("DELETE FROM quality_profiles WHERE id = ?")
             .bind(&id)
@@ -1412,8 +1404,7 @@ impl Repository<MetadataProfile> for SqliteMetadataProfileRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<MetadataProfile>> {
-        let id = id.into();
+    async fn get_by_id(&self, id: String) -> Result<Option<MetadataProfile>> {
         debug!(target: "repository", %id, "fetching metadata profile by id");
         let row = sqlx::query("SELECT * FROM metadata_profiles WHERE id = ? LIMIT 1")
             .bind(&id)
@@ -1469,8 +1460,7 @@ impl Repository<MetadataProfile> for SqliteMetadataProfileRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id = id.into();
+    async fn delete(&self, id: String) -> Result<()> {
         debug!(target: "repository", %id, "deleting metadata profile");
         let result = sqlx::query("DELETE FROM metadata_profiles WHERE id = ?")
             .bind(&id)
@@ -1540,8 +1530,7 @@ impl Repository<IndexerDefinition> for SqliteIndexerDefinitionRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<IndexerDefinition>> {
-        let id = id.into();
+    async fn get_by_id(&self, id: String) -> Result<Option<IndexerDefinition>> {
         debug!(target: "repository", %id, "fetching indexer definition by id");
         let row = sqlx::query("SELECT * FROM indexer_definitions WHERE id = ? LIMIT 1")
             .bind(&id)
@@ -1596,8 +1585,7 @@ impl Repository<IndexerDefinition> for SqliteIndexerDefinitionRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id = id.into();
+    async fn delete(&self, id: String) -> Result<()> {
         debug!(target: "repository", %id, "deleting indexer definition");
         let result = sqlx::query("DELETE FROM indexer_definitions WHERE id = ?")
             .bind(&id)
@@ -1669,11 +1657,7 @@ impl Repository<DownloadClientDefinition> for SqliteDownloadClientDefinitionRepo
         Ok(entity)
     }
 
-    async fn get_by_id(
-        &self,
-        id: impl Into<String> + Send,
-    ) -> Result<Option<DownloadClientDefinition>> {
-        let id = id.into();
+    async fn get_by_id(&self, id: String) -> Result<Option<DownloadClientDefinition>> {
         debug!(target: "repository", %id, "fetching download client definition by id");
         let row = sqlx::query("SELECT * FROM download_client_definitions WHERE id = ? LIMIT 1")
             .bind(&id)
@@ -1733,8 +1717,7 @@ impl Repository<DownloadClientDefinition> for SqliteDownloadClientDefinitionRepo
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id = id.into();
+    async fn delete(&self, id: String) -> Result<()> {
         debug!(target: "repository", %id, "deleting download client definition");
         let result = sqlx::query("DELETE FROM download_client_definitions WHERE id = ?")
             .bind(&id)
@@ -1883,17 +1866,13 @@ impl Repository<TrackFile> for SqliteTrackFileRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<TrackFile>> {
-        let id_str = id.into();
-        debug!(target: "repository", track_file_id = %id_str, "fetching track file by id");
+    async fn get_by_id(&self, id: String) -> Result<Option<TrackFile>> {
+        debug!(target: "repository", track_file_id = %id, "fetching track file by id");
         let row = self
             .profiler
             .timed("track_files::get_by_id", || async {
                 let q = "SELECT * FROM track_files WHERE id = ?";
-                sqlx::query(q)
-                    .bind(&id_str)
-                    .fetch_optional(&self.pool)
-                    .await
+                sqlx::query(q).bind(id).fetch_optional(&self.pool).await
             })
             .await?;
         match row {
@@ -1962,14 +1941,13 @@ impl Repository<TrackFile> for SqliteTrackFileRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id_str = id.into();
-        debug!(target: "repository", track_file_id = %id_str, "deleting track file");
+    async fn delete(&self, id: String) -> Result<()> {
+        debug!(target: "repository", track_file_id = %id, "deleting track file");
 
         let q = "DELETE FROM track_files WHERE id = ?";
-        sqlx::query(q).bind(&id_str).execute(&self.pool).await?;
+        sqlx::query(q).bind(&id).execute(&self.pool).await?;
 
-        debug!(target: "repository", track_file_id = %id_str, "track file deleted successfully");
+        debug!(target: "repository", track_file_id = %id, "track file deleted successfully");
         Ok(())
     }
 }
@@ -2090,8 +2068,7 @@ impl Repository<ArtistRelationship> for SqliteArtistRelationshipRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: impl Into<String> + Send) -> Result<Option<ArtistRelationship>> {
-        let id = id.into();
+    async fn get_by_id(&self, id: String) -> Result<Option<ArtistRelationship>> {
         debug!(target: "repository", %id, "fetching artist relationship by id");
 
         let row = sqlx::query("SELECT * FROM artist_relationships WHERE id = ? LIMIT 1")
@@ -2151,8 +2128,7 @@ impl Repository<ArtistRelationship> for SqliteArtistRelationshipRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: impl Into<String> + Send) -> Result<()> {
-        let id = id.into();
+    async fn delete(&self, id: String) -> Result<()> {
         debug!(target: "repository", %id, "deleting artist relationship");
 
         sqlx::query("DELETE FROM artist_relationships WHERE id = ?")

--- a/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
@@ -84,13 +84,13 @@ impl Repository<Artist> for SqliteArtistRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<Artist>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<Artist>> {
         debug!(target: "repository", %id, "fetching artist by id");
         let row = self
             .profiler
             .timed("artists::get_by_id", || async {
                 sqlx::query("SELECT * FROM artists WHERE id = ? LIMIT 1")
-                    .bind(&id)
+                    .bind(id)
                     .fetch_optional(&self.pool)
                     .await
             })
@@ -164,10 +164,10 @@ impl Repository<Artist> for SqliteArtistRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", %id, "deleting artist");
         let result = sqlx::query("DELETE FROM artists WHERE id = ?")
-            .bind(&id)
+            .bind(id)
             .execute(&self.pool)
             .await?;
         if result.rows_affected() == 0 {
@@ -517,13 +517,13 @@ impl Repository<Album> for SqliteAlbumRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<Album>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<Album>> {
         debug!(target: "repository", %id, "fetching album by id");
         let row = self
             .profiler
             .timed("albums::get_by_id", || async {
                 sqlx::query("SELECT * FROM albums WHERE id = ? LIMIT 1")
-                    .bind(&id)
+                    .bind(id)
                     .fetch_optional(&self.pool)
                     .await
             })
@@ -601,10 +601,10 @@ impl Repository<Album> for SqliteAlbumRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", %id, "deleting album");
         let result = sqlx::query("DELETE FROM albums WHERE id = ?")
-            .bind(&id)
+            .bind(id)
             .execute(&self.pool)
             .await?;
         if result.rows_affected() == 0 {
@@ -933,13 +933,13 @@ impl Repository<Track> for SqliteTrackRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<Track>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<Track>> {
         debug!(target: "repository", %id, "fetching track by id");
         let row = self
             .profiler
             .timed("tracks::get_by_id", || async {
                 sqlx::query("SELECT * FROM tracks WHERE id = ? LIMIT 1")
-                    .bind(&id)
+                    .bind(id)
                     .fetch_optional(&self.pool)
                     .await
             })
@@ -1001,10 +1001,10 @@ impl Repository<Track> for SqliteTrackRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", %id, "deleting track");
         let result = sqlx::query("DELETE FROM tracks WHERE id = ?")
-            .bind(&id)
+            .bind(id)
             .execute(&self.pool)
             .await?;
         if result.rows_affected() == 0 {
@@ -1277,10 +1277,10 @@ impl Repository<QualityProfile> for SqliteQualityProfileRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<QualityProfile>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<QualityProfile>> {
         debug!(target: "repository", %id, "fetching quality profile by id");
         let row = sqlx::query("SELECT * FROM quality_profiles WHERE id = ? LIMIT 1")
-            .bind(&id)
+            .bind(id)
             .fetch_optional(&self.pool)
             .await?;
         if let Some(r) = row {
@@ -1331,10 +1331,10 @@ impl Repository<QualityProfile> for SqliteQualityProfileRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", %id, "deleting quality profile");
         let result = sqlx::query("DELETE FROM quality_profiles WHERE id = ?")
-            .bind(&id)
+            .bind(id)
             .execute(&self.pool)
             .await?;
         if result.rows_affected() == 0 {
@@ -1404,10 +1404,10 @@ impl Repository<MetadataProfile> for SqliteMetadataProfileRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<MetadataProfile>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<MetadataProfile>> {
         debug!(target: "repository", %id, "fetching metadata profile by id");
         let row = sqlx::query("SELECT * FROM metadata_profiles WHERE id = ? LIMIT 1")
-            .bind(&id)
+            .bind(id)
             .fetch_optional(&self.pool)
             .await?;
         if let Some(r) = row {
@@ -1460,10 +1460,10 @@ impl Repository<MetadataProfile> for SqliteMetadataProfileRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", %id, "deleting metadata profile");
         let result = sqlx::query("DELETE FROM metadata_profiles WHERE id = ?")
-            .bind(&id)
+            .bind(id)
             .execute(&self.pool)
             .await?;
         if result.rows_affected() == 0 {
@@ -1530,10 +1530,10 @@ impl Repository<IndexerDefinition> for SqliteIndexerDefinitionRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<IndexerDefinition>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<IndexerDefinition>> {
         debug!(target: "repository", %id, "fetching indexer definition by id");
         let row = sqlx::query("SELECT * FROM indexer_definitions WHERE id = ? LIMIT 1")
-            .bind(&id)
+            .bind(id)
             .fetch_optional(&self.pool)
             .await?;
         if let Some(r) = row {
@@ -1585,10 +1585,10 @@ impl Repository<IndexerDefinition> for SqliteIndexerDefinitionRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", %id, "deleting indexer definition");
         let result = sqlx::query("DELETE FROM indexer_definitions WHERE id = ?")
-            .bind(&id)
+            .bind(id)
             .execute(&self.pool)
             .await?;
         if result.rows_affected() == 0 {
@@ -1657,10 +1657,10 @@ impl Repository<DownloadClientDefinition> for SqliteDownloadClientDefinitionRepo
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<DownloadClientDefinition>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<DownloadClientDefinition>> {
         debug!(target: "repository", %id, "fetching download client definition by id");
         let row = sqlx::query("SELECT * FROM download_client_definitions WHERE id = ? LIMIT 1")
-            .bind(&id)
+            .bind(id)
             .fetch_optional(&self.pool)
             .await?;
         if let Some(r) = row {
@@ -1717,10 +1717,10 @@ impl Repository<DownloadClientDefinition> for SqliteDownloadClientDefinitionRepo
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", %id, "deleting download client definition");
         let result = sqlx::query("DELETE FROM download_client_definitions WHERE id = ?")
-            .bind(&id)
+            .bind(id)
             .execute(&self.pool)
             .await?;
         if result.rows_affected() == 0 {
@@ -1866,7 +1866,7 @@ impl Repository<TrackFile> for SqliteTrackFileRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<TrackFile>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<TrackFile>> {
         debug!(target: "repository", track_file_id = %id, "fetching track file by id");
         let row = self
             .profiler
@@ -1941,11 +1941,11 @@ impl Repository<TrackFile> for SqliteTrackFileRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", track_file_id = %id, "deleting track file");
 
         let q = "DELETE FROM track_files WHERE id = ?";
-        sqlx::query(q).bind(&id).execute(&self.pool).await?;
+        sqlx::query(q).bind(id).execute(&self.pool).await?;
 
         debug!(target: "repository", track_file_id = %id, "track file deleted successfully");
         Ok(())
@@ -2068,7 +2068,7 @@ impl Repository<ArtistRelationship> for SqliteArtistRelationshipRepository {
         Ok(entity)
     }
 
-    async fn get_by_id(&self, id: String) -> Result<Option<ArtistRelationship>> {
+    async fn get_by_id(&self, id: &str) -> Result<Option<ArtistRelationship>> {
         debug!(target: "repository", %id, "fetching artist relationship by id");
 
         let row = sqlx::query("SELECT * FROM artist_relationships WHERE id = ? LIMIT 1")
@@ -2128,7 +2128,7 @@ impl Repository<ArtistRelationship> for SqliteArtistRelationshipRepository {
         Ok(entity)
     }
 
-    async fn delete(&self, id: String) -> Result<()> {
+    async fn delete(&self, id: &str) -> Result<()> {
         debug!(target: "repository", %id, "deleting artist relationship");
 
         sqlx::query("DELETE FROM artist_relationships WHERE id = ?")


### PR DESCRIPTION
## Summary
- refactor AppState repository dependencies to trait objects instead of concrete SQLite adapter types
- make base Repository<T> object-safe by switching get_by_id and delete to String IDs
- update SQLite repository adapter implementations to match the new trait signatures
- remove now-unused API trait imports caused by the trait-object transition

## Validation
- cargo check -p chorrosion-api -p chorrosion-cli
- cargo test -p chorrosion-api
- cargo clippy -p chorrosion-application -p chorrosion-infrastructure -p chorrosion-api -- -D warnings

Closes #381
