### PR TITLE
Add SQLite-PostgreSQL schema comparison tooling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -446,7 +446,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 ### 9.2 Migration Tools
 
 - [x] SQLite to PostgreSQL migration tool ✓
-- [ ] Schema comparison tools
+- [x] Schema comparison tools ✓
 - [ ] Data validation after migration
 
 ---
@@ -532,4 +532,4 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 **Last Updated:** 2026-04-16  
 **Current Phase:** Phase 9: PostgreSQL Support  
-**Next Milestone:** Complete remaining Phase 9.2 tooling: schema comparison tools and post-migration validation
+**Next Milestone:** Complete remaining Phase 9.2 tooling: post-migration data validation

--- a/crates/chorrosion-infrastructure/src/sqlite_to_postgres.rs
+++ b/crates/chorrosion-infrastructure/src/sqlite_to_postgres.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, Result};
 use chrono::{NaiveDate, NaiveDateTime};
+use std::collections::HashSet;
 use sqlx::{FromRow, PgPool, SqlitePool};
 
 const MIGRATED_TABLES: [&str; 9] = [
@@ -37,6 +38,29 @@ impl MigrationReport {
             .filter(|summary| summary.sqlite_rows != summary.postgres_rows)
             .collect()
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SchemaComparisonReport {
+    pub missing_tables_in_postgres: Vec<&'static str>,
+    pub missing_tables_in_sqlite: Vec<&'static str>,
+    pub missing_columns_in_postgres: Vec<TableColumnDifference>,
+    pub missing_columns_in_sqlite: Vec<TableColumnDifference>,
+}
+
+impl SchemaComparisonReport {
+    pub fn has_differences(&self) -> bool {
+        !self.missing_tables_in_postgres.is_empty()
+            || !self.missing_tables_in_sqlite.is_empty()
+            || !self.missing_columns_in_postgres.is_empty()
+            || !self.missing_columns_in_sqlite.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableColumnDifference {
+    pub table: &'static str,
+    pub columns: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -74,6 +98,74 @@ pub async fn plan_sqlite_to_postgres_migration(
             postgres_rows: count_rows_postgres(postgres_pool, table).await?,
         });
     }
+
+    Ok(report)
+}
+
+pub async fn compare_sqlite_postgres_schema(
+    sqlite_pool: &SqlitePool,
+    postgres_pool: &PgPool,
+) -> Result<SchemaComparisonReport> {
+    let mut report = SchemaComparisonReport::default();
+
+    for table in MIGRATED_TABLES {
+        let sqlite_exists = sqlite_table_exists(sqlite_pool, table).await?;
+        let postgres_exists = postgres_table_exists(postgres_pool, table).await?;
+
+        if sqlite_exists && !postgres_exists {
+            report.missing_tables_in_postgres.push(table);
+            continue;
+        }
+
+        if !sqlite_exists && postgres_exists {
+            report.missing_tables_in_sqlite.push(table);
+            continue;
+        }
+
+        if !sqlite_exists && !postgres_exists {
+            report.missing_tables_in_postgres.push(table);
+            report.missing_tables_in_sqlite.push(table);
+            continue;
+        }
+
+        let sqlite_columns = sqlite_columns_for_table(sqlite_pool, table).await?;
+        let postgres_columns = postgres_columns_for_table(postgres_pool, table).await?;
+
+        let missing_in_postgres = sqlite_columns
+            .difference(&postgres_columns)
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing_in_postgres.is_empty() {
+            report
+                .missing_columns_in_postgres
+                .push(TableColumnDifference {
+                    table,
+                    columns: sorted_columns(missing_in_postgres),
+                });
+        }
+
+        let missing_in_sqlite = postgres_columns
+            .difference(&sqlite_columns)
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing_in_sqlite.is_empty() {
+            report
+                .missing_columns_in_sqlite
+                .push(TableColumnDifference {
+                    table,
+                    columns: sorted_columns(missing_in_sqlite),
+                });
+        }
+    }
+
+    report.missing_tables_in_postgres.sort_unstable();
+    report.missing_tables_in_sqlite.sort_unstable();
+    report
+        .missing_columns_in_postgres
+        .sort_by(|a, b| a.table.cmp(b.table));
+    report
+        .missing_columns_in_sqlite
+        .sort_by(|a, b| a.table.cmp(b.table));
 
     Ok(report)
 }
@@ -533,6 +625,59 @@ fn ensure_migrated_table(table: &str) -> Result<()> {
     }
 }
 
+fn sorted_columns(mut columns: Vec<String>) -> Vec<String> {
+    columns.sort_unstable();
+    columns
+}
+
+async fn sqlite_table_exists(pool: &SqlitePool, table: &str) -> Result<bool> {
+    ensure_migrated_table(table)?;
+    let exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+    )
+    .bind(table)
+    .fetch_optional(pool)
+    .await?;
+    Ok(exists.is_some())
+}
+
+async fn postgres_table_exists(pool: &PgPool, table: &str) -> Result<bool> {
+    ensure_migrated_table(table)?;
+    let schema: String = sqlx::query_scalar("SELECT current_schema()")
+        .fetch_one(pool)
+        .await?;
+    let exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2 LIMIT 1",
+    )
+    .bind(schema)
+    .bind(table)
+    .fetch_optional(pool)
+    .await?;
+    Ok(exists.is_some())
+}
+
+async fn sqlite_columns_for_table(pool: &SqlitePool, table: &str) -> Result<HashSet<String>> {
+    ensure_migrated_table(table)?;
+    let pragma = format!("SELECT name FROM pragma_table_info('{table}')");
+    let rows: Vec<String> = sqlx::query_scalar(&pragma).fetch_all(pool).await?;
+    Ok(rows.into_iter().collect())
+}
+
+async fn postgres_columns_for_table(pool: &PgPool, table: &str) -> Result<HashSet<String>> {
+    ensure_migrated_table(table)?;
+    let schema: String = sqlx::query_scalar("SELECT current_schema()")
+        .fetch_one(pool)
+        .await?;
+    let rows: Vec<String> = sqlx::query_scalar(
+        "SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2",
+    )
+    .bind(schema)
+    .bind(table)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().collect())
+}
+
 #[derive(Debug, Clone, FromRow)]
 struct QualityProfileRow {
     id: String,
@@ -694,5 +839,17 @@ mod tests {
         let mismatches = report.mismatched_tables();
         assert_eq!(mismatches.len(), 1);
         assert_eq!(mismatches[0].table, "albums");
+    }
+
+    #[test]
+    fn schema_report_has_differences_detects_presence() {
+        let report = SchemaComparisonReport::default();
+        assert!(!report.has_differences());
+
+        let report = SchemaComparisonReport {
+            missing_tables_in_postgres: vec!["artists"],
+            ..SchemaComparisonReport::default()
+        };
+        assert!(report.has_differences());
     }
 }

--- a/crates/chorrosion-infrastructure/src/sqlite_to_postgres.rs
+++ b/crates/chorrosion-infrastructure/src/sqlite_to_postgres.rs
@@ -3,8 +3,8 @@
 
 use anyhow::{anyhow, Result};
 use chrono::{NaiveDate, NaiveDateTime};
-use std::collections::HashSet;
 use sqlx::{FromRow, PgPool, SqlitePool};
+use std::collections::HashSet;
 
 const MIGRATED_TABLES: [&str; 9] = [
     "quality_profiles",
@@ -107,10 +107,11 @@ pub async fn compare_sqlite_postgres_schema(
     postgres_pool: &PgPool,
 ) -> Result<SchemaComparisonReport> {
     let mut report = SchemaComparisonReport::default();
+    let postgres_schema = postgres_current_schema(postgres_pool).await?;
 
     for table in MIGRATED_TABLES {
         let sqlite_exists = sqlite_table_exists(sqlite_pool, table).await?;
-        let postgres_exists = postgres_table_exists(postgres_pool, table).await?;
+        let postgres_exists = postgres_table_exists(postgres_pool, &postgres_schema, table).await?;
 
         if sqlite_exists && !postgres_exists {
             report.missing_tables_in_postgres.push(table);
@@ -129,7 +130,8 @@ pub async fn compare_sqlite_postgres_schema(
         }
 
         let sqlite_columns = sqlite_columns_for_table(sqlite_pool, table).await?;
-        let postgres_columns = postgres_columns_for_table(postgres_pool, table).await?;
+        let postgres_columns =
+            postgres_columns_for_table(postgres_pool, &postgres_schema, table).await?;
 
         let missing_in_postgres = sqlite_columns
             .difference(&postgres_columns)
@@ -632,20 +634,22 @@ fn sorted_columns(mut columns: Vec<String>) -> Vec<String> {
 
 async fn sqlite_table_exists(pool: &SqlitePool, table: &str) -> Result<bool> {
     ensure_migrated_table(table)?;
-    let exists: Option<i64> = sqlx::query_scalar(
-        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
-    )
-    .bind(table)
-    .fetch_optional(pool)
-    .await?;
+    let exists: Option<i64> =
+        sqlx::query_scalar("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1")
+            .bind(table)
+            .fetch_optional(pool)
+            .await?;
     Ok(exists.is_some())
 }
 
-async fn postgres_table_exists(pool: &PgPool, table: &str) -> Result<bool> {
-    ensure_migrated_table(table)?;
-    let schema: String = sqlx::query_scalar("SELECT current_schema()")
+async fn postgres_current_schema(pool: &PgPool) -> Result<String> {
+    Ok(sqlx::query_scalar("SELECT current_schema()")
         .fetch_one(pool)
-        .await?;
+        .await?)
+}
+
+async fn postgres_table_exists(pool: &PgPool, schema: &str, table: &str) -> Result<bool> {
+    ensure_migrated_table(table)?;
     let exists: Option<i64> = sqlx::query_scalar(
         "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2 LIMIT 1",
     )
@@ -663,11 +667,12 @@ async fn sqlite_columns_for_table(pool: &SqlitePool, table: &str) -> Result<Hash
     Ok(rows.into_iter().collect())
 }
 
-async fn postgres_columns_for_table(pool: &PgPool, table: &str) -> Result<HashSet<String>> {
+async fn postgres_columns_for_table(
+    pool: &PgPool,
+    schema: &str,
+    table: &str,
+) -> Result<HashSet<String>> {
     ensure_migrated_table(table)?;
-    let schema: String = sqlx::query_scalar("SELECT current_schema()")
-        .fetch_one(pool)
-        .await?;
     let rows: Vec<String> = sqlx::query_scalar(
         "SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2",
     )

--- a/crates/chorrosion-infrastructure/tests/database_integration_tests.rs
+++ b/crates/chorrosion-infrastructure/tests/database_integration_tests.rs
@@ -502,13 +502,23 @@ impl PostgresSchemaGuard {
 impl Drop for PostgresSchemaGuard {
     fn drop(&mut self) {
         let pool = self.pool.clone();
-        let query = format!(
-            "DROP SCHEMA IF EXISTS \"{}\" CASCADE",
-            self.escaped_schema.replace('"', "\"\"")
-        );
-        tokio::spawn(async move {
-            let _ = sqlx::query(&query).execute(&pool).await;
-        });
+        let query = format!("DROP SCHEMA IF EXISTS \"{}\" CASCADE", self.escaped_schema);
+
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            tokio::task::block_in_place(|| {
+                let _ = handle.block_on(async move { sqlx::query(&query).execute(&pool).await });
+            });
+            return;
+        }
+
+        if let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            let _ = runtime.block_on(async move { sqlx::query(&query).execute(&pool).await });
+        } else {
+            eprintln!("failed to create runtime for postgres schema cleanup: {query}");
+        }
     }
 }
 

--- a/crates/chorrosion-infrastructure/tests/database_integration_tests.rs
+++ b/crates/chorrosion-infrastructure/tests/database_integration_tests.rs
@@ -32,7 +32,8 @@ use chorrosion_infrastructure::sqlite_adapters::{
 };
 #[cfg(feature = "postgres")]
 use chorrosion_infrastructure::sqlite_to_postgres::{
-    migrate_sqlite_to_postgres_with_options, MigrationOptions, TargetResetPolicy,
+    compare_sqlite_postgres_schema, migrate_sqlite_to_postgres_with_options, MigrationOptions,
+    TargetResetPolicy,
 };
 #[cfg(feature = "postgres")]
 use sqlx::Executor;
@@ -421,6 +422,56 @@ async fn sqlite_to_postgres_migration_copies_core_rows() {
     .execute(&_pool)
     .await
     .expect("drop isolated schema for sqlite->postgres migration test");
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn sqlite_to_postgres_schema_comparison_reports_no_differences_after_init() {
+    let mut sqlite_config = AppConfig::default();
+    sqlite_config.database.url = "sqlite://:memory:".to_string();
+    sqlite_config.database.pool_max_size = 1;
+    let sqlite_pool = init_database(&sqlite_config)
+        .await
+        .expect("initialize sqlite source pool");
+
+    let Some(base_postgres_pool) = setup_postgres_pool_from_env().await else {
+        return;
+    };
+
+    let postgres_url = std::env::var("CHORROSION_TEST_POSTGRES_URL")
+        .expect("CHORROSION_TEST_POSTGRES_URL should be set when running this test");
+    let isolated_schema = format!("it_schema_compare_{}", Uuid::new_v4().simple());
+    assert!(
+        is_safe_postgres_schema_name(&isolated_schema),
+        "generated schema name must only contain ascii letters, numbers, and underscores"
+    );
+    let escaped_schema = isolated_schema.replace('"', "\"\"");
+    sqlx::query(&format!("CREATE SCHEMA \"{escaped_schema}\""))
+        .execute(&base_postgres_pool)
+        .await
+        .expect("create isolated schema for schema comparison test");
+
+    let mut postgres_config = AppConfig::default();
+    postgres_config.database.url = postgres_url_with_search_path(&postgres_url, &isolated_schema);
+    postgres_config.database.pool_max_size = 2;
+    let postgres_pool = init_postgres_database(&postgres_config)
+        .await
+        .expect("initialize postgres target pool");
+
+    let report = compare_sqlite_postgres_schema(&sqlite_pool, &postgres_pool)
+        .await
+        .expect("compare sqlite and postgres schema");
+    assert!(
+        !report.has_differences(),
+        "schema comparison should report no missing tables or columns; got: {report:?}"
+    );
+
+    sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{escaped_schema}\" CASCADE"
+    ))
+    .execute(&base_postgres_pool)
+    .await
+    .expect("drop isolated schema for schema comparison test");
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/chorrosion-infrastructure/tests/database_integration_tests.rs
+++ b/crates/chorrosion-infrastructure/tests/database_integration_tests.rs
@@ -369,7 +369,7 @@ async fn sqlite_to_postgres_migration_copies_core_rows() {
         .await
         .expect("create source track file");
 
-    let Some(_pool) = setup_postgres_pool_from_env().await else {
+    let Some(base_postgres_pool) = setup_postgres_pool_from_env().await else {
         return;
     };
 
@@ -382,9 +382,11 @@ async fn sqlite_to_postgres_migration_copies_core_rows() {
     );
     let escaped_schema = isolated_schema.replace('"', "\"\"");
     sqlx::query(&format!("CREATE SCHEMA \"{escaped_schema}\""))
-        .execute(&_pool)
+        .execute(&base_postgres_pool)
         .await
         .expect("create isolated schema for sqlite->postgres migration test");
+    let _schema_guard =
+        PostgresSchemaGuard::new(base_postgres_pool.clone(), escaped_schema.clone());
 
     let mut postgres_config = AppConfig::default();
     postgres_config.database.url = postgres_url_with_search_path(&postgres_url, &isolated_schema);
@@ -415,13 +417,6 @@ async fn sqlite_to_postgres_migration_copies_core_rows() {
         .expect("query migrated artist")
         .expect("artist should exist in postgres after migration");
     assert_eq!(migrated_artist.name, "Migration Artist");
-
-    sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{escaped_schema}\" CASCADE"
-    ))
-    .execute(&_pool)
-    .await
-    .expect("drop isolated schema for sqlite->postgres migration test");
 }
 
 #[cfg(feature = "postgres")]
@@ -450,6 +445,8 @@ async fn sqlite_to_postgres_schema_comparison_reports_no_differences_after_init(
         .execute(&base_postgres_pool)
         .await
         .expect("create isolated schema for schema comparison test");
+    let _schema_guard =
+        PostgresSchemaGuard::new(base_postgres_pool.clone(), escaped_schema.clone());
 
     let mut postgres_config = AppConfig::default();
     postgres_config.database.url = postgres_url_with_search_path(&postgres_url, &isolated_schema);
@@ -465,13 +462,6 @@ async fn sqlite_to_postgres_schema_comparison_reports_no_differences_after_init(
         !report.has_differences(),
         "schema comparison should report no missing tables or columns; got: {report:?}"
     );
-
-    sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{escaped_schema}\" CASCADE"
-    ))
-    .execute(&base_postgres_pool)
-    .await
-    .expect("drop isolated schema for schema comparison test");
 }
 
 #[cfg(feature = "postgres")]
@@ -490,6 +480,36 @@ fn is_safe_postgres_schema_name(schema: &str) -> bool {
         && schema
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(feature = "postgres")]
+struct PostgresSchemaGuard {
+    pool: PgPool,
+    escaped_schema: String,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresSchemaGuard {
+    fn new(pool: PgPool, escaped_schema: String) -> Self {
+        Self {
+            pool,
+            escaped_schema,
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl Drop for PostgresSchemaGuard {
+    fn drop(&mut self) {
+        let pool = self.pool.clone();
+        let query = format!(
+            "DROP SCHEMA IF EXISTS \"{}\" CASCADE",
+            self.escaped_schema.replace('"', "\"\"")
+        );
+        tokio::spawn(async move {
+            let _ = sqlx::query(&query).execute(&pool).await;
+        });
+    }
 }
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
## Summary
Implements the next Phase 9.2 deliverable by adding schema comparison tools for SQLite and PostgreSQL and validating them with integration coverage.

## What changed
- Extended `sqlite_to_postgres` with schema comparison support:
  - `compare_sqlite_postgres_schema(...)`
  - `SchemaComparisonReport`
  - `TableColumnDifference`
  - table-presence and column-presence checks across migrated tables
- Comparison logic uses the active PostgreSQL schema (`current_schema()`) so it works with isolated test schemas.
- Added integration test:
  - `sqlite_to_postgres_schema_comparison_reports_no_differences_after_init`
- Updated `ROADMAP.md`:
  - Marked `Schema comparison tools` complete in Phase 9.2
  - Updated next milestone to remaining `post-migration data validation`

## Validation
- `cargo test -p chorrosion-infrastructure`
- `cargo test -p chorrosion-infrastructure --features postgres`

## Notes
- Default SQLite-only workflow remains unchanged.
- This comparison intentionally validates schema presence parity (tables/columns), not cross-engine type equivalence semantics.


## Issue Link
- Closes #12

