### PR TITLE
Add PostgreSQL artist repository adapter and gated tests

### DIFF
--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -9,6 +9,7 @@ use chorrosion_infrastructure::{
     ResponseCache,
 };
 use moka::sync::Cache;
+use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -220,7 +221,7 @@ impl ActivityHistoryStore {
     pub fn snapshot(&self) -> Vec<CachedActivityItem> {
         let records = self.inner.lock().expect("activity history store lock");
         let mut sorted: Vec<_> = records.values().cloned().collect();
-        sorted.sort_by(|a, b| b.last_seen.cmp(&a.last_seen));
+        sorted.sort_by_key(|record| Reverse(record.last_seen));
         sorted.into_iter().map(|record| record.item).collect()
     }
 }

--- a/crates/chorrosion-infrastructure/src/lib.rs
+++ b/crates/chorrosion-infrastructure/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pub mod backup_restore;
 pub mod cache;
+pub mod postgres_adapters;
 pub mod profiler;
 pub mod repositories;
 pub mod sqlite_adapters;

--- a/crates/chorrosion-infrastructure/src/lib.rs
+++ b/crates/chorrosion-infrastructure/src/lib.rs
@@ -15,7 +15,11 @@ pub use transaction::run_in_transaction;
 use anyhow::Result;
 use chorrosion_config::AppConfig;
 use reqwest::Client;
+#[cfg(feature = "postgres")]
+use sqlx::postgres::PgPoolOptions;
 use sqlx::sqlite::SqlitePoolOptions;
+#[cfg(feature = "postgres")]
+use sqlx::PgPool;
 use sqlx::SqlitePool;
 use std::path::Path;
 use tracing::info;
@@ -87,6 +91,31 @@ pub async fn init_database(config: &AppConfig) -> Result<SqlitePool> {
     sqlx::migrate!("../../migrations").run(&pool).await?;
 
     info!(target: "infrastructure", "database initialized successfully");
+    Ok(pool)
+}
+
+#[cfg(feature = "postgres")]
+pub async fn create_postgres_pool(config: &AppConfig) -> Result<PgPool> {
+    info!(target: "infrastructure", db_url = %config.database.url, "connecting to postgres database");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(config.database.pool_max_size)
+        .connect(&config.database.url)
+        .await?;
+
+    Ok(pool)
+}
+
+#[cfg(feature = "postgres")]
+pub async fn init_postgres_database(config: &AppConfig) -> Result<PgPool> {
+    info!(target: "infrastructure", "initializing postgres database");
+
+    let pool = create_postgres_pool(config).await?;
+
+    info!(target: "infrastructure", db_url = %config.database.url, "running migrations");
+    sqlx::migrate!("../../migrations").run(&pool).await?;
+
+    info!(target: "infrastructure", "postgres database initialized successfully");
     Ok(pool)
 }
 

--- a/crates/chorrosion-infrastructure/src/lib.rs
+++ b/crates/chorrosion-infrastructure/src/lib.rs
@@ -96,7 +96,8 @@ pub async fn init_database(config: &AppConfig) -> Result<SqlitePool> {
 
 #[cfg(feature = "postgres")]
 pub async fn create_postgres_pool(config: &AppConfig) -> Result<PgPool> {
-    info!(target: "infrastructure", db_url = %config.database.url, "connecting to postgres database");
+    let redacted_db_url = redact_postgres_url(&config.database.url);
+    info!(target: "infrastructure", db_url = %redacted_db_url, "connecting to postgres database");
 
     let pool = PgPoolOptions::new()
         .max_connections(config.database.pool_max_size)
@@ -112,11 +113,47 @@ pub async fn init_postgres_database(config: &AppConfig) -> Result<PgPool> {
 
     let pool = create_postgres_pool(config).await?;
 
-    info!(target: "infrastructure", db_url = %config.database.url, "running migrations");
-    sqlx::migrate!("../../migrations").run(&pool).await?;
+    let redacted_db_url = redact_postgres_url(&config.database.url);
+    info!(target: "infrastructure", db_url = %redacted_db_url, "running postgres migrations");
+    run_postgres_migrations(&pool).await?;
 
     info!(target: "infrastructure", "postgres database initialized successfully");
     Ok(pool)
+}
+
+#[cfg(feature = "postgres")]
+fn redact_postgres_url(db_url: &str) -> String {
+    let trimmed = db_url
+        .strip_prefix("postgres://")
+        .or_else(|| db_url.strip_prefix("postgresql://"));
+
+    if let Some(rest) = trimmed {
+        let without_credentials = rest.rsplit('@').next().unwrap_or(rest);
+        let without_query = without_credentials
+            .split('?')
+            .next()
+            .unwrap_or(without_credentials);
+        format!("postgres://{}", without_query)
+    } else {
+        "postgres://<redacted>".to_string()
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn run_postgres_migrations(pool: &PgPool) -> Result<()> {
+    let migrations_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../migrations/postgres");
+
+    if !migrations_path.exists() {
+        return Err(anyhow::anyhow!(
+            "postgres migrations directory not found at {}; use a Postgres-specific migration set instead of the shared SQLite migrations",
+            migrations_path.display()
+        ));
+    }
+
+    let migrator = sqlx::migrate::Migrator::new(migrations_path).await?;
+    migrator.run(pool).await?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/chorrosion-infrastructure/src/lib.rs
+++ b/crates/chorrosion-infrastructure/src/lib.rs
@@ -16,12 +16,16 @@ use anyhow::Result;
 use chorrosion_config::AppConfig;
 use reqwest::Client;
 #[cfg(feature = "postgres")]
+use sqlx::postgres::PgConnectOptions;
+#[cfg(feature = "postgres")]
 use sqlx::postgres::PgPoolOptions;
 use sqlx::sqlite::SqlitePoolOptions;
 #[cfg(feature = "postgres")]
 use sqlx::PgPool;
 use sqlx::SqlitePool;
 use std::path::Path;
+#[cfg(feature = "postgres")]
+use std::str::FromStr;
 use tracing::info;
 
 pub fn http_client() -> Client {
@@ -123,19 +127,17 @@ pub async fn init_postgres_database(config: &AppConfig) -> Result<PgPool> {
 
 #[cfg(feature = "postgres")]
 fn redact_postgres_url(db_url: &str) -> String {
-    let trimmed = db_url
-        .strip_prefix("postgres://")
-        .or_else(|| db_url.strip_prefix("postgresql://"));
-
-    if let Some(rest) = trimmed {
-        let without_credentials = rest.rsplit('@').next().unwrap_or(rest);
-        let without_query = without_credentials
-            .split('?')
-            .next()
-            .unwrap_or(without_credentials);
-        format!("postgres://{}", without_query)
-    } else {
-        "postgres://<redacted>".to_string()
+    match PgConnectOptions::from_str(db_url) {
+        Ok(options) => {
+            let db_name = options.get_database().unwrap_or("<none>");
+            format!(
+                "postgres://{}:{}/{}",
+                options.get_host(),
+                options.get_port(),
+                db_name
+            )
+        }
+        Err(_) => "postgres://<redacted>".to_string(),
     }
 }
 

--- a/crates/chorrosion-infrastructure/src/postgres_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/postgres_adapters.rs
@@ -1,0 +1,655 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#![cfg(feature = "postgres")]
+
+use anyhow::{anyhow, Result};
+use chorrosion_domain::{
+    Album, AlbumId, AlbumStatus, Artist, ArtistId, ArtistRelationship, ArtistRelationshipId,
+    ArtistStatus, DownloadClientDefinition, DownloadClientDefinitionId, IndexerDefinition,
+    IndexerDefinitionId, MetadataProfile, ProfileId, QualityProfile, Track, TrackFile, TrackFileId,
+    TrackId,
+};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use sqlx::postgres::PgPool;
+use sqlx::Row;
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::profiler::QueryProfiler;
+use crate::repositories::{
+    AlbumRepository, ArtistRelationshipRepository, ArtistRepository,
+    DownloadClientDefinitionRepository, IndexerDefinitionRepository, MetadataProfileRepository,
+    QualityProfileRepository, Repository, TrackFileRepository, TrackRepository,
+};
+
+/// PostgreSQL-backed Artist repository
+#[allow(dead_code)]
+pub struct PostgresArtistRepository {
+    pool: PgPool,
+    profiler: QueryProfiler,
+}
+
+impl PostgresArtistRepository {
+    pub fn new(pool: PgPool) -> Self {
+        let profiler = QueryProfiler::new(pool.clone(), 0);
+        Self { pool, profiler }
+    }
+
+    pub fn new_with_threshold(pool: PgPool, threshold_ms: u64) -> Self {
+        let profiler = QueryProfiler::new(pool.clone(), threshold_ms);
+        Self { pool, profiler }
+    }
+}
+
+#[async_trait::async_trait]
+impl Repository<Artist> for PostgresArtistRepository {
+    async fn create(&self, entity: Artist) -> Result<Artist> {
+        debug!(target: "repository", artist_id = %entity.id, "creating artist");
+        let q = r#"
+            INSERT INTO artists (
+                id, name, foreign_artist_id, musicbrainz_artist_id, metadata_profile_id, quality_profile_id,
+                status, path, monitored, artist_type, sort_name, country, disambiguation, genre_tags, style_tags, created_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+        "#;
+
+        let id_str = entity.id.to_string();
+        let foreign_id = entity.foreign_artist_id.clone();
+        let musicbrainz_id = entity.musicbrainz_artist_id.clone();
+        let metadata_id = entity.metadata_profile_id.map(|p| p.to_string());
+        let quality_id = entity.quality_profile_id.map(|p| p.to_string());
+        let status = entity.status.to_string();
+        let path = entity.path.clone();
+        let monitored = entity.monitored;
+        let created_at = entity.created_at;
+        let updated_at = entity.updated_at;
+
+        sqlx::query(q)
+            .bind(&id_str)
+            .bind(&entity.name)
+            .bind(&foreign_id)
+            .bind(&musicbrainz_id)
+            .bind(&metadata_id)
+            .bind(&quality_id)
+            .bind(&status)
+            .bind(&path)
+            .bind(monitored)
+            .bind(&entity.artist_type)
+            .bind(&entity.sort_name)
+            .bind(&entity.country)
+            .bind(&entity.disambiguation)
+            .bind(&entity.genre_tags)
+            .bind(&entity.style_tags)
+            .bind(created_at)
+            .bind(updated_at)
+            .execute(&self.pool)
+            .await?;
+        Ok(entity)
+    }
+
+    async fn get_by_id(&self, id: &str) -> Result<Option<Artist>> {
+        debug!(target: "repository", %id, "fetching artist by id");
+        let row = self
+            .profiler
+            .timed("artists::get_by_id", || async {
+                sqlx::query("SELECT * FROM artists WHERE id = $1 LIMIT 1")
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await
+            })
+            .await?;
+        if let Some(r) = row {
+            Ok(Some(row_to_artist(&r)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn list(&self, limit: i64, offset: i64) -> Result<Vec<Artist>> {
+        debug!(target: "repository", limit, offset, "listing artists");
+        let rows = self
+            .profiler
+            .timed("artists::list", || async {
+                sqlx::query("SELECT * FROM artists ORDER BY name LIMIT $1 OFFSET $2")
+                    .bind(limit)
+                    .bind(offset)
+                    .fetch_all(&self.pool)
+                    .await
+            })
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_artist(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn update(&self, entity: Artist) -> Result<Artist> {
+        debug!(target: "repository", artist_id = %entity.id, "updating artist");
+        let q = r#"
+            UPDATE artists SET
+                name = $1,
+                foreign_artist_id = $2,
+                musicbrainz_artist_id = $3,
+                metadata_profile_id = $4,
+                quality_profile_id = $5,
+                status = $6,
+                path = $7,
+                monitored = $8,
+                artist_type = $9,
+                sort_name = $10,
+                country = $11,
+                disambiguation = $12,
+                genre_tags = $13,
+                style_tags = $14,
+                updated_at = $15
+            WHERE id = $16
+        "#;
+        sqlx::query(q)
+            .bind(&entity.name)
+            .bind(&entity.foreign_artist_id)
+            .bind(&entity.musicbrainz_artist_id)
+            .bind(entity.metadata_profile_id.map(|p| p.to_string()))
+            .bind(entity.quality_profile_id.map(|p| p.to_string()))
+            .bind(entity.status.to_string())
+            .bind(&entity.path)
+            .bind(entity.monitored)
+            .bind(&entity.artist_type)
+            .bind(&entity.sort_name)
+            .bind(&entity.country)
+            .bind(&entity.disambiguation)
+            .bind(&entity.genre_tags)
+            .bind(&entity.style_tags)
+            .bind(entity.updated_at)
+            .bind(entity.id.to_string())
+            .execute(&self.pool)
+            .await?;
+        Ok(entity)
+    }
+
+    async fn delete(&self, id: &str) -> Result<()> {
+        debug!(target: "repository", %id, "deleting artist");
+        let result = sqlx::query("DELETE FROM artists WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        if result.rows_affected() == 0 {
+            Err(anyhow!("artist {} not found", id))
+        } else {
+            debug!(target: "repository", %id, "artist deleted successfully");
+            Ok(())
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ArtistRepository for PostgresArtistRepository {
+    async fn get_by_name(&self, name: &str) -> Result<Option<Artist>> {
+        debug!(target: "repository", name, "fetching artist by name");
+        let row = sqlx::query("SELECT * FROM artists WHERE name = $1 LIMIT 1")
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?;
+        if let Some(r) = row {
+            Ok(Some(row_to_artist(&r)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn get_by_foreign_id(&self, foreign_id: &str) -> Result<Option<Artist>> {
+        debug!(target: "repository", foreign_id, "fetching artist by foreign id");
+        let row = sqlx::query("SELECT * FROM artists WHERE foreign_artist_id = $1 LIMIT 1")
+            .bind(foreign_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        match row {
+            Some(r) => Ok(Some(row_to_artist(&r)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_monitored(&self, limit: i64, offset: i64) -> Result<Vec<Artist>> {
+        debug!(target: "repository", limit, offset, "listing monitored artists");
+        let rows = sqlx::query(
+            "SELECT * FROM artists WHERE monitored = true ORDER BY name LIMIT $1 OFFSET $2",
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_artist(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn get_by_status(
+        &self,
+        status: ArtistStatus,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Artist>> {
+        debug!(target: "repository", status = ?status, "fetching artists by status");
+        let status_str = status.to_string();
+        let rows =
+            sqlx::query("SELECT * FROM artists WHERE status = $1 ORDER BY name LIMIT $2 OFFSET $3")
+                .bind(&status_str)
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(&self.pool)
+                .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_artist(&r)?);
+        }
+        Ok(out)
+    }
+}
+
+// ============================================================================
+// Album Repository
+// ============================================================================
+
+#[allow(dead_code)]
+pub struct PostgresAlbumRepository {
+    pool: PgPool,
+    profiler: QueryProfiler,
+}
+
+impl PostgresAlbumRepository {
+    pub fn new(pool: PgPool) -> Self {
+        let profiler = QueryProfiler::new(pool.clone(), 0);
+        Self { pool, profiler }
+    }
+
+    pub fn new_with_threshold(pool: PgPool, threshold_ms: u64) -> Self {
+        let profiler = QueryProfiler::new(pool.clone(), threshold_ms);
+        Self { pool, profiler }
+    }
+}
+
+#[async_trait::async_trait]
+impl Repository<Album> for PostgresAlbumRepository {
+    async fn create(&self, entity: Album) -> Result<Album> {
+        debug!(target: "repository", album_id = %entity.id, "creating album");
+        let q = r#"
+            INSERT INTO albums (
+                id, artist_id, title, album_type, musicbrainz_release_group_id,
+                musicbrainz_release_id, foreign_album_id, release_date, disambiguation,
+                status, monitored, quality_profile_id, metadata_profile_id, path,
+                genre_tags, style_tags, created_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+        "#;
+
+        let id_str = entity.id.to_string();
+        let artist_id_str = entity.artist_id.to_string();
+        let quality_id = entity.quality_profile_id.map(|p| p.to_string());
+        let metadata_id = entity.metadata_profile_id.map(|p| p.to_string());
+        let status = entity.status.to_string();
+
+        sqlx::query(q)
+            .bind(&id_str)
+            .bind(&artist_id_str)
+            .bind(&entity.title)
+            .bind(&entity.album_type)
+            .bind(&entity.musicbrainz_release_group_id)
+            .bind(&entity.musicbrainz_release_id)
+            .bind(&entity.foreign_album_id)
+            .bind(entity.release_date)
+            .bind(&entity.disambiguation)
+            .bind(&status)
+            .bind(entity.monitored)
+            .bind(&quality_id)
+            .bind(&metadata_id)
+            .bind(&entity.path)
+            .bind(&entity.genre_tags)
+            .bind(&entity.style_tags)
+            .bind(entity.created_at)
+            .bind(entity.updated_at)
+            .execute(&self.pool)
+            .await?;
+        Ok(entity)
+    }
+
+    async fn get_by_id(&self, id: &str) -> Result<Option<Album>> {
+        debug!(target: "repository", %id, "fetching album by id");
+        let row = self
+            .profiler
+            .timed("albums::get_by_id", || async {
+                sqlx::query("SELECT * FROM albums WHERE id = $1 LIMIT 1")
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await
+            })
+            .await?;
+        if let Some(r) = row {
+            Ok(Some(row_to_album(&r)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn list(&self, limit: i64, offset: i64) -> Result<Vec<Album>> {
+        debug!(target: "repository", limit, offset, "listing albums");
+        let rows = self
+            .profiler
+            .timed("albums::list", || async {
+                sqlx::query("SELECT * FROM albums ORDER BY title LIMIT $1 OFFSET $2")
+                    .bind(limit)
+                    .bind(offset)
+                    .fetch_all(&self.pool)
+                    .await
+            })
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_album(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn update(&self, entity: Album) -> Result<Album> {
+        debug!(target: "repository", album_id = %entity.id, "updating album");
+        let q = r#"
+            UPDATE albums SET
+                artist_id = $1,
+                title = $2,
+                album_type = $3,
+                musicbrainz_release_group_id = $4,
+                musicbrainz_release_id = $5,
+                foreign_album_id = $6,
+                release_date = $7,
+                disambiguation = $8,
+                status = $9,
+                monitored = $10,
+                quality_profile_id = $11,
+                metadata_profile_id = $12,
+                path = $13,
+                genre_tags = $14,
+                style_tags = $15,
+                updated_at = $16
+            WHERE id = $17
+        "#;
+        sqlx::query(q)
+            .bind(entity.artist_id.to_string())
+            .bind(&entity.title)
+            .bind(&entity.album_type)
+            .bind(&entity.musicbrainz_release_group_id)
+            .bind(&entity.musicbrainz_release_id)
+            .bind(&entity.foreign_album_id)
+            .bind(entity.release_date)
+            .bind(&entity.disambiguation)
+            .bind(entity.status.to_string())
+            .bind(entity.monitored)
+            .bind(entity.quality_profile_id.map(|p| p.to_string()))
+            .bind(entity.metadata_profile_id.map(|p| p.to_string()))
+            .bind(&entity.path)
+            .bind(&entity.genre_tags)
+            .bind(&entity.style_tags)
+            .bind(entity.updated_at)
+            .bind(entity.id.to_string())
+            .execute(&self.pool)
+            .await?;
+        Ok(entity)
+    }
+
+    async fn delete(&self, id: &str) -> Result<()> {
+        debug!(target: "repository", %id, "deleting album");
+        let result = sqlx::query("DELETE FROM albums WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        if result.rows_affected() == 0 {
+            Err(anyhow!("album {} not found", id))
+        } else {
+            debug!(target: "repository", %id, "album deleted successfully");
+            Ok(())
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AlbumRepository for PostgresAlbumRepository {
+    async fn get_by_artist(
+        &self,
+        artist_id: ArtistId,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Album>> {
+        debug!(target: "repository", artist_id = %artist_id, "fetching albums by artist");
+        let artist_id_str = artist_id.to_string();
+        let rows = sqlx::query("SELECT * FROM albums WHERE artist_id = $1 ORDER BY release_date DESC, title LIMIT $2 OFFSET $3")
+            .bind(&artist_id_str)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_album(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn get_by_foreign_id(&self, foreign_id: &str) -> Result<Option<Album>> {
+        debug!(target: "repository", foreign_id, "fetching album by foreign id");
+        let row = sqlx::query("SELECT * FROM albums WHERE foreign_album_id = $1 LIMIT 1")
+            .bind(foreign_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        match row {
+            Some(r) => Ok(Some(row_to_album(&r)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn get_by_artist_and_title(
+        &self,
+        artist_id: ArtistId,
+        title: &str,
+    ) -> Result<Option<Album>> {
+        debug!(target: "repository", artist_id = %artist_id, title, "fetching album by artist and title");
+        let artist_id_str = artist_id.to_string();
+        let row = sqlx::query(
+            "SELECT * FROM albums WHERE artist_id = $1 AND LOWER(title) = LOWER($2) LIMIT 1",
+        )
+        .bind(&artist_id_str)
+        .bind(title)
+        .fetch_optional(&self.pool)
+        .await?;
+        match row {
+            Some(r) => Ok(Some(row_to_album(&r)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn get_by_status(
+        &self,
+        status: AlbumStatus,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Album>> {
+        debug!(target: "repository", status = ?status, "fetching albums by status");
+        let status_str = status.to_string();
+        let rows = sqlx::query(
+            "SELECT * FROM albums WHERE status = $1 ORDER BY release_date DESC LIMIT $2 OFFSET $3",
+        )
+        .bind(&status_str)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_album(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn list_monitored(&self, limit: i64, offset: i64) -> Result<Vec<Album>> {
+        debug!(target: "repository", limit, offset, "listing monitored albums");
+        let rows = sqlx::query("SELECT * FROM albums WHERE monitored = true ORDER BY release_date DESC LIMIT $1 OFFSET $2")
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_album(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn get_by_album_type(
+        &self,
+        album_type: &str,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Album>> {
+        debug!(target: "repository", album_type, "fetching albums by type");
+        let rows = sqlx::query("SELECT * FROM albums WHERE album_type = $1 ORDER BY release_date DESC LIMIT $2 OFFSET $3")
+            .bind(album_type)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_album(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn list_wanted_without_tracks(&self, limit: i64, offset: i64) -> Result<Vec<Album>> {
+        debug!(target: "repository", limit, offset, "fetching wanted albums without tracks");
+        let rows = sqlx::query(r#"
+            SELECT a.* FROM albums a
+            WHERE a.status = 'Wanted' AND NOT EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = a.id)
+            ORDER BY a.release_date DESC
+            LIMIT $1 OFFSET $2
+        "#)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_album(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn list_cutoff_unmet_albums(&self, limit: i64, offset: i64) -> Result<Vec<Album>> {
+        debug!(target: "repository", limit, offset, "fetching albums with cutoff unmet");
+        let rows = sqlx::query(r#"
+            SELECT a.* FROM albums a
+            WHERE a.monitored = true AND a.status = 'Wanted'
+            AND (SELECT COUNT(*) FROM tracks t WHERE t.album_id = a.id AND t.quality IS NOT NULL) > 0
+            AND (SELECT COUNT(*) FROM tracks t WHERE t.album_id = a.id AND t.quality IS NOT NULL)
+                < (SELECT array_length(allowed_qualities, 1) FROM quality_profiles qp WHERE qp.id = a.quality_profile_id)
+            ORDER BY a.release_date DESC
+            LIMIT $1 OFFSET $2
+        "#)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_album(&r)?);
+        }
+        Ok(out)
+    }
+
+    async fn list_upcoming_releases(
+        &self,
+        start: NaiveDate,
+        end: NaiveDate,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Album>> {
+        debug!(target: "repository", from = %start, to = %end, "fetching upcoming album releases");
+        let rows = sqlx::query("SELECT * FROM albums WHERE release_date >= $1 AND release_date <= $2 ORDER BY release_date LIMIT $3 OFFSET $4")
+            .bind(start)
+            .bind(end)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(row_to_album(&r)?);
+        }
+        Ok(out)
+    }
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+fn row_to_artist(row: &sqlx::postgres::PgRow) -> Result<Artist> {
+    let id: String = row.try_get("id")?;
+    let monitored: bool = row.try_get("monitored")?;
+    let created_at: DateTime<Utc> = row.try_get("created_at")?;
+    let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+
+    Ok(Artist {
+        id: ArtistId::from_uuid(Uuid::parse_str(&id)?),
+        name: row.try_get("name")?,
+        foreign_artist_id: row.try_get("foreign_artist_id")?,
+        musicbrainz_artist_id: row.try_get("musicbrainz_artist_id")?,
+        metadata_profile_id: row
+            .try_get::<Option<String>, _>("metadata_profile_id")?
+            .map(|id| ProfileId::from_uuid(Uuid::parse_str(&id).unwrap())),
+        quality_profile_id: row
+            .try_get::<Option<String>, _>("quality_profile_id")?
+            .map(|id| ProfileId::from_uuid(Uuid::parse_str(&id).unwrap())),
+        status: row.try_get::<String, _>("status")?.parse()?,
+        path: row.try_get("path")?,
+        monitored,
+        artist_type: row.try_get("artist_type")?,
+        sort_name: row.try_get("sort_name")?,
+        country: row.try_get("country")?,
+        disambiguation: row.try_get("disambiguation")?,
+        genre_tags: row.try_get("genre_tags")?,
+        style_tags: row.try_get("style_tags")?,
+        created_at,
+        updated_at,
+    })
+}
+
+fn row_to_album(row: &sqlx::postgres::PgRow) -> Result<Album> {
+    let id: String = row.try_get("id")?;
+    let artist_id: String = row.try_get("artist_id")?;
+    let monitored: bool = row.try_get("monitored")?;
+    let created_at: DateTime<Utc> = row.try_get("created_at")?;
+    let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+
+    Ok(Album {
+        id: AlbumId::from_uuid(Uuid::parse_str(&id)?),
+        artist_id: ArtistId::from_uuid(Uuid::parse_str(&artist_id)?),
+        title: row.try_get("title")?,
+        album_type: row.try_get("album_type")?,
+        musicbrainz_release_group_id: row.try_get("musicbrainz_release_group_id")?,
+        musicbrainz_release_id: row.try_get("musicbrainz_release_id")?,
+        foreign_album_id: row.try_get("foreign_album_id")?,
+        release_date: row.try_get("release_date")?,
+        disambiguation: row.try_get("disambiguation")?,
+        status: row.try_get::<String, _>("status")?.parse()?,
+        monitored,
+        quality_profile_id: row
+            .try_get::<Option<String>, _>("quality_profile_id")?
+            .map(|id| ProfileId::from_uuid(Uuid::parse_str(&id).unwrap())),
+        metadata_profile_id: row
+            .try_get::<Option<String>, _>("metadata_profile_id")?
+            .map(|id| ProfileId::from_uuid(Uuid::parse_str(&id).unwrap())),
+        path: row.try_get("path")?,
+        genre_tags: row.try_get("genre_tags")?,
+        style_tags: row.try_get("style_tags")?,
+        created_at,
+        updated_at,
+    })
+}

--- a/crates/chorrosion-infrastructure/src/postgres_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/postgres_adapters.rs
@@ -157,6 +157,7 @@ impl ArtistRepository for PostgresArtistRepository {
     async fn get_by_name(&self, name: &str) -> Result<Option<Artist>> {
         debug!(target: "repository", name, "fetching artist by name (postgres)");
 
+        // Escape '\' first so literal '%' and '_' remain literal under ILIKE ... ESCAPE '\'.
         let escaped_name = name
             .replace('\\', "\\\\")
             .replace('%', "\\%")

--- a/crates/chorrosion-infrastructure/src/postgres_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/postgres_adapters.rs
@@ -157,8 +157,13 @@ impl ArtistRepository for PostgresArtistRepository {
     async fn get_by_name(&self, name: &str) -> Result<Option<Artist>> {
         debug!(target: "repository", name, "fetching artist by name (postgres)");
 
-        let row = sqlx::query("SELECT * FROM artists WHERE LOWER(name) = LOWER($1) LIMIT 1")
-            .bind(name)
+        let escaped_name = name
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+
+        let row = sqlx::query("SELECT * FROM artists WHERE name ILIKE $1 ESCAPE '\\' LIMIT 1")
+            .bind(escaped_name)
             .fetch_optional(&self.pool)
             .await?;
 

--- a/crates/chorrosion-infrastructure/src/postgres_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/postgres_adapters.rs
@@ -2,48 +2,36 @@
 #![cfg(feature = "postgres")]
 
 use anyhow::{anyhow, Result};
-use chorrosion_domain::{
-    Album, AlbumId, AlbumStatus, Artist, ArtistId, ArtistRelationship, ArtistRelationshipId,
-    ArtistStatus, DownloadClientDefinition, DownloadClientDefinitionId, IndexerDefinition,
-    IndexerDefinitionId, MetadataProfile, ProfileId, QualityProfile, Track, TrackFile, TrackFileId,
-    TrackId,
-};
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
-use sqlx::postgres::PgPool;
+use chorrosion_domain::{Artist, ArtistId, ArtistStatus};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use sqlx::postgres::PgRow;
+use sqlx::PgPool;
 use sqlx::Row;
 use tracing::debug;
 use uuid::Uuid;
 
-use crate::profiler::QueryProfiler;
-use crate::repositories::{
-    AlbumRepository, ArtistRelationshipRepository, ArtistRepository,
-    DownloadClientDefinitionRepository, IndexerDefinitionRepository, MetadataProfileRepository,
-    QualityProfileRepository, Repository, TrackFileRepository, TrackRepository,
-};
+use crate::repositories::{ArtistRepository, Repository};
 
-/// PostgreSQL-backed Artist repository
-#[allow(dead_code)]
+/// PostgreSQL-backed Artist repository scaffold.
 pub struct PostgresArtistRepository {
     pool: PgPool,
-    profiler: QueryProfiler,
 }
 
 impl PostgresArtistRepository {
     pub fn new(pool: PgPool) -> Self {
-        let profiler = QueryProfiler::new(pool.clone(), 0);
-        Self { pool, profiler }
+        Self { pool }
     }
 
-    pub fn new_with_threshold(pool: PgPool, threshold_ms: u64) -> Self {
-        let profiler = QueryProfiler::new(pool.clone(), threshold_ms);
-        Self { pool, profiler }
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
     }
 }
 
 #[async_trait::async_trait]
 impl Repository<Artist> for PostgresArtistRepository {
     async fn create(&self, entity: Artist) -> Result<Artist> {
-        debug!(target: "repository", artist_id = %entity.id, "creating artist");
+        debug!(target: "repository", artist_id = %entity.id, "creating artist (postgres)");
+
         let q = r#"
             INSERT INTO artists (
                 id, name, foreign_artist_id, musicbrainz_artist_id, metadata_profile_id, quality_profile_id,
@@ -51,79 +39,60 @@ impl Repository<Artist> for PostgresArtistRepository {
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
         "#;
 
-        let id_str = entity.id.to_string();
-        let foreign_id = entity.foreign_artist_id.clone();
-        let musicbrainz_id = entity.musicbrainz_artist_id.clone();
-        let metadata_id = entity.metadata_profile_id.map(|p| p.to_string());
-        let quality_id = entity.quality_profile_id.map(|p| p.to_string());
-        let status = entity.status.to_string();
-        let path = entity.path.clone();
-        let monitored = entity.monitored;
-        let created_at = entity.created_at;
-        let updated_at = entity.updated_at;
-
         sqlx::query(q)
-            .bind(&id_str)
-            .bind(&entity.name)
-            .bind(&foreign_id)
-            .bind(&musicbrainz_id)
-            .bind(&metadata_id)
-            .bind(&quality_id)
-            .bind(&status)
-            .bind(&path)
-            .bind(monitored)
-            .bind(&entity.artist_type)
-            .bind(&entity.sort_name)
-            .bind(&entity.country)
-            .bind(&entity.disambiguation)
-            .bind(&entity.genre_tags)
-            .bind(&entity.style_tags)
-            .bind(created_at)
-            .bind(updated_at)
+            .bind(entity.id.to_string())
+            .bind(entity.name.clone())
+            .bind(entity.foreign_artist_id.clone())
+            .bind(entity.musicbrainz_artist_id.clone())
+            .bind(entity.metadata_profile_id.map(|p| p.to_string()))
+            .bind(entity.quality_profile_id.map(|p| p.to_string()))
+            .bind(entity.status.to_string())
+            .bind(entity.path.clone())
+            .bind(entity.monitored)
+            .bind(entity.artist_type.clone())
+            .bind(entity.sort_name.clone())
+            .bind(entity.country.clone())
+            .bind(entity.disambiguation.clone())
+            .bind(entity.genre_tags.clone())
+            .bind(entity.style_tags.clone())
+            .bind(entity.created_at.naive_utc())
+            .bind(entity.updated_at.naive_utc())
             .execute(&self.pool)
             .await?;
+
         Ok(entity)
     }
 
     async fn get_by_id(&self, id: &str) -> Result<Option<Artist>> {
-        debug!(target: "repository", %id, "fetching artist by id");
-        let row = self
-            .profiler
-            .timed("artists::get_by_id", || async {
-                sqlx::query("SELECT * FROM artists WHERE id = $1 LIMIT 1")
-                    .bind(id)
-                    .fetch_optional(&self.pool)
-                    .await
-            })
+        debug!(target: "repository", %id, "fetching artist by id (postgres)");
+
+        let row = sqlx::query("SELECT * FROM artists WHERE id = $1 LIMIT 1")
+            .bind(id)
+            .fetch_optional(&self.pool)
             .await?;
-        if let Some(r) = row {
-            Ok(Some(row_to_artist(&r)?))
-        } else {
-            Ok(None)
-        }
+
+        Ok(row.map(|r| row_to_artist(&r)).transpose()?)
     }
 
     async fn list(&self, limit: i64, offset: i64) -> Result<Vec<Artist>> {
-        debug!(target: "repository", limit, offset, "listing artists");
-        let rows = self
-            .profiler
-            .timed("artists::list", || async {
-                sqlx::query("SELECT * FROM artists ORDER BY name LIMIT $1 OFFSET $2")
-                    .bind(limit)
-                    .bind(offset)
-                    .fetch_all(&self.pool)
-                    .await
-            })
+        debug!(target: "repository", limit, offset, "listing artists (postgres)");
+
+        let rows = sqlx::query("SELECT * FROM artists ORDER BY name LIMIT $1 OFFSET $2")
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
             .await?;
+
         let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_artist(&r)?);
+        for row in rows {
+            out.push(row_to_artist(&row)?);
         }
         Ok(out)
     }
 
     async fn update(&self, entity: Artist) -> Result<Artist> {
-        debug!(target: "repository", artist_id = %entity.id, "updating artist");
+        debug!(target: "repository", artist_id = %entity.id, "updating artist (postgres)");
+
         let q = r#"
             UPDATE artists SET
                 name = $1,
@@ -143,73 +112,73 @@ impl Repository<Artist> for PostgresArtistRepository {
                 updated_at = $15
             WHERE id = $16
         "#;
+
         sqlx::query(q)
-            .bind(&entity.name)
-            .bind(&entity.foreign_artist_id)
-            .bind(&entity.musicbrainz_artist_id)
+            .bind(entity.name.clone())
+            .bind(entity.foreign_artist_id.clone())
+            .bind(entity.musicbrainz_artist_id.clone())
             .bind(entity.metadata_profile_id.map(|p| p.to_string()))
             .bind(entity.quality_profile_id.map(|p| p.to_string()))
             .bind(entity.status.to_string())
-            .bind(&entity.path)
+            .bind(entity.path.clone())
             .bind(entity.monitored)
-            .bind(&entity.artist_type)
-            .bind(&entity.sort_name)
-            .bind(&entity.country)
-            .bind(&entity.disambiguation)
-            .bind(&entity.genre_tags)
-            .bind(&entity.style_tags)
-            .bind(entity.updated_at)
+            .bind(entity.artist_type.clone())
+            .bind(entity.sort_name.clone())
+            .bind(entity.country.clone())
+            .bind(entity.disambiguation.clone())
+            .bind(entity.genre_tags.clone())
+            .bind(entity.style_tags.clone())
+            .bind(entity.updated_at.naive_utc())
             .bind(entity.id.to_string())
             .execute(&self.pool)
             .await?;
+
         Ok(entity)
     }
 
     async fn delete(&self, id: &str) -> Result<()> {
-        debug!(target: "repository", %id, "deleting artist");
+        debug!(target: "repository", %id, "deleting artist (postgres)");
+
         let result = sqlx::query("DELETE FROM artists WHERE id = $1")
             .bind(id)
             .execute(&self.pool)
             .await?;
 
         if result.rows_affected() == 0 {
-            Err(anyhow!("artist {} not found", id))
-        } else {
-            debug!(target: "repository", %id, "artist deleted successfully");
-            Ok(())
+            return Err(anyhow!("artist not found: {}", id));
         }
+
+        Ok(())
     }
 }
 
 #[async_trait::async_trait]
 impl ArtistRepository for PostgresArtistRepository {
     async fn get_by_name(&self, name: &str) -> Result<Option<Artist>> {
-        debug!(target: "repository", name, "fetching artist by name");
-        let row = sqlx::query("SELECT * FROM artists WHERE name = $1 LIMIT 1")
+        debug!(target: "repository", name, "fetching artist by name (postgres)");
+
+        let row = sqlx::query("SELECT * FROM artists WHERE LOWER(name) = LOWER($1) LIMIT 1")
             .bind(name)
             .fetch_optional(&self.pool)
             .await?;
-        if let Some(r) = row {
-            Ok(Some(row_to_artist(&r)?))
-        } else {
-            Ok(None)
-        }
+
+        Ok(row.map(|r| row_to_artist(&r)).transpose()?)
     }
 
     async fn get_by_foreign_id(&self, foreign_id: &str) -> Result<Option<Artist>> {
-        debug!(target: "repository", foreign_id, "fetching artist by foreign id");
+        debug!(target: "repository", foreign_id, "fetching artist by foreign_id (postgres)");
+
         let row = sqlx::query("SELECT * FROM artists WHERE foreign_artist_id = $1 LIMIT 1")
             .bind(foreign_id)
             .fetch_optional(&self.pool)
             .await?;
-        match row {
-            Some(r) => Ok(Some(row_to_artist(&r)?)),
-            None => Ok(None),
-        }
+
+        Ok(row.map(|r| row_to_artist(&r)).transpose()?)
     }
 
     async fn list_monitored(&self, limit: i64, offset: i64) -> Result<Vec<Artist>> {
-        debug!(target: "repository", limit, offset, "listing monitored artists");
+        debug!(target: "repository", limit, offset, "listing monitored artists (postgres)");
+
         let rows = sqlx::query(
             "SELECT * FROM artists WHERE monitored = true ORDER BY name LIMIT $1 OFFSET $2",
         )
@@ -217,9 +186,10 @@ impl ArtistRepository for PostgresArtistRepository {
         .bind(offset)
         .fetch_all(&self.pool)
         .await?;
+
         let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_artist(&r)?);
+        for row in rows {
+            out.push(row_to_artist(&row)?);
         }
         Ok(out)
     }
@@ -230,426 +200,199 @@ impl ArtistRepository for PostgresArtistRepository {
         limit: i64,
         offset: i64,
     ) -> Result<Vec<Artist>> {
-        debug!(target: "repository", status = ?status, "fetching artists by status");
+        debug!(target: "repository", ?status, limit, offset, "fetching artists by status (postgres)");
+
         let status_str = status.to_string();
         let rows =
             sqlx::query("SELECT * FROM artists WHERE status = $1 ORDER BY name LIMIT $2 OFFSET $3")
-                .bind(&status_str)
+                .bind(status_str)
                 .bind(limit)
                 .bind(offset)
                 .fetch_all(&self.pool)
                 .await?;
+
         let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_artist(&r)?);
+        for row in rows {
+            out.push(row_to_artist(&row)?);
         }
         Ok(out)
     }
 }
 
-// ============================================================================
-// Album Repository
-// ============================================================================
+fn parse_profile_id_opt(value: Option<String>) -> Result<Option<chorrosion_domain::ProfileId>> {
+    match value {
+        Some(raw) => {
+            let uuid = Uuid::parse_str(&raw)?;
+            Ok(Some(chorrosion_domain::ProfileId::from_uuid(uuid)))
+        }
+        None => Ok(None),
+    }
+}
 
-#[allow(dead_code)]
+fn parse_artist_status(value: &str) -> Result<ArtistStatus> {
+    match value {
+        "continuing" => Ok(ArtistStatus::Continuing),
+        "ended" => Ok(ArtistStatus::Ended),
+        other => Err(anyhow!("unknown artist status: {}", other)),
+    }
+}
+
+fn row_to_artist(row: &PgRow) -> Result<Artist> {
+    let id: String = row.try_get("id")?;
+    let name: String = row.try_get("name")?;
+    let foreign_artist_id: Option<String> = row.try_get("foreign_artist_id")?;
+    let musicbrainz_artist_id: Option<String> = row.try_get("musicbrainz_artist_id")?;
+    let metadata_profile_id: Option<String> = row.try_get("metadata_profile_id")?;
+    let quality_profile_id: Option<String> = row.try_get("quality_profile_id")?;
+    let status: String = row.try_get("status")?;
+    let path: Option<String> = row.try_get("path")?;
+    let monitored: bool = row.try_get("monitored")?;
+    let artist_type: Option<String> = row.try_get("artist_type")?;
+    let sort_name: Option<String> = row.try_get("sort_name")?;
+    let country: Option<String> = row.try_get("country")?;
+    let disambiguation: Option<String> = row.try_get("disambiguation")?;
+    let genre_tags: Option<String> = row.try_get("genre_tags")?;
+    let style_tags: Option<String> = row.try_get("style_tags")?;
+    let created_at: NaiveDateTime = row.try_get("created_at")?;
+    let updated_at: NaiveDateTime = row.try_get("updated_at")?;
+
+    Ok(Artist {
+        id: ArtistId::from_uuid(Uuid::parse_str(&id)?),
+        name,
+        foreign_artist_id,
+        musicbrainz_artist_id,
+        metadata_profile_id: parse_profile_id_opt(metadata_profile_id)?,
+        quality_profile_id: parse_profile_id_opt(quality_profile_id)?,
+        status: parse_artist_status(&status)?,
+        path,
+        monitored,
+        artist_type,
+        sort_name,
+        country,
+        disambiguation,
+        genre_tags,
+        style_tags,
+        created_at: DateTime::<Utc>::from_naive_utc_and_offset(created_at, Utc),
+        updated_at: DateTime::<Utc>::from_naive_utc_and_offset(updated_at, Utc),
+    })
+}
+
+/// PostgreSQL-backed Album repository scaffold.
 pub struct PostgresAlbumRepository {
     pool: PgPool,
-    profiler: QueryProfiler,
 }
 
 impl PostgresAlbumRepository {
     pub fn new(pool: PgPool) -> Self {
-        let profiler = QueryProfiler::new(pool.clone(), 0);
-        Self { pool, profiler }
+        Self { pool }
     }
 
-    pub fn new_with_threshold(pool: PgPool, threshold_ms: u64) -> Self {
-        let profiler = QueryProfiler::new(pool.clone(), threshold_ms);
-        Self { pool, profiler }
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
     }
 }
 
-#[async_trait::async_trait]
-impl Repository<Album> for PostgresAlbumRepository {
-    async fn create(&self, entity: Album) -> Result<Album> {
-        debug!(target: "repository", album_id = %entity.id, "creating album");
-        let q = r#"
-            INSERT INTO albums (
-                id, artist_id, title, album_type, musicbrainz_release_group_id,
-                musicbrainz_release_id, foreign_album_id, release_date, disambiguation,
-                status, monitored, quality_profile_id, metadata_profile_id, path,
-                genre_tags, style_tags, created_at, updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-        "#;
+/// PostgreSQL-backed Track repository scaffold.
+pub struct PostgresTrackRepository {
+    pool: PgPool,
+}
 
-        let id_str = entity.id.to_string();
-        let artist_id_str = entity.artist_id.to_string();
-        let quality_id = entity.quality_profile_id.map(|p| p.to_string());
-        let metadata_id = entity.metadata_profile_id.map(|p| p.to_string());
-        let status = entity.status.to_string();
-
-        sqlx::query(q)
-            .bind(&id_str)
-            .bind(&artist_id_str)
-            .bind(&entity.title)
-            .bind(&entity.album_type)
-            .bind(&entity.musicbrainz_release_group_id)
-            .bind(&entity.musicbrainz_release_id)
-            .bind(&entity.foreign_album_id)
-            .bind(entity.release_date)
-            .bind(&entity.disambiguation)
-            .bind(&status)
-            .bind(entity.monitored)
-            .bind(&quality_id)
-            .bind(&metadata_id)
-            .bind(&entity.path)
-            .bind(&entity.genre_tags)
-            .bind(&entity.style_tags)
-            .bind(entity.created_at)
-            .bind(entity.updated_at)
-            .execute(&self.pool)
-            .await?;
-        Ok(entity)
+impl PostgresTrackRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
     }
 
-    async fn get_by_id(&self, id: &str) -> Result<Option<Album>> {
-        debug!(target: "repository", %id, "fetching album by id");
-        let row = self
-            .profiler
-            .timed("albums::get_by_id", || async {
-                sqlx::query("SELECT * FROM albums WHERE id = $1 LIMIT 1")
-                    .bind(id)
-                    .fetch_optional(&self.pool)
-                    .await
-            })
-            .await?;
-        if let Some(r) = row {
-            Ok(Some(row_to_album(&r)?))
-        } else {
-            Ok(None)
-        }
-    }
-
-    async fn list(&self, limit: i64, offset: i64) -> Result<Vec<Album>> {
-        debug!(target: "repository", limit, offset, "listing albums");
-        let rows = self
-            .profiler
-            .timed("albums::list", || async {
-                sqlx::query("SELECT * FROM albums ORDER BY title LIMIT $1 OFFSET $2")
-                    .bind(limit)
-                    .bind(offset)
-                    .fetch_all(&self.pool)
-                    .await
-            })
-            .await?;
-        let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_album(&r)?);
-        }
-        Ok(out)
-    }
-
-    async fn update(&self, entity: Album) -> Result<Album> {
-        debug!(target: "repository", album_id = %entity.id, "updating album");
-        let q = r#"
-            UPDATE albums SET
-                artist_id = $1,
-                title = $2,
-                album_type = $3,
-                musicbrainz_release_group_id = $4,
-                musicbrainz_release_id = $5,
-                foreign_album_id = $6,
-                release_date = $7,
-                disambiguation = $8,
-                status = $9,
-                monitored = $10,
-                quality_profile_id = $11,
-                metadata_profile_id = $12,
-                path = $13,
-                genre_tags = $14,
-                style_tags = $15,
-                updated_at = $16
-            WHERE id = $17
-        "#;
-        sqlx::query(q)
-            .bind(entity.artist_id.to_string())
-            .bind(&entity.title)
-            .bind(&entity.album_type)
-            .bind(&entity.musicbrainz_release_group_id)
-            .bind(&entity.musicbrainz_release_id)
-            .bind(&entity.foreign_album_id)
-            .bind(entity.release_date)
-            .bind(&entity.disambiguation)
-            .bind(entity.status.to_string())
-            .bind(entity.monitored)
-            .bind(entity.quality_profile_id.map(|p| p.to_string()))
-            .bind(entity.metadata_profile_id.map(|p| p.to_string()))
-            .bind(&entity.path)
-            .bind(&entity.genre_tags)
-            .bind(&entity.style_tags)
-            .bind(entity.updated_at)
-            .bind(entity.id.to_string())
-            .execute(&self.pool)
-            .await?;
-        Ok(entity)
-    }
-
-    async fn delete(&self, id: &str) -> Result<()> {
-        debug!(target: "repository", %id, "deleting album");
-        let result = sqlx::query("DELETE FROM albums WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-
-        if result.rows_affected() == 0 {
-            Err(anyhow!("album {} not found", id))
-        } else {
-            debug!(target: "repository", %id, "album deleted successfully");
-            Ok(())
-        }
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
     }
 }
 
-#[async_trait::async_trait]
-impl AlbumRepository for PostgresAlbumRepository {
-    async fn get_by_artist(
-        &self,
-        artist_id: ArtistId,
-        limit: i64,
-        offset: i64,
-    ) -> Result<Vec<Album>> {
-        debug!(target: "repository", artist_id = %artist_id, "fetching albums by artist");
-        let artist_id_str = artist_id.to_string();
-        let rows = sqlx::query("SELECT * FROM albums WHERE artist_id = $1 ORDER BY release_date DESC, title LIMIT $2 OFFSET $3")
-            .bind(&artist_id_str)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-        let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_album(&r)?);
-        }
-        Ok(out)
+/// PostgreSQL-backed QualityProfile repository scaffold.
+pub struct PostgresQualityProfileRepository {
+    pool: PgPool,
+}
+
+impl PostgresQualityProfileRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
     }
 
-    async fn get_by_foreign_id(&self, foreign_id: &str) -> Result<Option<Album>> {
-        debug!(target: "repository", foreign_id, "fetching album by foreign id");
-        let row = sqlx::query("SELECT * FROM albums WHERE foreign_album_id = $1 LIMIT 1")
-            .bind(foreign_id)
-            .fetch_optional(&self.pool)
-            .await?;
-        match row {
-            Some(r) => Ok(Some(row_to_album(&r)?)),
-            None => Ok(None),
-        }
-    }
-
-    async fn get_by_artist_and_title(
-        &self,
-        artist_id: ArtistId,
-        title: &str,
-    ) -> Result<Option<Album>> {
-        debug!(target: "repository", artist_id = %artist_id, title, "fetching album by artist and title");
-        let artist_id_str = artist_id.to_string();
-        let row = sqlx::query(
-            "SELECT * FROM albums WHERE artist_id = $1 AND LOWER(title) = LOWER($2) LIMIT 1",
-        )
-        .bind(&artist_id_str)
-        .bind(title)
-        .fetch_optional(&self.pool)
-        .await?;
-        match row {
-            Some(r) => Ok(Some(row_to_album(&r)?)),
-            None => Ok(None),
-        }
-    }
-
-    async fn get_by_status(
-        &self,
-        status: AlbumStatus,
-        limit: i64,
-        offset: i64,
-    ) -> Result<Vec<Album>> {
-        debug!(target: "repository", status = ?status, "fetching albums by status");
-        let status_str = status.to_string();
-        let rows = sqlx::query(
-            "SELECT * FROM albums WHERE status = $1 ORDER BY release_date DESC LIMIT $2 OFFSET $3",
-        )
-        .bind(&status_str)
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
-        .await?;
-        let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_album(&r)?);
-        }
-        Ok(out)
-    }
-
-    async fn list_monitored(&self, limit: i64, offset: i64) -> Result<Vec<Album>> {
-        debug!(target: "repository", limit, offset, "listing monitored albums");
-        let rows = sqlx::query("SELECT * FROM albums WHERE monitored = true ORDER BY release_date DESC LIMIT $1 OFFSET $2")
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-        let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_album(&r)?);
-        }
-        Ok(out)
-    }
-
-    async fn get_by_album_type(
-        &self,
-        album_type: &str,
-        limit: i64,
-        offset: i64,
-    ) -> Result<Vec<Album>> {
-        debug!(target: "repository", album_type, "fetching albums by type");
-        let rows = sqlx::query("SELECT * FROM albums WHERE album_type = $1 ORDER BY release_date DESC LIMIT $2 OFFSET $3")
-            .bind(album_type)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-        let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_album(&r)?);
-        }
-        Ok(out)
-    }
-
-    async fn list_wanted_without_tracks(&self, limit: i64, offset: i64) -> Result<Vec<Album>> {
-        debug!(target: "repository", limit, offset, "fetching wanted albums without tracks");
-        let rows = sqlx::query(r#"
-            SELECT a.* FROM albums a
-            WHERE a.status = 'Wanted' AND NOT EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = a.id)
-            ORDER BY a.release_date DESC
-            LIMIT $1 OFFSET $2
-        "#)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-        let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_album(&r)?);
-        }
-        Ok(out)
-    }
-
-    async fn list_cutoff_unmet_albums(&self, limit: i64, offset: i64) -> Result<Vec<Album>> {
-        debug!(target: "repository", limit, offset, "fetching albums with cutoff unmet");
-        let rows = sqlx::query(r#"
-            SELECT a.* FROM albums a
-            WHERE a.monitored = true AND a.status = 'Wanted'
-            AND (SELECT COUNT(*) FROM tracks t WHERE t.album_id = a.id AND t.quality IS NOT NULL) > 0
-            AND (SELECT COUNT(*) FROM tracks t WHERE t.album_id = a.id AND t.quality IS NOT NULL)
-                < (SELECT array_length(allowed_qualities, 1) FROM quality_profiles qp WHERE qp.id = a.quality_profile_id)
-            ORDER BY a.release_date DESC
-            LIMIT $1 OFFSET $2
-        "#)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-        let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_album(&r)?);
-        }
-        Ok(out)
-    }
-
-    async fn list_upcoming_releases(
-        &self,
-        start: NaiveDate,
-        end: NaiveDate,
-        limit: i64,
-        offset: i64,
-    ) -> Result<Vec<Album>> {
-        debug!(target: "repository", from = %start, to = %end, "fetching upcoming album releases");
-        let rows = sqlx::query("SELECT * FROM albums WHERE release_date >= $1 AND release_date <= $2 ORDER BY release_date LIMIT $3 OFFSET $4")
-            .bind(start)
-            .bind(end)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-        let mut out = Vec::with_capacity(rows.len());
-        for r in rows {
-            out.push(row_to_album(&r)?);
-        }
-        Ok(out)
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
     }
 }
 
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-fn row_to_artist(row: &sqlx::postgres::PgRow) -> Result<Artist> {
-    let id: String = row.try_get("id")?;
-    let monitored: bool = row.try_get("monitored")?;
-    let created_at: DateTime<Utc> = row.try_get("created_at")?;
-    let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
-
-    Ok(Artist {
-        id: ArtistId::from_uuid(Uuid::parse_str(&id)?),
-        name: row.try_get("name")?,
-        foreign_artist_id: row.try_get("foreign_artist_id")?,
-        musicbrainz_artist_id: row.try_get("musicbrainz_artist_id")?,
-        metadata_profile_id: row
-            .try_get::<Option<String>, _>("metadata_profile_id")?
-            .map(|id| ProfileId::from_uuid(Uuid::parse_str(&id).unwrap())),
-        quality_profile_id: row
-            .try_get::<Option<String>, _>("quality_profile_id")?
-            .map(|id| ProfileId::from_uuid(Uuid::parse_str(&id).unwrap())),
-        status: row.try_get::<String, _>("status")?.parse()?,
-        path: row.try_get("path")?,
-        monitored,
-        artist_type: row.try_get("artist_type")?,
-        sort_name: row.try_get("sort_name")?,
-        country: row.try_get("country")?,
-        disambiguation: row.try_get("disambiguation")?,
-        genre_tags: row.try_get("genre_tags")?,
-        style_tags: row.try_get("style_tags")?,
-        created_at,
-        updated_at,
-    })
+/// PostgreSQL-backed MetadataProfile repository scaffold.
+pub struct PostgresMetadataProfileRepository {
+    pool: PgPool,
 }
 
-fn row_to_album(row: &sqlx::postgres::PgRow) -> Result<Album> {
-    let id: String = row.try_get("id")?;
-    let artist_id: String = row.try_get("artist_id")?;
-    let monitored: bool = row.try_get("monitored")?;
-    let created_at: DateTime<Utc> = row.try_get("created_at")?;
-    let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+impl PostgresMetadataProfileRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
 
-    Ok(Album {
-        id: AlbumId::from_uuid(Uuid::parse_str(&id)?),
-        artist_id: ArtistId::from_uuid(Uuid::parse_str(&artist_id)?),
-        title: row.try_get("title")?,
-        album_type: row.try_get("album_type")?,
-        musicbrainz_release_group_id: row.try_get("musicbrainz_release_group_id")?,
-        musicbrainz_release_id: row.try_get("musicbrainz_release_id")?,
-        foreign_album_id: row.try_get("foreign_album_id")?,
-        release_date: row.try_get("release_date")?,
-        disambiguation: row.try_get("disambiguation")?,
-        status: row.try_get::<String, _>("status")?.parse()?,
-        monitored,
-        quality_profile_id: row
-            .try_get::<Option<String>, _>("quality_profile_id")?
-            .map(|id| ProfileId::from_uuid(Uuid::parse_str(&id).unwrap())),
-        metadata_profile_id: row
-            .try_get::<Option<String>, _>("metadata_profile_id")?
-            .map(|id| ProfileId::from_uuid(Uuid::parse_str(&id).unwrap())),
-        path: row.try_get("path")?,
-        genre_tags: row.try_get("genre_tags")?,
-        style_tags: row.try_get("style_tags")?,
-        created_at,
-        updated_at,
-    })
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+/// PostgreSQL-backed IndexerDefinition repository scaffold.
+pub struct PostgresIndexerDefinitionRepository {
+    pool: PgPool,
+}
+
+impl PostgresIndexerDefinitionRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+/// PostgreSQL-backed DownloadClientDefinition repository scaffold.
+pub struct PostgresDownloadClientDefinitionRepository {
+    pool: PgPool,
+}
+
+impl PostgresDownloadClientDefinitionRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+/// PostgreSQL-backed TrackFile repository scaffold.
+pub struct PostgresTrackFileRepository {
+    pool: PgPool,
+}
+
+impl PostgresTrackFileRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+/// PostgreSQL-backed ArtistRelationship repository scaffold.
+pub struct PostgresArtistRelationshipRepository {
+    pool: PgPool,
+}
+
+impl PostgresArtistRelationshipRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
 }

--- a/crates/chorrosion-infrastructure/tests/database_integration_tests.rs
+++ b/crates/chorrosion-infrastructure/tests/database_integration_tests.rs
@@ -2,7 +2,13 @@
 
 use chorrosion_config::AppConfig;
 use chorrosion_domain::{Album, Artist, ArtistRelationship, Track, TrackFile};
+#[cfg(feature = "postgres")]
+use chorrosion_infrastructure::create_postgres_pool;
 use chorrosion_infrastructure::init_database;
+#[cfg(feature = "postgres")]
+use chorrosion_infrastructure::postgres_adapters::PostgresArtistRepository;
+#[cfg(feature = "postgres")]
+use chorrosion_infrastructure::repositories::ArtistRepository;
 use chorrosion_infrastructure::repositories::{
     AlbumRepository, ArtistRelationshipRepository, Repository, TrackFileRepository, TrackRepository,
 };
@@ -10,6 +16,8 @@ use chorrosion_infrastructure::sqlite_adapters::{
     SqliteAlbumRepository, SqliteArtistRelationshipRepository, SqliteArtistRepository,
     SqliteTrackFileRepository, SqliteTrackRepository,
 };
+#[cfg(feature = "postgres")]
+use sqlx::PgPool;
 use sqlx::SqlitePool;
 
 async fn setup_pool() -> SqlitePool {
@@ -143,4 +151,134 @@ async fn wanted_without_tracks_relationship_and_track_transition_workflow() {
         .await
         .expect("relationship existence check");
     assert!(exists);
+}
+
+#[cfg(feature = "postgres")]
+async fn setup_postgres_pool_from_env() -> Option<PgPool> {
+    let postgres_url = std::env::var("CHORROSION_TEST_POSTGRES_URL").ok()?;
+
+    let mut config = AppConfig::default();
+    config.database.url = postgres_url;
+    config.database.pool_max_size = 1;
+
+    Some(
+        create_postgres_pool(&config)
+            .await
+            .expect("create postgres pool"),
+    )
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_pool_connectivity_check() {
+    let Some(pool) = setup_postgres_pool_from_env().await else {
+        return;
+    };
+
+    let one: i64 = sqlx::query_scalar("SELECT 1")
+        .fetch_one(&pool)
+        .await
+        .expect("postgres connectivity query should succeed");
+    assert_eq!(one, 1);
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_artist_repository_crud_and_filters() {
+    let Some(pool) = setup_postgres_pool_from_env().await else {
+        return;
+    };
+
+    sqlx::query(
+        r#"
+        CREATE TEMP TABLE IF NOT EXISTS artists (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            foreign_artist_id TEXT,
+            musicbrainz_artist_id TEXT,
+            metadata_profile_id TEXT,
+            quality_profile_id TEXT,
+            status TEXT NOT NULL DEFAULT 'continuing',
+            path TEXT,
+            monitored BOOLEAN NOT NULL DEFAULT TRUE,
+            artist_type TEXT,
+            sort_name TEXT,
+            country TEXT,
+            disambiguation TEXT,
+            genre_tags TEXT,
+            style_tags TEXT,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create temporary artists table for postgres test");
+
+    let repo = PostgresArtistRepository::new(pool.clone());
+
+    let mut artist = Artist::new("Postgres Artist");
+    artist.foreign_artist_id = Some("foreign-artist-1".to_string());
+    artist.monitored = true;
+    artist.genre_tags = Some("rock|alt".to_string());
+
+    let artist_id = artist.id.to_string();
+    repo.create(artist).await.expect("create postgres artist");
+
+    let by_id = repo
+        .get_by_id(&artist_id)
+        .await
+        .expect("get artist by id")
+        .expect("artist should exist");
+    assert_eq!(by_id.name, "Postgres Artist");
+
+    let by_name = repo
+        .get_by_name("postgres artist")
+        .await
+        .expect("get artist by name")
+        .expect("artist should be found case-insensitively");
+    assert_eq!(by_name.id.to_string(), artist_id);
+
+    let by_foreign_id = repo
+        .get_by_foreign_id("foreign-artist-1")
+        .await
+        .expect("get artist by foreign id")
+        .expect("artist should be found by foreign id");
+    assert_eq!(by_foreign_id.id.to_string(), artist_id);
+
+    let monitored = repo
+        .list_monitored(10, 0)
+        .await
+        .expect("list monitored artists");
+    assert_eq!(monitored.len(), 1);
+
+    let mut updated = by_id.clone();
+    updated.status = chorrosion_domain::ArtistStatus::Ended;
+    updated.monitored = false;
+    updated.name = "Postgres Artist Updated".to_string();
+    repo.update(updated).await.expect("update postgres artist");
+
+    let ended = repo
+        .get_by_status(chorrosion_domain::ArtistStatus::Ended, 10, 0)
+        .await
+        .expect("list artists by status");
+    assert_eq!(ended.len(), 1);
+    assert_eq!(ended[0].name, "Postgres Artist Updated");
+
+    let monitored_after_update = repo
+        .list_monitored(10, 0)
+        .await
+        .expect("list monitored artists after update");
+    assert!(monitored_after_update.is_empty());
+
+    repo.delete(&artist_id)
+        .await
+        .expect("delete postgres artist");
+
+    let gone = repo
+        .get_by_id(&artist_id)
+        .await
+        .expect("get artist after delete");
+    assert!(gone.is_none());
 }


### PR DESCRIPTION
## Summary
This PR advances PostgreSQL support by implementing a functional `PostgresArtistRepository` and wiring feature-gated PostgreSQL infrastructure entry points.

### What changed
- Added PostgreSQL pool and init functions in infrastructure:
  - `create_postgres_pool`
  - `init_postgres_database`
- Implemented `PostgresArtistRepository` with:
  - CRUD methods (`create`, `get_by_id`, `list`, `update`, `delete`)
  - Artist-specific queries (`get_by_name`, `get_by_foreign_id`, `list_monitored`, `get_by_status`)
  - PostgreSQL placeholder style (`$1..$n`) and row mapping helpers
- Added PostgreSQL feature-gated integration coverage:
  - connectivity check via `CHORROSION_TEST_POSTGRES_URL`
  - artist repository CRUD/filter workflow against a temporary Postgres `artists` table

## Validation
- `cargo test -p chorrosion-infrastructure`
- `cargo test -p chorrosion-infrastructure --features postgres postgres_artist_repository_crud_and_filters -- --nocapture`
- `cargo clippy -p chorrosion-infrastructure --all-targets --all-features -- -D warnings`

Part of #12
