### PR TITLE
docs: sync phase 9 PostgreSQL roadmap progress

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -433,14 +433,13 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ## Phase 9: PostgreSQL Support (TBD)
 
-- Related issues: #12, #381
-- Related PRs: #382, #383, #384
+- Related issues: #12, #381, #382, #383, #384
 
 ### 9.1 Database Abstraction
 
-- [x] Abstract database-specific queries (Issue #381) ✓
+- [x] Abstract AppState repositories behind trait objects (Issue #381) ✓
+- [x] Implement PostgreSQL repository adapters for all core entities (PR #383, PR #384) ✓
 - [ ] Add PostgreSQL-specific optimizations
-  - [x] Implement PostgreSQL repository adapters for all core entities (PR #383, PR #384) ✓
 - [ ] Migration compatibility
 - [ ] Connection pooling tuning
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -433,12 +433,14 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ## Phase 9: PostgreSQL Support (TBD)
 
-- Related issues: #12
+- Related issues: #12, #381
+- Related PRs: #382, #383, #384
 
 ### 9.1 Database Abstraction
 
-- [ ] Abstract database-specific queries
+- [x] Abstract database-specific queries (Issue #381) ✓
 - [ ] Add PostgreSQL-specific optimizations
+  - [x] Implement PostgreSQL repository adapters for all core entities (PR #383, PR #384) ✓
 - [ ] Migration compatibility
 - [ ] Connection pooling tuning
 


### PR DESCRIPTION
## Summary

Updates the Phase 9 section in ROADMAP.md to reflect recently merged PostgreSQL milestones.

## Changes

- Marks database-specific query abstraction as completed (Issue #381 / PR #382)
- Adds related PR references for PostgreSQL adapter completion (PR #383, PR #384)
- Adds a completed sub-item under PostgreSQL optimizations for full repository adapter coverage

## Tracking

Part of #12
