### PR TITLE
Implement RSS sync feed polling and wanted-album matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chorrosion-application",
  "chorrosion-config",
  "chorrosion-infrastructure",
  "chorrosion-metadata",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -186,8 +186,8 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
   - [x] Search triggering logic ✓
   - [x] Best release selection algorithm ✓
 - [ ] RSS sync enhancement
-  - [ ] Parse RSS feeds from indexers
-  - [ ] Match releases to wanted albums
+  - [x] Parse RSS feeds from indexers ✓
+  - [x] Match releases to wanted albums ✓
   - [ ] Automatic grab logic
 
 ### 4.2 Download Client Integration

--- a/crates/chorrosion-scheduler/Cargo.toml
+++ b/crates/chorrosion-scheduler/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 chorrosion-config = { path = "../chorrosion-config" }
+chorrosion-application = { path = "../chorrosion-application" }
 chorrosion-infrastructure = { path = "../chorrosion-infrastructure" }
 chorrosion-metadata = { path = "../chorrosion-metadata" }
 sqlx = { workspace = true }

--- a/crates/chorrosion-scheduler/src/jobs.rs
+++ b/crates/chorrosion-scheduler/src/jobs.rs
@@ -625,7 +625,10 @@ impl Job for RssSyncJob {
         info!(target: "jobs", job_id = %ctx.job_id, "executing RSS sync job");
 
         let indexers = match self.indexer_repository.list(5000, 0).await {
-            Ok(indexers) => indexers.into_iter().filter(|i| i.enabled).collect::<Vec<_>>(),
+            Ok(indexers) => indexers
+                .into_iter()
+                .filter(|i| i.enabled)
+                .collect::<Vec<_>>(),
             Err(error) => {
                 return Ok(JobResult::Failure {
                     error: format!("failed to list configured indexers: {error}"),
@@ -639,23 +642,26 @@ impl Job for RssSyncJob {
             return Ok(JobResult::Success);
         }
 
-        let wanted_titles = match collect_wanted_album_titles(&self.album_repository, self.scan_limit).await {
-            Ok(titles) => titles,
-            Err(error) => {
-                return Ok(JobResult::Failure {
-                    error: format!("failed to load wanted albums for RSS matching: {error}"),
-                    retry: true,
-                });
-            }
-        };
+        let wanted_titles =
+            match collect_wanted_album_titles(&self.album_repository, self.scan_limit).await {
+                Ok(titles) => titles,
+                Err(error) => {
+                    return Ok(JobResult::Failure {
+                        error: format!("failed to load wanted albums for RSS matching: {error}"),
+                        retry: true,
+                    });
+                }
+            };
 
         if wanted_titles.is_empty() {
             info!(target: "jobs", job_id = %ctx.job_id, "no wanted albums to match; skipping RSS sync");
             return Ok(JobResult::Success);
         }
 
+        let enabled_indexers = indexers.len();
         let mut indexers_polled: usize = 0;
         let mut poll_failures: usize = 0;
+        let mut config_failures: usize = 0;
         let mut rss_items_seen: usize = 0;
         let mut rss_items_matched: usize = 0;
 
@@ -663,14 +669,14 @@ impl Job for RssSyncJob {
             let protocol = match definition.protocol.parse::<IndexerProtocol>() {
                 Ok(protocol) => protocol,
                 Err(error) => {
-                    poll_failures += 1;
+                    config_failures += 1;
                     warn!(
                         target: "jobs",
                         job_id = %ctx.job_id,
                         indexer = %definition.name,
                         protocol = %definition.protocol,
                         error = %error,
-                        "skipping indexer with unsupported protocol"
+                        "skipping indexer with invalid protocol"
                     );
                     continue;
                 }
@@ -684,24 +690,25 @@ impl Job for RssSyncJob {
                 enabled: definition.enabled,
             };
 
-            indexers_polled += 1;
             let fetch_result = match protocol {
                 IndexerProtocol::Newznab => {
+                    indexers_polled += 1;
                     let client = NewznabClient::new(config);
                     client.fetch_rss_feed().await
                 }
                 IndexerProtocol::Torznab => {
+                    indexers_polled += 1;
                     let client = TorznabClient::new(config);
                     client.fetch_rss_feed().await
                 }
                 other => {
-                    poll_failures += 1;
+                    config_failures += 1;
                     warn!(
                         target: "jobs",
                         job_id = %ctx.job_id,
                         indexer = %definition.name,
                         protocol = %other.as_str(),
-                        "RSS sync currently supports only newznab/torznab indexers"
+                        "skipping indexer: unsupported RSS sync protocol (supported: newznab, torznab)"
                     );
                     continue;
                 }
@@ -737,13 +744,24 @@ impl Job for RssSyncJob {
         info!(
             target: "jobs",
             job_id = %ctx.job_id,
+            enabled_indexers,
             indexers_polled,
             poll_failures,
+            config_failures,
             rss_items_seen,
             rss_items_matched,
             wanted_album_count = wanted_titles.len(),
             "RSS sync completed"
         );
+
+        if indexers_polled == 0 && config_failures > 0 {
+            return Ok(JobResult::Failure {
+                error:
+                    "no enabled indexers use a supported RSS protocol (supported: newznab, torznab)"
+                        .to_string(),
+                retry: false,
+            });
+        }
 
         if indexers_polled > 0 && poll_failures == indexers_polled {
             return Ok(JobResult::Failure {
@@ -770,37 +788,61 @@ async fn collect_wanted_album_titles(
 ) -> Result<HashSet<String>> {
     let mut titles = HashSet::new();
 
-    let mut offset: i64 = 0;
-    loop {
-        let batch = album_repository
-            .list_wanted_without_tracks(scan_limit, offset)
-            .await?;
-        let batch_len = batch.len();
-        for album in batch {
-            titles.insert(normalize_match_key(&album.title));
-        }
-        if batch_len < scan_limit as usize {
-            break;
-        }
-        offset += scan_limit;
-    }
-
-    let mut offset: i64 = 0;
-    loop {
-        let batch = album_repository
-            .list_cutoff_unmet_albums(scan_limit, offset)
-            .await?;
-        let batch_len = batch.len();
-        for album in batch {
-            titles.insert(normalize_match_key(&album.title));
-        }
-        if batch_len < scan_limit as usize {
-            break;
-        }
-        offset += scan_limit;
-    }
+    collect_titles_by_source(
+        album_repository,
+        scan_limit,
+        &mut titles,
+        WantedAlbumTitleSource::WantedWithoutTracks,
+    )
+    .await?;
+    collect_titles_by_source(
+        album_repository,
+        scan_limit,
+        &mut titles,
+        WantedAlbumTitleSource::CutoffUnmet,
+    )
+    .await?;
 
     Ok(titles)
+}
+
+enum WantedAlbumTitleSource {
+    WantedWithoutTracks,
+    CutoffUnmet,
+}
+
+async fn collect_titles_by_source(
+    album_repository: &SqliteAlbumRepository,
+    scan_limit: i64,
+    titles: &mut HashSet<String>,
+    source: WantedAlbumTitleSource,
+) -> Result<()> {
+    let mut offset: i64 = 0;
+    loop {
+        let batch = match source {
+            WantedAlbumTitleSource::WantedWithoutTracks => {
+                album_repository
+                    .list_wanted_without_tracks(scan_limit, offset)
+                    .await?
+            }
+            WantedAlbumTitleSource::CutoffUnmet => {
+                album_repository
+                    .list_cutoff_unmet_albums(scan_limit, offset)
+                    .await?
+            }
+        };
+
+        let batch_len = batch.len();
+        for album in batch {
+            titles.insert(normalize_match_key(&album.title));
+        }
+        if batch_len < scan_limit as usize {
+            break;
+        }
+        offset += scan_limit;
+    }
+
+    Ok(())
 }
 
 fn count_rss_matches(
@@ -1784,5 +1826,64 @@ mod tests {
 
         let result = job.execute(ctx).await.expect("execute should not Err");
         assert!(matches!(result, JobResult::Success));
+    }
+
+    #[tokio::test]
+    async fn test_rss_sync_job_returns_non_retriable_failure_for_unsupported_protocols() {
+        let pool = make_migrated_pool().await;
+
+        let artist_id = Uuid::new_v4().to_string();
+        let album_id = Uuid::new_v4().to_string();
+        let indexer_id = Uuid::new_v4().to_string();
+
+        sqlx::query("INSERT INTO artists (id, name, status, monitored) VALUES (?, ?, ?, ?)")
+            .bind(&artist_id)
+            .bind("Radiohead")
+            .bind("continuing")
+            .bind(true)
+            .execute(&pool)
+            .await
+            .expect("insert artist failed");
+
+        sqlx::query(
+            "INSERT INTO albums (id, artist_id, title, status, monitored) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&album_id)
+        .bind(&artist_id)
+        .bind("OK Computer")
+        .bind("wanted")
+        .bind(true)
+        .execute(&pool)
+        .await
+        .expect("insert wanted album failed");
+
+        sqlx::query(
+            "INSERT INTO indexer_definitions (id, name, base_url, protocol, enabled) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&indexer_id)
+        .bind("Unsupported Indexer")
+        .bind("https://example.com")
+        .bind("gazelle")
+        .bind(true)
+        .execute(&pool)
+        .await
+        .expect("insert indexer failed");
+
+        let album_repo = Arc::new(SqliteAlbumRepository::new(pool.clone()));
+        let indexer_repo = Arc::new(SqliteIndexerDefinitionRepository::new(pool));
+        let job = RssSyncJob::new(album_repo, indexer_repo);
+        let ctx = JobContext::new("test-rss-unsupported-protocols");
+
+        let result = job.execute(ctx).await.expect("execute should not Err");
+        match result {
+            JobResult::Failure { retry, error } => {
+                assert!(!retry, "unsupported protocols should not be retriable");
+                assert!(
+                    error.contains("supported RSS protocol"),
+                    "unexpected error: {error}"
+                );
+            }
+            other => panic!("expected non-retriable Failure, got {other:?}"),
+        }
     }
 }

--- a/crates/chorrosion-scheduler/src/jobs.rs
+++ b/crates/chorrosion-scheduler/src/jobs.rs
@@ -696,12 +696,14 @@ impl Job for RssSyncJob {
                 IndexerProtocol::Newznab => {
                     indexers_polled += 1;
                     let client = NewznabClient::new(config);
-                    client.fetch_rss_feed().await
+                    let rss_items = client.fetch_rss_feed().await;
+                    rss_items
                 }
                 IndexerProtocol::Torznab => {
                     indexers_polled += 1;
                     let client = TorznabClient::new(config);
-                    client.fetch_rss_feed().await
+                    let rss_items = client.fetch_rss_feed().await;
+                    rss_items
                 }
                 other => {
                     config_failures += 1;

--- a/crates/chorrosion-scheduler/src/jobs.rs
+++ b/crates/chorrosion-scheduler/src/jobs.rs
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use crate::job::{Job, JobContext, JobResult};
 use anyhow::Result;
+use chorrosion_application::{
+    parse_release_title, IndexerClient, IndexerConfig, IndexerProtocol, NewznabClient,
+    TorznabClient,
+};
 use chorrosion_config::{
     CacheConfig, DiscogsAlbumSeed, DiscogsConfig, LastFmAlbumSeed, LastFmConfig,
 };
 use chorrosion_infrastructure::{
-    repositories::AlbumRepository, sqlite_adapters::SqliteAlbumRepository,
+    repositories::{AlbumRepository, Repository},
+    sqlite_adapters::{SqliteAlbumRepository, SqliteIndexerDefinitionRepository},
 };
 use chorrosion_metadata::discogs::DiscogsClient;
 use chorrosion_metadata::lastfm::LastFmClient;
@@ -587,17 +592,22 @@ impl Job for DiscogsMetadataRefreshJob {
     }
 }
 
-pub struct RssSyncJob;
-
-impl RssSyncJob {
-    pub fn new() -> Self {
-        Self
-    }
+pub struct RssSyncJob {
+    album_repository: Arc<SqliteAlbumRepository>,
+    indexer_repository: Arc<SqliteIndexerDefinitionRepository>,
+    scan_limit: i64,
 }
 
-impl Default for RssSyncJob {
-    fn default() -> Self {
-        Self::new()
+impl RssSyncJob {
+    pub fn new(
+        album_repository: Arc<SqliteAlbumRepository>,
+        indexer_repository: Arc<SqliteIndexerDefinitionRepository>,
+    ) -> Self {
+        Self {
+            album_repository,
+            indexer_repository,
+            scan_limit: 5000,
+        }
     }
 }
 
@@ -614,15 +624,134 @@ impl Job for RssSyncJob {
     async fn execute(&self, ctx: JobContext) -> Result<JobResult> {
         info!(target: "jobs", job_id = %ctx.job_id, "executing RSS sync job");
 
-        // TODO: Implement actual RSS polling logic
-        // - Fetch configured indexers from database
-        // - Poll each indexer's RSS feed
-        // - Parse and filter new releases
-        // - Create download tasks for monitored artists/albums
+        let indexers = match self.indexer_repository.list(5000, 0).await {
+            Ok(indexers) => indexers.into_iter().filter(|i| i.enabled).collect::<Vec<_>>(),
+            Err(error) => {
+                return Ok(JobResult::Failure {
+                    error: format!("failed to list configured indexers: {error}"),
+                    retry: true,
+                });
+            }
+        };
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        if indexers.is_empty() {
+            info!(target: "jobs", job_id = %ctx.job_id, "no enabled indexers configured; skipping RSS sync");
+            return Ok(JobResult::Success);
+        }
 
-        info!(target: "jobs", job_id = %ctx.job_id, "RSS sync completed successfully");
+        let wanted_titles = match collect_wanted_album_titles(&self.album_repository, self.scan_limit).await {
+            Ok(titles) => titles,
+            Err(error) => {
+                return Ok(JobResult::Failure {
+                    error: format!("failed to load wanted albums for RSS matching: {error}"),
+                    retry: true,
+                });
+            }
+        };
+
+        if wanted_titles.is_empty() {
+            info!(target: "jobs", job_id = %ctx.job_id, "no wanted albums to match; skipping RSS sync");
+            return Ok(JobResult::Success);
+        }
+
+        let mut indexers_polled: usize = 0;
+        let mut poll_failures: usize = 0;
+        let mut rss_items_seen: usize = 0;
+        let mut rss_items_matched: usize = 0;
+
+        for definition in indexers {
+            let protocol = match definition.protocol.parse::<IndexerProtocol>() {
+                Ok(protocol) => protocol,
+                Err(error) => {
+                    poll_failures += 1;
+                    warn!(
+                        target: "jobs",
+                        job_id = %ctx.job_id,
+                        indexer = %definition.name,
+                        protocol = %definition.protocol,
+                        error = %error,
+                        "skipping indexer with unsupported protocol"
+                    );
+                    continue;
+                }
+            };
+
+            let config = IndexerConfig {
+                name: definition.name.clone(),
+                base_url: definition.base_url.clone(),
+                protocol: protocol.clone(),
+                api_key: definition.api_key.clone(),
+                enabled: definition.enabled,
+            };
+
+            indexers_polled += 1;
+            let fetch_result = match protocol {
+                IndexerProtocol::Newznab => {
+                    let client = NewznabClient::new(config);
+                    client.fetch_rss_feed().await
+                }
+                IndexerProtocol::Torznab => {
+                    let client = TorznabClient::new(config);
+                    client.fetch_rss_feed().await
+                }
+                other => {
+                    poll_failures += 1;
+                    warn!(
+                        target: "jobs",
+                        job_id = %ctx.job_id,
+                        indexer = %definition.name,
+                        protocol = %other.as_str(),
+                        "RSS sync currently supports only newznab/torznab indexers"
+                    );
+                    continue;
+                }
+            };
+
+            match fetch_result {
+                Ok(items) => {
+                    let matched = count_rss_matches(&items, &wanted_titles);
+                    rss_items_seen += items.len();
+                    rss_items_matched += matched;
+                    info!(
+                        target: "jobs",
+                        job_id = %ctx.job_id,
+                        indexer = %definition.name,
+                        rss_items = items.len(),
+                        matched,
+                        "processed RSS feed for indexer"
+                    );
+                }
+                Err(error) => {
+                    poll_failures += 1;
+                    warn!(
+                        target: "jobs",
+                        job_id = %ctx.job_id,
+                        indexer = %definition.name,
+                        error = %error,
+                        "failed to fetch RSS feed from indexer"
+                    );
+                }
+            }
+        }
+
+        info!(
+            target: "jobs",
+            job_id = %ctx.job_id,
+            indexers_polled,
+            poll_failures,
+            rss_items_seen,
+            rss_items_matched,
+            wanted_album_count = wanted_titles.len(),
+            "RSS sync completed"
+        );
+
+        if indexers_polled > 0 && poll_failures == indexers_polled {
+            return Ok(JobResult::Failure {
+                error: "failed to fetch RSS feeds from all polled indexers".to_string(),
+                retry: true,
+            });
+        }
+
         Ok(JobResult::Success)
     }
 
@@ -633,6 +762,65 @@ impl Job for RssSyncJob {
     fn max_retries(&self) -> u32 {
         2
     }
+}
+
+async fn collect_wanted_album_titles(
+    album_repository: &SqliteAlbumRepository,
+    scan_limit: i64,
+) -> Result<HashSet<String>> {
+    let mut titles = HashSet::new();
+
+    let mut offset: i64 = 0;
+    loop {
+        let batch = album_repository
+            .list_wanted_without_tracks(scan_limit, offset)
+            .await?;
+        let batch_len = batch.len();
+        for album in batch {
+            titles.insert(normalize_match_key(&album.title));
+        }
+        if batch_len < scan_limit as usize {
+            break;
+        }
+        offset += scan_limit;
+    }
+
+    let mut offset: i64 = 0;
+    loop {
+        let batch = album_repository
+            .list_cutoff_unmet_albums(scan_limit, offset)
+            .await?;
+        let batch_len = batch.len();
+        for album in batch {
+            titles.insert(normalize_match_key(&album.title));
+        }
+        if batch_len < scan_limit as usize {
+            break;
+        }
+        offset += scan_limit;
+    }
+
+    Ok(titles)
+}
+
+fn count_rss_matches(
+    items: &[chorrosion_application::IndexerRssItem],
+    wanted_titles: &HashSet<String>,
+) -> usize {
+    items
+        .iter()
+        .filter(|item| {
+            let parsed = parse_release_title(&item.title);
+            parsed
+                .album
+                .as_ref()
+                .is_some_and(|album| wanted_titles.contains(&normalize_match_key(album)))
+        })
+        .count()
+}
+
+fn normalize_match_key(value: &str) -> String {
+    value.trim().to_lowercase()
 }
 
 /// Backlog search job - searches indexers for missing albums
@@ -1548,5 +1736,53 @@ mod tests {
             JobResult::Failure { retry, .. } => assert!(retry, "failure must be retriable"),
             other => panic!("expected Failure, got {other:?}"),
         }
+    }
+
+    // ── RssSyncJob tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_rss_match_count_matches_album_titles_from_parsed_release() {
+        let wanted = ["OK Computer", "In Rainbows"]
+            .into_iter()
+            .map(normalize_match_key)
+            .collect::<HashSet<_>>();
+
+        let items = vec![
+            chorrosion_application::IndexerRssItem {
+                title: "Radiohead - OK Computer FLAC".to_string(),
+                guid: None,
+                link: None,
+                published_at: None,
+                description: None,
+            },
+            chorrosion_application::IndexerRssItem {
+                title: "Somebody - Unrelated Album MP3 320".to_string(),
+                guid: None,
+                link: None,
+                published_at: None,
+                description: None,
+            },
+            chorrosion_application::IndexerRssItem {
+                title: "Radiohead - In Rainbows [2007]".to_string(),
+                guid: None,
+                link: None,
+                published_at: None,
+                description: None,
+            },
+        ];
+
+        assert_eq!(count_rss_matches(&items, &wanted), 2);
+    }
+
+    #[tokio::test]
+    async fn test_rss_sync_job_returns_success_when_no_indexers() {
+        let pool = make_migrated_pool().await;
+        let album_repo = Arc::new(SqliteAlbumRepository::new(pool.clone()));
+        let indexer_repo = Arc::new(SqliteIndexerDefinitionRepository::new(pool));
+        let job = RssSyncJob::new(album_repo, indexer_repo);
+        let ctx = JobContext::new("test-rss-no-indexers");
+
+        let result = job.execute(ctx).await.expect("execute should not Err");
+        assert!(matches!(result, JobResult::Success));
     }
 }

--- a/crates/chorrosion-scheduler/src/jobs.rs
+++ b/crates/chorrosion-scheduler/src/jobs.rs
@@ -598,6 +598,8 @@ pub struct RssSyncJob {
     scan_limit: i64,
 }
 
+const SUPPORTED_RSS_PROTOCOLS: &str = "newznab, torznab";
+
 impl RssSyncJob {
     pub fn new(
         album_repository: Arc<SqliteAlbumRepository>,
@@ -676,7 +678,7 @@ impl Job for RssSyncJob {
                         indexer = %definition.name,
                         protocol = %definition.protocol,
                         error = %error,
-                        "skipping indexer with invalid protocol"
+                        "skipping indexer: unrecognized protocol"
                     );
                     continue;
                 }
@@ -708,7 +710,8 @@ impl Job for RssSyncJob {
                         job_id = %ctx.job_id,
                         indexer = %definition.name,
                         protocol = %other.as_str(),
-                        "skipping indexer: unsupported RSS sync protocol (supported: newznab, torznab)"
+                        supported_protocols = %SUPPORTED_RSS_PROTOCOLS,
+                        "skipping indexer: unsupported RSS sync protocol"
                     );
                     continue;
                 }
@@ -756,9 +759,10 @@ impl Job for RssSyncJob {
 
         if indexers_polled == 0 && config_failures > 0 {
             return Ok(JobResult::Failure {
-                error:
-                    "no enabled indexers use a supported RSS protocol (supported: newznab, torznab)"
-                        .to_string(),
+                error: format!(
+                    "no enabled indexers use a supported RSS protocol (supported: {})",
+                    SUPPORTED_RSS_PROTOCOLS
+                ),
                 retry: false,
             });
         }
@@ -806,11 +810,13 @@ async fn collect_wanted_album_titles(
     Ok(titles)
 }
 
+/// Source query used to collect candidate album titles for RSS matching.
 enum WantedAlbumTitleSource {
     WantedWithoutTracks,
     CutoffUnmet,
 }
 
+/// Collect wanted album titles from a paginated repository query and append them to `titles`.
 async fn collect_titles_by_source(
     album_repository: &SqliteAlbumRepository,
     scan_limit: i64,

--- a/crates/chorrosion-scheduler/src/lib.rs
+++ b/crates/chorrosion-scheduler/src/lib.rs
@@ -5,7 +5,9 @@ pub mod registry;
 
 use anyhow::Result;
 use chorrosion_config::AppConfig;
-use chorrosion_infrastructure::sqlite_adapters::SqliteAlbumRepository;
+use chorrosion_infrastructure::sqlite_adapters::{
+    SqliteAlbumRepository, SqliteIndexerDefinitionRepository,
+};
 use registry::JobRegistry;
 use sqlx::SqlitePool;
 use std::sync::Arc;
@@ -39,8 +41,19 @@ impl Scheduler {
         info!(target: "scheduler", "registering background jobs");
 
         // RSS sync every 15 minutes
+        let rss_album_repository = Arc::new(SqliteAlbumRepository::new_with_threshold(
+            self.pool.clone(),
+            self.config.database.slow_query_threshold_ms,
+        ));
+        let rss_indexer_repository = Arc::new(SqliteIndexerDefinitionRepository::new(
+            self.pool.clone(),
+        ));
         self.registry
-            .register("rss-sync", RssSyncJob::new(), Schedule::Interval(15 * 60))
+            .register(
+                "rss-sync",
+                RssSyncJob::new(rss_album_repository, rss_indexer_repository),
+                Schedule::Interval(15 * 60),
+            )
             .await;
 
         // Backlog search every hour, reusing the caller-provided database pool


### PR DESCRIPTION
## Summary
Implements the next practical slice of the RSS sync enhancement by replacing the placeholder scheduler job with real RSS polling and matching behavior.

## What changed
- Implemented `RssSyncJob` execution flow in scheduler:
  - Loads enabled indexers from DB
  - Polls RSS feeds for supported protocols (`newznab`, `torznab`)
  - Parses release titles and matches RSS items to wanted album titles
  - Emits useful sync metrics via tracing logs
  - Returns retriable failure when all polled indexers fail
- Added helper functions for:
  - collecting wanted/cutoff-unmet album titles
  - release-title matching against RSS items
  - title normalization
- Wired scheduler registration to construct `RssSyncJob` with required repositories.
- Added scheduler tests:
  - release-title RSS matching behavior
  - success behavior when no indexers are configured
- Updated roadmap RSS sub-items:
  - parse RSS feeds from indexers ✓
  - match releases to wanted albums ✓
  - automatic grab logic remains pending
- Added lockfile update for the new scheduler dependency graph.

## Validation
- `cargo test -p chorrosion-scheduler`

## Issue Link
- Refs #33
