### PR TITLE
Add automatic RSS grab submission to RSS sync job

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -188,7 +188,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
 - [ ] RSS sync enhancement
   - [x] Parse RSS feeds from indexers ✓
   - [x] Match releases to wanted albums ✓
-  - [ ] Automatic grab logic
+  - [x] Automatic grab logic ✓
 
 ### 4.2 Download Client Integration
 

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -90,6 +90,7 @@ pub struct IndexerRssItem {
     pub title: String,
     pub guid: Option<String>,
     pub link: Option<String>,
+    pub download_url: Option<String>,
     pub published_at: Option<String>,
     pub description: Option<String>,
 }
@@ -525,12 +526,21 @@ pub fn parse_rss_feed(xml: &str) -> Result<Vec<IndexerRssItem>, IndexerError> {
         .channel
         .items
         .into_iter()
-        .map(|item| IndexerRssItem {
-            title: item.title,
-            guid: item.guid,
-            link: item.link,
-            published_at: parse_pub_date(item.pub_date),
-            description: item.description,
+        .map(|item| {
+            let download_url = item
+                .enclosure
+                .as_ref()
+                .and_then(|enclosure| enclosure.url.clone())
+                .or_else(|| item.link.clone());
+
+            IndexerRssItem {
+                download_url,
+                title: item.title,
+                guid: item.guid,
+                link: item.link,
+                published_at: parse_pub_date(item.pub_date),
+                description: item.description,
+            }
         })
         .collect())
 }
@@ -565,6 +575,7 @@ struct RssRawItem {
     title: String,
     guid: Option<String>,
     link: Option<String>,
+    enclosure: Option<SearchEnclosure>,
     #[serde(rename = "pubDate")]
     pub_date: Option<String>,
     description: Option<String>,
@@ -604,8 +615,35 @@ mod tests {
             Some("https://example.org/download/abc")
         );
         assert_eq!(
+            items[0].download_url.as_deref(),
+            Some("https://example.org/download/abc")
+        );
+        assert_eq!(
             items[0].published_at.as_deref(),
             Some("2026-02-25T10:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn parses_rss_items_preferring_enclosure_download_url() {
+        let xml = r#"
+            <rss>
+                <channel>
+                    <item>
+                        <title>Artist - Album FLAC</title>
+                        <guid>abc-123</guid>
+                        <link>https://example.org/details/abc</link>
+                        <enclosure url="magnet:?xt=urn:btih:rss123" length="123456789" type="application/x-bittorrent" />
+                    </item>
+                </channel>
+            </rss>
+        "#;
+
+        let items = parse_rss_feed(xml).expect("rss should parse");
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].download_url.as_deref(),
+            Some("magnet:?xt=urn:btih:rss123")
         );
     }
 

--- a/crates/chorrosion-scheduler/src/jobs.rs
+++ b/crates/chorrosion-scheduler/src/jobs.rs
@@ -3,8 +3,8 @@ use crate::job::{Job, JobContext, JobResult};
 use anyhow::Result;
 use chorrosion_application::{
     parse_release_title, AddTorrentRequest, DelugeClient, DownloadClient, IndexerClient,
-    IndexerConfig, IndexerProtocol, NewznabClient, NzbgetClient, QBittorrentClient,
-    SabnzbdClient, TorznabClient, TransmissionClient,
+    IndexerConfig, IndexerProtocol, NewznabClient, NzbgetClient, QBittorrentClient, SabnzbdClient,
+    TorznabClient, TransmissionClient,
 };
 use chorrosion_config::{
     CacheConfig, DiscogsAlbumSeed, DiscogsConfig, LastFmAlbumSeed, LastFmConfig,
@@ -668,16 +668,33 @@ impl Job for RssSyncJob {
             return Ok(JobResult::Success);
         }
 
-        let (active_download_client_name, active_download_client_category, mut active_download_client) =
-            match load_active_download_client(&self.download_client_repository).await {
-                Ok(client) => client,
-                Err(error) => {
-                    return Ok(JobResult::Failure {
-                        error: format!("failed to load download client for automatic RSS grabs: {error}"),
-                        retry: true,
-                    });
-                }
-            };
+        let (
+            active_download_client_name,
+            active_download_client_category,
+            mut active_download_client,
+        ) = match load_active_download_client(&self.download_client_repository).await {
+            Ok(client) => client,
+            Err(error) => {
+                return Ok(JobResult::Failure {
+                    error: format!(
+                        "failed to load download client for automatic RSS grabs: {error}"
+                    ),
+                    retry: true,
+                });
+            }
+        };
+
+        if let Some(client) = active_download_client.as_mut() {
+            if let Err(error) = client.test_connection().await {
+                return Ok(JobResult::Failure {
+                    error: format!(
+                        "failed to connect to active download client '{}' for automatic RSS grabs: {error}",
+                        active_download_client_name
+                    ),
+                    retry: true,
+                });
+            }
+        }
 
         let enabled_indexers = indexers.len();
         let mut indexers_polled: usize = 0;
@@ -688,7 +705,7 @@ impl Job for RssSyncJob {
         let mut grab_attempted: usize = 0;
         let mut grab_succeeded: usize = 0;
         let mut grab_failed: usize = 0;
-        let mut skipped_no_download_url: usize = 0;
+        let mut skipped_no_download_client: usize = 0;
         let mut skipped_duplicate_url: usize = 0;
         let mut seen_grab_urls: HashSet<String> = HashSet::new();
 
@@ -752,7 +769,7 @@ impl Job for RssSyncJob {
                     rss_items_matched += matched;
 
                     for candidate in candidates {
-                        if !seen_grab_urls.insert(candidate.download_url.clone()) {
+                        if !should_attempt_grab_url(&candidate.download_url, &mut seen_grab_urls) {
                             skipped_duplicate_url += 1;
                             continue;
                         }
@@ -799,7 +816,7 @@ impl Job for RssSyncJob {
                     }
 
                     if matched > 0 && active_download_client.is_none() {
-                        skipped_no_download_url += matched;
+                        skipped_no_download_client += matched;
                         warn!(
                             target: "jobs",
                             job_id = %ctx.job_id,
@@ -842,36 +859,21 @@ impl Job for RssSyncJob {
             grab_attempted,
             grab_succeeded,
             grab_failed,
-            skipped_no_download_url,
+            skipped_no_download_client,
             skipped_duplicate_url,
             wanted_album_count = wanted_titles.len(),
             download_client = %active_download_client_name,
             "RSS sync completed"
         );
 
-        if indexers_polled == 0 && config_failures > 0 {
-            return Ok(JobResult::Failure {
-                error: format!(
-                    "no enabled indexers use a supported RSS protocol (supported: {})",
-                    SUPPORTED_RSS_PROTOCOLS
-                ),
-                retry: false,
-            });
-        }
-
-        if indexers_polled > 0 && poll_failures == indexers_polled {
-            return Ok(JobResult::Failure {
-                error: "failed to fetch RSS feeds from all polled indexers".to_string(),
-                retry: true,
-            });
-        }
-
-        if grab_attempted > 0 && grab_failed == grab_attempted {
-            return Ok(JobResult::Failure {
-                error: "automatic RSS grab submission failed for all matched releases"
-                    .to_string(),
-                retry: true,
-            });
+        if let Some(failure) = rss_sync_terminal_failure(
+            indexers_polled,
+            config_failures,
+            poll_failures,
+            grab_attempted,
+            grab_failed,
+        ) {
+            return Ok(failure);
         }
 
         Ok(JobResult::Success)
@@ -971,7 +973,11 @@ fn collect_rss_grab_candidates(
                 return None;
             }
 
-            let download_url = item.link.as_deref()?.trim();
+            let download_url = item
+                .download_url
+                .as_deref()
+                .or(item.link.as_deref())?
+                .trim();
             if download_url.is_empty() {
                 return None;
             }
@@ -989,57 +995,98 @@ fn normalize_match_key(value: &str) -> String {
     value.trim().to_lowercase()
 }
 
+fn should_attempt_grab_url(download_url: &str, seen_grab_urls: &mut HashSet<String>) -> bool {
+    seen_grab_urls.insert(download_url.to_string())
+}
+
+fn rss_sync_terminal_failure(
+    indexers_polled: usize,
+    config_failures: usize,
+    poll_failures: usize,
+    grab_attempted: usize,
+    grab_failed: usize,
+) -> Option<JobResult> {
+    if indexers_polled == 0 && config_failures > 0 {
+        return Some(JobResult::Failure {
+            error: format!(
+                "no enabled indexers use a supported RSS protocol (supported: {})",
+                SUPPORTED_RSS_PROTOCOLS
+            ),
+            retry: false,
+        });
+    }
+
+    if indexers_polled > 0 && poll_failures == indexers_polled {
+        return Some(JobResult::Failure {
+            error: "failed to fetch RSS feeds from all polled indexers".to_string(),
+            retry: true,
+        });
+    }
+
+    if grab_attempted > 0 && grab_failed == grab_attempted {
+        return Some(JobResult::Failure {
+            error: "automatic RSS grab submission failed for all matched releases".to_string(),
+            retry: true,
+        });
+    }
+
+    None
+}
+
 async fn load_active_download_client(
     download_client_repository: &SqliteDownloadClientDefinitionRepository,
 ) -> Result<(String, Option<String>, Option<Box<dyn DownloadClient>>)> {
     let definitions = download_client_repository.list(5000, 0).await?;
-    let active = definitions.into_iter().find(|definition| definition.enabled);
+    for definition in definitions
+        .into_iter()
+        .filter(|definition| definition.enabled)
+    {
+        let name = definition.name.clone();
+        let category = definition.category.clone();
+        let client_type = definition.client_type.trim().to_lowercase();
 
-    let Some(definition) = active else {
-        return Ok(("<none>".to_string(), None, None));
-    };
+        let client: Option<Box<dyn DownloadClient>> = match client_type.as_str() {
+            "qbittorrent" => Some(Box::new(QBittorrentClient::new(
+                definition.base_url.clone(),
+                definition.username.clone(),
+                definition.password_encrypted.clone(),
+            ))),
+            "transmission" => Some(Box::new(TransmissionClient::new(
+                definition.base_url.clone(),
+                definition.username.clone(),
+                definition.password_encrypted.clone(),
+            ))),
+            "deluge" => Some(Box::new(DelugeClient::new(
+                definition.base_url.clone(),
+                definition.password_encrypted.clone(),
+            ))),
+            "sabnzbd" => Some(Box::new(SabnzbdClient::new(
+                definition.base_url.clone(),
+                definition.password_encrypted.clone(),
+            ))),
+            "nzbget" => Some(Box::new(NzbgetClient::new(
+                definition.base_url.clone(),
+                definition.username.clone(),
+                definition.password_encrypted.clone(),
+            ))),
+            other => {
+                warn!(
+                    target: "jobs",
+                    download_client = %name,
+                    client_type = %other,
+                    supported_client_types = %SUPPORTED_GRAB_CLIENTS,
+                    "configured download client type is not supported for automatic RSS grabs"
+                );
+                None
+            }
+        };
 
-    let name = definition.name.clone();
-    let category = definition.category.clone();
-    let client_type = definition.client_type.trim().to_lowercase();
-
-    let client: Option<Box<dyn DownloadClient>> = match client_type.as_str() {
-        "qbittorrent" => Some(Box::new(QBittorrentClient::new(
-            definition.base_url.clone(),
-            definition.username.clone(),
-            definition.password_encrypted.clone(),
-        ))),
-        "transmission" => Some(Box::new(TransmissionClient::new(
-            definition.base_url.clone(),
-            definition.username.clone(),
-            definition.password_encrypted.clone(),
-        ))),
-        "deluge" => Some(Box::new(DelugeClient::new(
-            definition.base_url.clone(),
-            definition.password_encrypted.clone(),
-        ))),
-        "sabnzbd" => Some(Box::new(SabnzbdClient::new(
-            definition.base_url.clone(),
-            definition.password_encrypted.clone(),
-        ))),
-        "nzbget" => Some(Box::new(NzbgetClient::new(
-            definition.base_url.clone(),
-            definition.username.clone(),
-            definition.password_encrypted.clone(),
-        ))),
-        other => {
-            warn!(
-                target: "jobs",
-                download_client = %name,
-                client_type = %other,
-                supported_client_types = %SUPPORTED_GRAB_CLIENTS,
-                "configured download client type is not supported for automatic RSS grabs"
-            );
-            None
+        if client.is_some() {
+            return Ok((name, category, client));
         }
-    };
+    }
 
-    Ok((name, category, client))
+    Ok(("<none>".to_string(), None, None))
 }
 
 /// Backlog search job - searches indexers for missing albums
@@ -1971,6 +2018,7 @@ mod tests {
                 title: "Radiohead - OK Computer FLAC".to_string(),
                 guid: None,
                 link: Some("magnet:?xt=urn:btih:okc".to_string()),
+                download_url: Some("magnet:?xt=urn:btih:okc".to_string()),
                 published_at: None,
                 description: None,
             },
@@ -1978,6 +2026,7 @@ mod tests {
                 title: "Somebody - Unrelated Album MP3 320".to_string(),
                 guid: None,
                 link: Some("magnet:?xt=urn:btih:other".to_string()),
+                download_url: Some("magnet:?xt=urn:btih:other".to_string()),
                 published_at: None,
                 description: None,
             },
@@ -1985,6 +2034,7 @@ mod tests {
                 title: "Radiohead - In Rainbows [2007]".to_string(),
                 guid: None,
                 link: Some("https://example.test/download/nzb123".to_string()),
+                download_url: Some("https://example.test/download/nzb123".to_string()),
                 published_at: None,
                 description: None,
             },
@@ -1992,6 +2042,7 @@ mod tests {
                 title: "Radiohead - In Rainbows [Alt]".to_string(),
                 guid: None,
                 link: None,
+                download_url: None,
                 published_at: None,
                 description: None,
             },
@@ -2001,6 +2052,127 @@ mod tests {
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].album_title, "OK Computer");
         assert_eq!(candidates[1].album_title, "In Rainbows");
+    }
+
+    #[test]
+    fn test_collect_rss_grab_candidates_prefers_download_url_over_link() {
+        let wanted = ["OK Computer"]
+            .into_iter()
+            .map(normalize_match_key)
+            .collect::<HashSet<_>>();
+
+        let items = vec![chorrosion_application::IndexerRssItem {
+            title: "Radiohead - OK Computer FLAC".to_string(),
+            guid: None,
+            link: Some("https://example.test/details/ok-computer".to_string()),
+            download_url: Some("magnet:?xt=urn:btih:okc".to_string()),
+            published_at: None,
+            description: None,
+        }];
+
+        let candidates = collect_rss_grab_candidates(&items, &wanted);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].download_url, "magnet:?xt=urn:btih:okc");
+    }
+
+    #[test]
+    fn test_should_attempt_grab_url_deduplicates() {
+        let mut seen = HashSet::new();
+        assert!(should_attempt_grab_url(
+            "magnet:?xt=urn:btih:one",
+            &mut seen
+        ));
+        assert!(!should_attempt_grab_url(
+            "magnet:?xt=urn:btih:one",
+            &mut seen
+        ));
+        assert!(should_attempt_grab_url(
+            "magnet:?xt=urn:btih:two",
+            &mut seen
+        ));
+    }
+
+    #[test]
+    fn test_rss_sync_terminal_failure_all_grabs_failed_is_retriable() {
+        let outcome = rss_sync_terminal_failure(1, 0, 0, 2, 2);
+        match outcome {
+            Some(JobResult::Failure { retry, error }) => {
+                assert!(retry, "all failed submissions should be retriable");
+                assert!(
+                    error.contains("automatic RSS grab submission failed"),
+                    "unexpected error: {error}"
+                );
+            }
+            other => panic!("expected retriable failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_active_download_client_returns_none_when_no_enabled_clients() {
+        let pool = make_migrated_pool().await;
+        let repository = SqliteDownloadClientDefinitionRepository::new(pool.clone());
+        let definition_id = Uuid::new_v4().to_string();
+
+        sqlx::query(
+            "INSERT INTO download_client_definitions (id, name, client_type, base_url, enabled) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&definition_id)
+        .bind("Disabled qBittorrent")
+        .bind("qbittorrent")
+        .bind("http://localhost:8080")
+        .bind(false)
+        .execute(&pool)
+        .await
+        .expect("insert disabled download client failed");
+
+        let (name, category, client) = load_active_download_client(&repository)
+            .await
+            .expect("load active download client should succeed");
+
+        assert_eq!(name, "<none>");
+        assert_eq!(category, None);
+        assert!(client.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_load_active_download_client_skips_unsupported_enabled_client_type() {
+        let pool = make_migrated_pool().await;
+        let repository = SqliteDownloadClientDefinitionRepository::new(pool.clone());
+        let unsupported_id = Uuid::new_v4().to_string();
+        let supported_id = Uuid::new_v4().to_string();
+
+        sqlx::query(
+            "INSERT INTO download_client_definitions (id, name, client_type, base_url, enabled) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&unsupported_id)
+        .bind("A Unsupported")
+        .bind("unknown-client")
+        .bind("http://localhost:9999")
+        .bind(true)
+        .execute(&pool)
+        .await
+        .expect("insert unsupported download client failed");
+
+        sqlx::query(
+            "INSERT INTO download_client_definitions (id, name, client_type, base_url, enabled, category) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&supported_id)
+        .bind("B qBittorrent")
+        .bind("qbittorrent")
+        .bind("http://localhost:8080")
+        .bind(true)
+        .bind("music")
+        .execute(&pool)
+        .await
+        .expect("insert supported download client failed");
+
+        let (name, category, client) = load_active_download_client(&repository)
+            .await
+            .expect("load active download client should succeed");
+
+        assert_eq!(name, "B qBittorrent");
+        assert_eq!(category.as_deref(), Some("music"));
+        assert!(client.is_some());
     }
 
     #[tokio::test]

--- a/crates/chorrosion-scheduler/src/jobs.rs
+++ b/crates/chorrosion-scheduler/src/jobs.rs
@@ -2,15 +2,19 @@
 use crate::job::{Job, JobContext, JobResult};
 use anyhow::Result;
 use chorrosion_application::{
-    parse_release_title, IndexerClient, IndexerConfig, IndexerProtocol, NewznabClient,
-    TorznabClient,
+    parse_release_title, AddTorrentRequest, DelugeClient, DownloadClient, IndexerClient,
+    IndexerConfig, IndexerProtocol, NewznabClient, NzbgetClient, QBittorrentClient,
+    SabnzbdClient, TorznabClient, TransmissionClient,
 };
 use chorrosion_config::{
     CacheConfig, DiscogsAlbumSeed, DiscogsConfig, LastFmAlbumSeed, LastFmConfig,
 };
 use chorrosion_infrastructure::{
     repositories::{AlbumRepository, Repository},
-    sqlite_adapters::{SqliteAlbumRepository, SqliteIndexerDefinitionRepository},
+    sqlite_adapters::{
+        SqliteAlbumRepository, SqliteDownloadClientDefinitionRepository,
+        SqliteIndexerDefinitionRepository,
+    },
 };
 use chorrosion_metadata::discogs::DiscogsClient;
 use chorrosion_metadata::lastfm::LastFmClient;
@@ -595,19 +599,23 @@ impl Job for DiscogsMetadataRefreshJob {
 pub struct RssSyncJob {
     album_repository: Arc<SqliteAlbumRepository>,
     indexer_repository: Arc<SqliteIndexerDefinitionRepository>,
+    download_client_repository: Arc<SqliteDownloadClientDefinitionRepository>,
     scan_limit: i64,
 }
 
 const SUPPORTED_RSS_PROTOCOLS: &str = "newznab, torznab";
+const SUPPORTED_GRAB_CLIENTS: &str = "qbittorrent, transmission, deluge, sabnzbd, nzbget";
 
 impl RssSyncJob {
     pub fn new(
         album_repository: Arc<SqliteAlbumRepository>,
         indexer_repository: Arc<SqliteIndexerDefinitionRepository>,
+        download_client_repository: Arc<SqliteDownloadClientDefinitionRepository>,
     ) -> Self {
         Self {
             album_repository,
             indexer_repository,
+            download_client_repository,
             scan_limit: 5000,
         }
     }
@@ -660,12 +668,29 @@ impl Job for RssSyncJob {
             return Ok(JobResult::Success);
         }
 
+        let (active_download_client_name, active_download_client_category, mut active_download_client) =
+            match load_active_download_client(&self.download_client_repository).await {
+                Ok(client) => client,
+                Err(error) => {
+                    return Ok(JobResult::Failure {
+                        error: format!("failed to load download client for automatic RSS grabs: {error}"),
+                        retry: true,
+                    });
+                }
+            };
+
         let enabled_indexers = indexers.len();
         let mut indexers_polled: usize = 0;
         let mut poll_failures: usize = 0;
         let mut config_failures: usize = 0;
         let mut rss_items_seen: usize = 0;
         let mut rss_items_matched: usize = 0;
+        let mut grab_attempted: usize = 0;
+        let mut grab_succeeded: usize = 0;
+        let mut grab_failed: usize = 0;
+        let mut skipped_no_download_url: usize = 0;
+        let mut skipped_duplicate_url: usize = 0;
+        let mut seen_grab_urls: HashSet<String> = HashSet::new();
 
         for definition in indexers {
             let protocol = match definition.protocol.parse::<IndexerProtocol>() {
@@ -721,9 +746,68 @@ impl Job for RssSyncJob {
 
             match fetch_result {
                 Ok(items) => {
-                    let matched = count_rss_matches(&items, &wanted_titles);
+                    let candidates = collect_rss_grab_candidates(&items, &wanted_titles);
+                    let matched = candidates.len();
                     rss_items_seen += items.len();
                     rss_items_matched += matched;
+
+                    for candidate in candidates {
+                        if !seen_grab_urls.insert(candidate.download_url.clone()) {
+                            skipped_duplicate_url += 1;
+                            continue;
+                        }
+
+                        let Some(client) = active_download_client.as_mut() else {
+                            break;
+                        };
+
+                        grab_attempted += 1;
+                        let add_result = client
+                            .add_torrent(AddTorrentRequest {
+                                torrent_or_magnet: candidate.download_url.clone(),
+                                category: active_download_client_category.clone(),
+                            })
+                            .await;
+
+                        match add_result {
+                            Ok(_) => {
+                                grab_succeeded += 1;
+                                info!(
+                                    target: "jobs",
+                                    job_id = %ctx.job_id,
+                                    indexer = %definition.name,
+                                    release_title = %candidate.item_title,
+                                    album = %candidate.album_title,
+                                    download_client = %active_download_client_name,
+                                    "submitted automatic RSS grab"
+                                );
+                            }
+                            Err(error) => {
+                                grab_failed += 1;
+                                warn!(
+                                    target: "jobs",
+                                    job_id = %ctx.job_id,
+                                    indexer = %definition.name,
+                                    release_title = %candidate.item_title,
+                                    album = %candidate.album_title,
+                                    download_client = %active_download_client_name,
+                                    error = %error,
+                                    "failed to submit automatic RSS grab"
+                                );
+                            }
+                        }
+                    }
+
+                    if matched > 0 && active_download_client.is_none() {
+                        skipped_no_download_url += matched;
+                        warn!(
+                            target: "jobs",
+                            job_id = %ctx.job_id,
+                            matched,
+                            "RSS matches found but no enabled/usable download client configured; skipping automatic grab"
+                        );
+                    }
+
                     info!(
                         target: "jobs",
                         job_id = %ctx.job_id,
@@ -755,7 +839,13 @@ impl Job for RssSyncJob {
             config_failures,
             rss_items_seen,
             rss_items_matched,
+            grab_attempted,
+            grab_succeeded,
+            grab_failed,
+            skipped_no_download_url,
+            skipped_duplicate_url,
             wanted_album_count = wanted_titles.len(),
+            download_client = %active_download_client_name,
             "RSS sync completed"
         );
 
@@ -772,6 +862,14 @@ impl Job for RssSyncJob {
         if indexers_polled > 0 && poll_failures == indexers_polled {
             return Ok(JobResult::Failure {
                 error: "failed to fetch RSS feeds from all polled indexers".to_string(),
+                retry: true,
+            });
+        }
+
+        if grab_attempted > 0 && grab_failed == grab_attempted {
+            return Ok(JobResult::Failure {
+                error: "automatic RSS grab submission failed for all matched releases"
+                    .to_string(),
                 retry: true,
             });
         }
@@ -853,24 +951,95 @@ async fn collect_titles_by_source(
     Ok(())
 }
 
-fn count_rss_matches(
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RssGrabCandidate {
+    item_title: String,
+    album_title: String,
+    download_url: String,
+}
+
+fn collect_rss_grab_candidates(
     items: &[chorrosion_application::IndexerRssItem],
     wanted_titles: &HashSet<String>,
-) -> usize {
+) -> Vec<RssGrabCandidate> {
     items
         .iter()
-        .filter(|item| {
+        .filter_map(|item| {
             let parsed = parse_release_title(&item.title);
-            parsed
-                .album
-                .as_ref()
-                .is_some_and(|album| wanted_titles.contains(&normalize_match_key(album)))
+            let album_title = parsed.album.as_deref()?;
+            if !wanted_titles.contains(&normalize_match_key(album_title)) {
+                return None;
+            }
+
+            let download_url = item.link.as_deref()?.trim();
+            if download_url.is_empty() {
+                return None;
+            }
+
+            Some(RssGrabCandidate {
+                item_title: item.title.clone(),
+                album_title: album_title.to_string(),
+                download_url: download_url.to_string(),
+            })
         })
-        .count()
+        .collect()
 }
 
 fn normalize_match_key(value: &str) -> String {
     value.trim().to_lowercase()
+}
+
+async fn load_active_download_client(
+    download_client_repository: &SqliteDownloadClientDefinitionRepository,
+) -> Result<(String, Option<String>, Option<Box<dyn DownloadClient>>)> {
+    let definitions = download_client_repository.list(5000, 0).await?;
+    let active = definitions.into_iter().find(|definition| definition.enabled);
+
+    let Some(definition) = active else {
+        return Ok(("<none>".to_string(), None, None));
+    };
+
+    let name = definition.name.clone();
+    let category = definition.category.clone();
+    let client_type = definition.client_type.trim().to_lowercase();
+
+    let client: Option<Box<dyn DownloadClient>> = match client_type.as_str() {
+        "qbittorrent" => Some(Box::new(QBittorrentClient::new(
+            definition.base_url.clone(),
+            definition.username.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        "transmission" => Some(Box::new(TransmissionClient::new(
+            definition.base_url.clone(),
+            definition.username.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        "deluge" => Some(Box::new(DelugeClient::new(
+            definition.base_url.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        "sabnzbd" => Some(Box::new(SabnzbdClient::new(
+            definition.base_url.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        "nzbget" => Some(Box::new(NzbgetClient::new(
+            definition.base_url.clone(),
+            definition.username.clone(),
+            definition.password_encrypted.clone(),
+        ))),
+        other => {
+            warn!(
+                target: "jobs",
+                download_client = %name,
+                client_type = %other,
+                supported_client_types = %SUPPORTED_GRAB_CLIENTS,
+                "configured download client type is not supported for automatic RSS grabs"
+            );
+            None
+        }
+    };
+
+    Ok((name, category, client))
 }
 
 /// Backlog search job - searches indexers for missing albums
@@ -1791,7 +1960,7 @@ mod tests {
     // ── RssSyncJob tests ────────────────────────────────────────────────────
 
     #[test]
-    fn test_rss_match_count_matches_album_titles_from_parsed_release() {
+    fn test_collect_rss_grab_candidates_matches_album_titles_from_parsed_release() {
         let wanted = ["OK Computer", "In Rainbows"]
             .into_iter()
             .map(normalize_match_key)
@@ -1801,19 +1970,26 @@ mod tests {
             chorrosion_application::IndexerRssItem {
                 title: "Radiohead - OK Computer FLAC".to_string(),
                 guid: None,
-                link: None,
+                link: Some("magnet:?xt=urn:btih:okc".to_string()),
                 published_at: None,
                 description: None,
             },
             chorrosion_application::IndexerRssItem {
                 title: "Somebody - Unrelated Album MP3 320".to_string(),
                 guid: None,
-                link: None,
+                link: Some("magnet:?xt=urn:btih:other".to_string()),
                 published_at: None,
                 description: None,
             },
             chorrosion_application::IndexerRssItem {
                 title: "Radiohead - In Rainbows [2007]".to_string(),
+                guid: None,
+                link: Some("https://example.test/download/nzb123".to_string()),
+                published_at: None,
+                description: None,
+            },
+            chorrosion_application::IndexerRssItem {
+                title: "Radiohead - In Rainbows [Alt]".to_string(),
                 guid: None,
                 link: None,
                 published_at: None,
@@ -1821,15 +1997,19 @@ mod tests {
             },
         ];
 
-        assert_eq!(count_rss_matches(&items, &wanted), 2);
+        let candidates = collect_rss_grab_candidates(&items, &wanted);
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].album_title, "OK Computer");
+        assert_eq!(candidates[1].album_title, "In Rainbows");
     }
 
     #[tokio::test]
     async fn test_rss_sync_job_returns_success_when_no_indexers() {
         let pool = make_migrated_pool().await;
         let album_repo = Arc::new(SqliteAlbumRepository::new(pool.clone()));
-        let indexer_repo = Arc::new(SqliteIndexerDefinitionRepository::new(pool));
-        let job = RssSyncJob::new(album_repo, indexer_repo);
+        let indexer_repo = Arc::new(SqliteIndexerDefinitionRepository::new(pool.clone()));
+        let download_repo = Arc::new(SqliteDownloadClientDefinitionRepository::new(pool));
+        let job = RssSyncJob::new(album_repo, indexer_repo, download_repo);
         let ctx = JobContext::new("test-rss-no-indexers");
 
         let result = job.execute(ctx).await.expect("execute should not Err");
@@ -1878,8 +2058,9 @@ mod tests {
         .expect("insert indexer failed");
 
         let album_repo = Arc::new(SqliteAlbumRepository::new(pool.clone()));
-        let indexer_repo = Arc::new(SqliteIndexerDefinitionRepository::new(pool));
-        let job = RssSyncJob::new(album_repo, indexer_repo);
+        let indexer_repo = Arc::new(SqliteIndexerDefinitionRepository::new(pool.clone()));
+        let download_repo = Arc::new(SqliteDownloadClientDefinitionRepository::new(pool));
+        let job = RssSyncJob::new(album_repo, indexer_repo, download_repo);
         let ctx = JobContext::new("test-rss-unsupported-protocols");
 
         let result = job.execute(ctx).await.expect("execute should not Err");

--- a/crates/chorrosion-scheduler/src/lib.rs
+++ b/crates/chorrosion-scheduler/src/lib.rs
@@ -6,7 +6,8 @@ pub mod registry;
 use anyhow::Result;
 use chorrosion_config::AppConfig;
 use chorrosion_infrastructure::sqlite_adapters::{
-    SqliteAlbumRepository, SqliteIndexerDefinitionRepository,
+    SqliteAlbumRepository, SqliteDownloadClientDefinitionRepository,
+    SqliteIndexerDefinitionRepository,
 };
 use registry::JobRegistry;
 use sqlx::SqlitePool;
@@ -48,10 +49,17 @@ impl Scheduler {
         let rss_indexer_repository = Arc::new(SqliteIndexerDefinitionRepository::new(
             self.pool.clone(),
         ));
+        let rss_download_client_repository = Arc::new(
+            SqliteDownloadClientDefinitionRepository::new(self.pool.clone()),
+        );
         self.registry
             .register(
                 "rss-sync",
-                RssSyncJob::new(rss_album_repository, rss_indexer_repository),
+                RssSyncJob::new(
+                    rss_album_repository,
+                    rss_indexer_repository,
+                    rss_download_client_repository,
+                ),
                 Schedule::Interval(15 * 60),
             )
             .await;


### PR DESCRIPTION
## Summary
- implement automatic RSS grab submission in `RssSyncJob` for matched wanted-album releases
- load and instantiate the first enabled download client definition for supported client types
- submit matched RSS candidates via `add_torrent` with configured category and deduplicate repeated URLs
- add grab outcome metrics/logging and retriable failure when all grab submissions fail
- wire scheduler registration to provide the download-client repository to the RSS job
- update scheduler tests for candidate extraction and constructor wiring
- mark roadmap item complete for RSS automatic grab logic

## Validation
- `cargo test -p chorrosion-scheduler`

Refs #4