### PR TITLE
Add Gazelle music-specific search via browse action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Cache vcpkg chromaprint (Windows)
         if: runner.os == 'Windows'
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -180,7 +180,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Cache vcpkg chromaprint (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
 
       - name: Cache vcpkg chromaprint (Windows)
         if: runner.os == 'Windows'
@@ -95,7 +100,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -146,7 +156,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -180,7 +195,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
 
       - name: Cache vcpkg chromaprint (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
 
       - name: Cache vcpkg chromaprint (Windows)
         if: runner.os == 'Windows'
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -180,7 +180,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
 
       - name: Cache vcpkg chromaprint (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
 
       - name: Install chromaprint (Ubuntu)
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
 
       - name: Install chromaprint (Ubuntu)
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install chromaprint (Ubuntu)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
@@ -39,7 +44,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
       - name: Install cargo-deny
         run: cargo install --locked cargo-deny
       - name: Run cargo-deny (warn on unmaintained)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
       - name: Install cargo-deny
         run: cargo install --locked cargo-deny
       - name: Run cargo-deny (warn on unmaintained)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-deny
         run: cargo install --locked cargo-deny
       - name: Run cargo-deny (warn on unmaintained)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,7 +24,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add clippy rustfmt --toolchain stable
+          rustc --version
+          cargo --version
 
       - name: Cache vcpkg chromaprint and FFmpeg (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7
 
       - name: Cache vcpkg chromaprint and FFmpeg (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Cache vcpkg chromaprint and FFmpeg (Windows)
         if: runner.os == 'Windows'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -159,7 +159,7 @@ _(See design: [Matching Strategy](DESIGN.md#matching-strategy-musicbrainz))_
   - [x] Magnet link support ✓
 - [ ] Gazelle protocol client (optional)
   - [x] API authentication ✓
-  - [ ] Music-specific search
+  - [x] Music-specific search ✓
 
 ### 3.3 Release Parsing
 

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -327,21 +327,23 @@ impl IndexerClient for GazelleClient {
     async fn detect_capabilities(&self) -> Result<IndexerCapabilities, IndexerError> {
         execute_gazelle_request(&self.client, &self.config, "index", None).await?;
         Ok(IndexerCapabilities {
-            supports_search: false,
+            supports_search: true,
             supports_rss: false,
             supports_capabilities_detection: true,
-            supports_categories: false,
-            supported_categories: Vec::new(),
+            supports_categories: true,
+            supported_categories: vec![
+                "music".to_string(),
+                "audio/flac".to_string(),
+                "audio/mp3".to_string(),
+            ],
         })
     }
 
     async fn search(
         &self,
-        _query: &IndexerSearchQuery,
+        query: &IndexerSearchQuery,
     ) -> Result<Vec<IndexerSearchResult>, IndexerError> {
-        Err(IndexerError::Unsupported(
-            "gazelle music-specific search is not implemented yet".to_string(),
-        ))
+        execute_gazelle_search(&self.client, &self.config, query).await
     }
 
     async fn fetch_rss_feed(&self) -> Result<Vec<IndexerRssItem>, IndexerError> {
@@ -677,6 +679,172 @@ fn parse_pub_date(value: Option<String>) -> Option<String> {
     Some(date)
 }
 
+// ── Gazelle JSON types ────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct GazelleResponse<T> {
+    status: String,
+    response: Option<T>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GazelleBrowseResponse {
+    #[serde(default)]
+    results: Vec<GazelleSearchGroup>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GazelleSearchGroup {
+    group_id: Option<u64>,
+    group_name: Option<String>,
+    artist: Option<String>,
+    group_year: Option<u32>,
+    #[serde(default)]
+    torrents: Vec<GazelleTorrent>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GazelleTorrent {
+    torrent_id: Option<u64>,
+    format: Option<String>,
+    encoding: Option<String>,
+    media: Option<String>,
+    size: Option<u64>,
+    seeders: Option<u32>,
+    leechers: Option<u32>,
+}
+
+async fn execute_gazelle_search(
+    client: &Client,
+    config: &IndexerConfig,
+    query: &IndexerSearchQuery,
+) -> Result<Vec<IndexerSearchResult>, IndexerError> {
+    let mut params: Vec<(&str, String)> = Vec::new();
+
+    if !query.query.trim().is_empty() {
+        params.push(("searchstr", query.query.trim().to_string()));
+    }
+
+    if let Some(limit) = query.limit {
+        params.push(("results", limit.to_string()));
+    }
+
+    // Map category to Gazelle encoding filter
+    if let Some(category) = query.category.as_deref() {
+        let normalized = category.trim().to_lowercase();
+        if normalized.contains("flac") || normalized == "audio/flac" {
+            params.push(("format", "FLAC".to_string()));
+        } else if normalized.contains("mp3") || normalized == "audio/mp3" {
+            params.push(("format", "MP3".to_string()));
+        }
+    }
+
+    let body = execute_gazelle_request(client, config, "browse", Some(params)).await?;
+
+    let parsed: GazelleResponse<GazelleBrowseResponse> = serde_json::from_str(&body)
+        .map_err(|error| IndexerError::RssParse(format!("gazelle JSON parse error: {error}")))?;
+
+    if parsed.status != "success" {
+        return Err(IndexerError::Request(format!(
+            "gazelle search returned status: {}",
+            parsed.status
+        )));
+    }
+
+    let groups = parsed.response.map(|r| r.results).unwrap_or_default();
+
+    let base_url = config.base_url.trim_end_matches('/').to_string();
+    let mut results = Vec::new();
+
+    for group in groups {
+        let artist = group.artist.as_deref().unwrap_or("");
+        let album = group.group_name.as_deref().unwrap_or("");
+        let year = group.group_year.unwrap_or(0);
+        let had_torrents = !group.torrents.is_empty();
+
+        for torrent in group.torrents {
+            let format = torrent.format.as_deref().unwrap_or("");
+            let encoding = torrent.encoding.as_deref().unwrap_or("");
+            let media = torrent.media.as_deref().unwrap_or("");
+
+            let title = build_gazelle_title(artist, album, year, format, encoding, media);
+
+            let download_url = torrent
+                .torrent_id
+                .map(|id| format!("{base_url}/torrents.php?action=download&id={id}"));
+
+            let guid = torrent
+                .torrent_id
+                .map(|id| format!("{}-{}", group.group_id.unwrap_or(0), id));
+
+            results.push(IndexerSearchResult {
+                title,
+                guid,
+                download_url,
+                published_at: None,
+                size_bytes: torrent.size,
+                seeders: torrent.seeders,
+                leechers: torrent.leechers,
+            });
+        }
+
+        // If the group has no torrent entries, emit one row for the group itself
+        if !had_torrents {
+            let title = build_gazelle_title(artist, album, year, "", "", "");
+            let guid = group.group_id.map(|id| id.to_string());
+            results.push(IndexerSearchResult {
+                title,
+                guid,
+                download_url: group
+                    .group_id
+                    .map(|id| format!("{base_url}/torrents.php?id={id}")),
+                published_at: None,
+                size_bytes: None,
+                seeders: None,
+                leechers: None,
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+fn build_gazelle_title(
+    artist: &str,
+    album: &str,
+    year: u32,
+    format: &str,
+    encoding: &str,
+    media: &str,
+) -> String {
+    let mut title = if artist.is_empty() {
+        album.to_string()
+    } else {
+        format!("{artist} - {album}")
+    };
+    let mut tags = Vec::new();
+    if year > 0 {
+        tags.push(year.to_string());
+    }
+    if !format.is_empty() {
+        tags.push(format.to_string());
+    }
+    if !encoding.is_empty() && encoding != format {
+        tags.push(encoding.to_string());
+    }
+    if !media.is_empty() {
+        tags.push(media.to_string());
+    }
+    if !tags.is_empty() {
+        title = format!("{title} [{}]", tags.join(" / "));
+    }
+    title
+}
+
+// ── XML / RSS helpers ─────────────────────────────────────────────────────────
+
 #[derive(Debug, Deserialize)]
 struct RssEnvelope {
     channel: RssChannel,
@@ -964,7 +1132,7 @@ mod tests {
 
         assert!(result.success);
         let capabilities = result.capabilities.expect("capabilities should be present");
-        assert!(!capabilities.supports_search);
+        assert!(capabilities.supports_search);
         assert!(!capabilities.supports_rss);
     }
 
@@ -985,5 +1153,137 @@ mod tests {
 
         assert!(matches!(error, super::IndexerError::Request(_)));
         assert!(error.to_string().contains("requires an api_key"));
+    }
+
+    #[tokio::test]
+    async fn gazelle_search_returns_results_with_auth_headers() {
+        let server = MockServer::start().await;
+
+        let response_body = r#"
+        {
+            "status": "success",
+            "response": {
+                "results": [
+                    {
+                        "groupId": 100,
+                        "groupName": "OK Computer",
+                        "artist": "Radiohead",
+                        "groupYear": 1997,
+                        "torrents": [
+                            {
+                                "torrentId": 200,
+                                "format": "FLAC",
+                                "encoding": "Lossless",
+                                "media": "WEB",
+                                "size": 300000000,
+                                "seeders": 15,
+                                "leechers": 2
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+        "#;
+
+        Mock::given(method("GET"))
+            .and(path("/ajax.php"))
+            .and(query_param("action", "browse"))
+            .and(query_param("searchstr", "radiohead"))
+            .and(query_param("format", "FLAC"))
+            .and(header("authorization", "Bearer secret"))
+            .and(header("x-api-key", "secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_body))
+            .mount(&server)
+            .await;
+
+        let client = GazelleClient::new(IndexerConfig {
+            name: "test-gazelle".to_string(),
+            base_url: server.uri(),
+            protocol: IndexerProtocol::Gazelle,
+            api_key: Some("secret".to_string()),
+            enabled: true,
+        });
+
+        let results = client
+            .search(&IndexerSearchQuery {
+                query: "radiohead".to_string(),
+                category: Some("audio/flac".to_string()),
+                limit: None,
+                offset: None,
+            })
+            .await
+            .expect("gazelle search should succeed");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].title,
+            "Radiohead - OK Computer [1997 / FLAC / Lossless / WEB]"
+        );
+        assert_eq!(results[0].guid.as_deref(), Some("100-200"));
+        assert!(results[0]
+            .download_url
+            .as_deref()
+            .unwrap()
+            .contains("action=download&id=200"));
+        assert_eq!(results[0].size_bytes, Some(300_000_000));
+        assert_eq!(results[0].seeders, Some(15));
+        assert_eq!(results[0].leechers, Some(2));
+    }
+
+    #[tokio::test]
+    async fn gazelle_search_group_without_torrents_emits_group_row() {
+        let server = MockServer::start().await;
+
+        let response_body = r#"
+        {
+            "status": "success",
+            "response": {
+                "results": [
+                    {
+                        "groupId": 50,
+                        "groupName": "Nevermind",
+                        "artist": "Nirvana",
+                        "groupYear": 1991,
+                        "torrents": []
+                    }
+                ]
+            }
+        }
+        "#;
+
+        Mock::given(method("GET"))
+            .and(path("/ajax.php"))
+            .and(query_param("action", "browse"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_body))
+            .mount(&server)
+            .await;
+
+        let client = GazelleClient::new(IndexerConfig {
+            name: "test-gazelle".to_string(),
+            base_url: server.uri(),
+            protocol: IndexerProtocol::Gazelle,
+            api_key: Some("secret".to_string()),
+            enabled: true,
+        });
+
+        let results = client
+            .search(&IndexerSearchQuery {
+                query: "nirvana".to_string(),
+                category: None,
+                limit: None,
+                offset: None,
+            })
+            .await
+            .expect("gazelle search should succeed");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Nirvana - Nevermind [1991]");
+        assert_eq!(results[0].guid.as_deref(), Some("50"));
+        assert!(results[0]
+            .download_url
+            .as_deref()
+            .unwrap()
+            .contains("torrents.php?id=50"));
     }
 }

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -721,6 +721,12 @@ async fn execute_gazelle_search(
     config: &IndexerConfig,
     query: &IndexerSearchQuery,
 ) -> Result<Vec<IndexerSearchResult>, IndexerError> {
+    if query.offset.is_some() {
+        return Err(IndexerError::Unsupported(
+            "gazelle browse does not support offset-based pagination".to_string(),
+        ));
+    }
+
     let mut params: Vec<(&str, String)> = Vec::new();
 
     if !query.query.trim().is_empty() {
@@ -731,7 +737,7 @@ async fn execute_gazelle_search(
         params.push(("results", limit.to_string()));
     }
 
-    // Map category to Gazelle encoding filter
+    // Map category to Gazelle format filter
     if let Some(category) = query.category.as_deref() {
         let normalized = category.trim().to_lowercase();
         if normalized.contains("flac") || normalized == "audio/flac" {
@@ -744,7 +750,7 @@ async fn execute_gazelle_search(
     let body = execute_gazelle_request(client, config, "browse", Some(params)).await?;
 
     let parsed: GazelleResponse<GazelleBrowseResponse> = serde_json::from_str(&body)
-        .map_err(|error| IndexerError::RssParse(format!("gazelle JSON parse error: {error}")))?;
+        .map_err(|error| IndexerError::Request(format!("gazelle JSON parse error: {error}")))?;
 
     if parsed.status != "success" {
         return Err(IndexerError::Request(format!(
@@ -755,29 +761,35 @@ async fn execute_gazelle_search(
 
     let groups = parsed.response.map(|r| r.results).unwrap_or_default();
 
-    let base_url = config.base_url.trim_end_matches('/').to_string();
+    let base_url = gazelle_site_root_url(&config.base_url)?;
     let mut results = Vec::new();
 
     for group in groups {
         let artist = group.artist.as_deref().unwrap_or("");
         let album = group.group_name.as_deref().unwrap_or("");
         let year = group.group_year.unwrap_or(0);
-        let had_torrents = !group.torrents.is_empty();
+        let group_id = group.group_id;
+        let mut emitted_torrent_result = false;
 
         for torrent in group.torrents {
+            let Some(torrent_id) = torrent.torrent_id else {
+                continue;
+            };
+
             let format = torrent.format.as_deref().unwrap_or("");
             let encoding = torrent.encoding.as_deref().unwrap_or("");
             let media = torrent.media.as_deref().unwrap_or("");
 
             let title = build_gazelle_title(artist, album, year, format, encoding, media);
 
-            let download_url = torrent
-                .torrent_id
-                .map(|id| format!("{base_url}/torrents.php?action=download&id={id}"));
+            let download_url = Some(format!(
+                "{base_url}/torrents.php?action=download&id={torrent_id}"
+            ));
 
-            let guid = torrent
-                .torrent_id
-                .map(|id| format!("{}-{}", group.group_id.unwrap_or(0), id));
+            let guid = Some(match group_id {
+                Some(group_id) => format!("{group_id}-{torrent_id}"),
+                None => torrent_id.to_string(),
+            });
 
             results.push(IndexerSearchResult {
                 title,
@@ -788,18 +800,19 @@ async fn execute_gazelle_search(
                 seeders: torrent.seeders,
                 leechers: torrent.leechers,
             });
+            emitted_torrent_result = true;
         }
 
-        // If the group has no torrent entries, emit one row for the group itself
-        if !had_torrents {
+        // If no valid torrent rows were emitted, emit one row for the group itself.
+        if !emitted_torrent_result {
+            let Some(group_id) = group_id else {
+                continue;
+            };
             let title = build_gazelle_title(artist, album, year, "", "", "");
-            let guid = group.group_id.map(|id| id.to_string());
             results.push(IndexerSearchResult {
                 title,
-                guid,
-                download_url: group
-                    .group_id
-                    .map(|id| format!("{base_url}/torrents.php?id={id}")),
+                guid: Some(group_id.to_string()),
+                download_url: Some(format!("{base_url}/torrents.php?id={group_id}")),
                 published_at: None,
                 size_bytes: None,
                 seeders: None,
@@ -841,6 +854,24 @@ fn build_gazelle_title(
         title = format!("{title} [{}]", tags.join(" / "));
     }
     title
+}
+
+fn gazelle_site_root_url(base_url: &str) -> Result<String, IndexerError> {
+    let mut url = Url::parse(base_url)
+        .map_err(|error| IndexerError::Request(format!("invalid base url: {error}")))?;
+    let normalized_path = url.path().trim_end_matches('/').to_string();
+    let root_path = normalized_path
+        .strip_suffix("/ajax.php")
+        .unwrap_or(normalized_path.as_str())
+        .to_string();
+    if root_path.is_empty() {
+        url.set_path("/");
+    } else {
+        url.set_path(&root_path);
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.to_string().trim_end_matches('/').to_string())
 }
 
 // ── XML / RSS helpers ─────────────────────────────────────────────────────────
@@ -1285,5 +1316,156 @@ mod tests {
             .as_deref()
             .unwrap()
             .contains("torrents.php?id=50"));
+    }
+
+    #[tokio::test]
+    async fn gazelle_search_rejects_offset_queries() {
+        let client = GazelleClient::new(IndexerConfig {
+            name: "test-gazelle".to_string(),
+            base_url: "https://gazelle.example".to_string(),
+            protocol: IndexerProtocol::Gazelle,
+            api_key: Some("secret".to_string()),
+            enabled: true,
+        });
+
+        let error = client
+            .search(&IndexerSearchQuery {
+                query: "radiohead".to_string(),
+                category: None,
+                limit: None,
+                offset: Some(10),
+            })
+            .await
+            .expect_err("offset should be rejected");
+
+        assert!(matches!(error, super::IndexerError::Unsupported(_)));
+        assert!(error.to_string().contains("offset-based pagination"));
+    }
+
+    #[tokio::test]
+    async fn gazelle_search_builds_download_urls_from_site_root() {
+        let server = MockServer::start().await;
+
+        let response_body = r#"
+        {
+            "status": "success",
+            "response": {
+                "results": [
+                    {
+                        "groupId": 100,
+                        "groupName": "OK Computer",
+                        "artist": "Radiohead",
+                        "groupYear": 1997,
+                        "torrents": [
+                            {
+                                "torrentId": 200
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+        "#;
+
+        Mock::given(method("GET"))
+            .and(path("/ajax.php"))
+            .and(query_param("action", "browse"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_body))
+            .mount(&server)
+            .await;
+
+        let client = GazelleClient::new(IndexerConfig {
+            name: "test-gazelle".to_string(),
+            base_url: format!("{}/ajax.php", server.uri()),
+            protocol: IndexerProtocol::Gazelle,
+            api_key: Some("secret".to_string()),
+            enabled: true,
+        });
+
+        let results = client
+            .search(&IndexerSearchQuery {
+                query: "radiohead".to_string(),
+                category: None,
+                limit: None,
+                offset: None,
+            })
+            .await
+            .expect("gazelle search should succeed");
+
+        assert_eq!(results.len(), 1);
+        let expected_download = format!("{}/torrents.php?action=download&id=200", server.uri());
+        assert_eq!(
+            results[0].download_url.as_deref(),
+            Some(expected_download.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn gazelle_search_skips_rows_without_required_ids() {
+        let server = MockServer::start().await;
+
+        let response_body = r#"
+        {
+            "status": "success",
+            "response": {
+                "results": [
+                    {
+                        "groupId": 100,
+                        "groupName": "OK Computer",
+                        "artist": "Radiohead",
+                        "groupYear": 1997,
+                        "torrents": [
+                            {
+                                "format": "FLAC"
+                            },
+                            {
+                                "torrentId": 200,
+                                "format": "FLAC"
+                            }
+                        ]
+                    },
+                    {
+                        "groupName": "Unknown Group",
+                        "artist": "Unknown",
+                        "groupYear": 2000,
+                        "torrents": []
+                    }
+                ]
+            }
+        }
+        "#;
+
+        Mock::given(method("GET"))
+            .and(path("/ajax.php"))
+            .and(query_param("action", "browse"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_body))
+            .mount(&server)
+            .await;
+
+        let client = GazelleClient::new(IndexerConfig {
+            name: "test-gazelle".to_string(),
+            base_url: server.uri(),
+            protocol: IndexerProtocol::Gazelle,
+            api_key: Some("secret".to_string()),
+            enabled: true,
+        });
+
+        let results = client
+            .search(&IndexerSearchQuery {
+                query: "radiohead".to_string(),
+                category: None,
+                limit: None,
+                offset: None,
+            })
+            .await
+            .expect("gazelle search should succeed");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].guid.as_deref(), Some("100-200"));
+        let expected_download = format!("{}/torrents.php?action=download&id=200", server.uri());
+        assert_eq!(
+            results[0].download_url.as_deref(),
+            Some(expected_download.as_str())
+        );
     }
 }

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -871,7 +871,8 @@ fn gazelle_site_root_url(base_url: &str) -> Result<String, IndexerError> {
     }
     url.set_query(None);
     url.set_fragment(None);
-    Ok(url.to_string().trim_end_matches('/').to_string())
+    let normalized_url = url.to_string();
+    Ok(normalized_url.trim_end_matches('/').to_string())
 }
 
 // ── XML / RSS helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements Gazelle music-specific search via the `browse` action, completing the Gazelle protocol client sub-items in Phase 3.

## Changes

- **`execute_gazelle_search`**: new async helper that calls `action=browse` with `searchstr`, optional `format` filter, and optional `results` limit; parses the JSON response into `Vec<IndexerSearchResult>`.
- **Gazelle JSON types**: `GazelleResponse<T>`, `GazelleBrowseResponse`, `GazelleSearchGroup`, `GazelleTorrent` — all deserialized via serde.
- **`GazelleClient::search()`**: now delegates to `execute_gazelle_search` (previously returned `Unsupported`).
- **`GazelleClient::detect_capabilities()`**: now returns `supports_search: true`, `supports_categories: true`, and music category list (FLAC / MP3 / music).
- **`build_gazelle_title`**: formats title as `"Artist - Album [Year / Format / Encoding / Media]"` for display consistency.
- **Download URLs**: per-torrent URLs use `torrents.php?action=download&id=<torrent_id>`; fallback group-only rows use `torrents.php?id=<group_id>`.
- **Tests** (2 new, 1 updated):
  - `gazelle_search_returns_results_with_auth_headers` — WireMock verifying auth headers, query params, and result mapping.
  - `gazelle_search_group_without_torrents_emits_group_row` — group with empty `torrents` array still emits a result row.
  - Updated `gazelle_test_connection_sends_auth_headers` to assert `supports_search: true`.
- **ROADMAP.md**: marked `Music-specific search` as complete.

## Test Results

```
running 4 tests
test indexers::tests::gazelle_test_connection_requires_api_key ... ok
test indexers::tests::gazelle_test_connection_sends_auth_headers ... ok
test indexers::tests::gazelle_search_group_without_torrents_emits_group_row ... ok
test indexers::tests::gazelle_search_returns_results_with_auth_headers ... ok
test result: ok. 4 passed; 0 failed
```

Refs #3
