### PR TITLE
Add tmp directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Thumbs.db
 
 # Misc
 repomix*
+tmp/


### PR DESCRIPTION
Excludes temporary working directory from version control. Prevents PR body template files and other transient files from being tracked.