### PR TITLE
feat: custom format support in release ranking (Issue #397)

### DIFF
--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -7,6 +7,8 @@ use chorrosion_application::{
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+const MAX_CUSTOM_FORMAT_SCORE_BONUS: i32 = 10_000;
+
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ManualSearchApiRequest {
     pub indexer_id: String,
@@ -121,21 +123,19 @@ pub async fn manual_search_endpoint(
             return (StatusCode::BAD_REQUEST, Json(SearchErrorResponse { error })).into_response();
         }
     };
+    let custom_format_rules = match parse_custom_format_rules(request.custom_format_rules) {
+        Ok(values) => values,
+        Err(error) => {
+            return (StatusCode::BAD_REQUEST, Json(SearchErrorResponse { error })).into_response();
+        }
+    };
 
     let options = ReleaseFilterOptions {
         preferred_qualities,
         min_bitrate_kbps: request.min_bitrate_kbps,
         preferred_release_groups: request.preferred_release_groups,
         preferred_words: request.preferred_words,
-        custom_format_rules: request
-            .custom_format_rules
-            .into_iter()
-            .map(|rule| CustomFormatRule {
-                name: rule.name,
-                keywords: rule.keywords,
-                score_bonus: rule.score_bonus,
-            })
-            .collect(),
+        custom_format_rules,
     };
 
     let manual_request = ManualSearchRequest {
@@ -277,6 +277,49 @@ fn parse_preferred_qualities(values: &[String]) -> Result<Vec<AudioQuality>, Str
         .collect()
 }
 
+fn parse_custom_format_rules(
+    rules: Vec<ManualSearchCustomFormatRule>,
+) -> Result<Vec<CustomFormatRule>, String> {
+    rules
+        .into_iter()
+        .enumerate()
+        .map(|(index, rule)| {
+            let name = rule.name.trim();
+            if name.is_empty() {
+                return Err(format!(
+                    "custom_format_rules[{index}].name must not be empty"
+                ));
+            }
+
+            let keywords: Vec<String> = rule
+                .keywords
+                .into_iter()
+                .map(|keyword| keyword.trim().to_string())
+                .filter(|keyword| !keyword.is_empty())
+                .collect();
+            if keywords.is_empty() {
+                return Err(format!(
+                    "custom_format_rules[{index}].keywords must include at least one non-empty value"
+                ));
+            }
+
+            if !(-MAX_CUSTOM_FORMAT_SCORE_BONUS..=MAX_CUSTOM_FORMAT_SCORE_BONUS)
+                .contains(&rule.score_bonus)
+            {
+                return Err(format!(
+                    "custom_format_rules[{index}].score_bonus must be between -{MAX_CUSTOM_FORMAT_SCORE_BONUS} and {MAX_CUSTOM_FORMAT_SCORE_BONUS}"
+                ));
+            }
+
+            Ok(CustomFormatRule {
+                name: name.to_string(),
+                keywords,
+                score_bonus: rule.score_bonus,
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,6 +362,57 @@ mod tests {
     async fn parse_preferred_qualities_rejects_invalid_values() {
         let err = parse_preferred_qualities(&["lossless".to_string()]).expect_err("invalid");
         assert!(err.contains("unsupported quality"));
+    }
+
+    #[test]
+    fn parse_custom_format_rules_maps_valid_rule() {
+        let rules = vec![ManualSearchCustomFormatRule {
+            name: "MQA".to_string(),
+            keywords: vec!["  mqa  ".to_string(), "master quality".to_string()],
+            score_bonus: 120,
+        }];
+
+        let parsed = parse_custom_format_rules(rules).expect("valid rules");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].name, "MQA");
+        assert_eq!(parsed[0].keywords, vec!["mqa", "master quality"]);
+        assert_eq!(parsed[0].score_bonus, 120);
+    }
+
+    #[test]
+    fn parse_custom_format_rules_rejects_empty_name() {
+        let rules = vec![ManualSearchCustomFormatRule {
+            name: "   ".to_string(),
+            keywords: vec!["mqa".to_string()],
+            score_bonus: 10,
+        }];
+
+        let err = parse_custom_format_rules(rules).expect_err("invalid name");
+        assert!(err.contains("name must not be empty"));
+    }
+
+    #[test]
+    fn parse_custom_format_rules_rejects_empty_keywords() {
+        let rules = vec![ManualSearchCustomFormatRule {
+            name: "MQA".to_string(),
+            keywords: vec![" ".to_string()],
+            score_bonus: 10,
+        }];
+
+        let err = parse_custom_format_rules(rules).expect_err("invalid keywords");
+        assert!(err.contains("keywords must include at least one non-empty value"));
+    }
+
+    #[test]
+    fn parse_custom_format_rules_rejects_out_of_range_score_bonus() {
+        let rules = vec![ManualSearchCustomFormatRule {
+            name: "MQA".to_string(),
+            keywords: vec!["mqa".to_string()],
+            score_bonus: MAX_CUSTOM_FORMAT_SCORE_BONUS + 1,
+        }];
+
+        let err = parse_custom_format_rules(rules).expect_err("invalid score bonus");
+        assert!(err.contains("score_bonus must be between"));
     }
 
     #[tokio::test]
@@ -418,6 +512,34 @@ mod tests {
                 preferred_release_groups: vec![],
                 preferred_words: vec![],
                 custom_format_rules: vec![],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn manual_search_endpoint_rejects_invalid_custom_format_rules() {
+        let state = make_test_state().await;
+
+        let response = manual_search_endpoint(
+            State(state),
+            Json(ManualSearchApiRequest {
+                indexer_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                artist: None,
+                album: None,
+                query: Some("discovery".to_string()),
+                preferred_qualities: vec![],
+                min_bitrate_kbps: None,
+                preferred_release_groups: vec![],
+                preferred_words: vec![],
+                custom_format_rules: vec![ManualSearchCustomFormatRule {
+                    name: "   ".to_string(),
+                    keywords: vec!["mqa".to_string()],
+                    score_bonus: 10,
+                }],
             }),
         )
         .await

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use chorrosion_application::{
-    manual_search, AppState, AudioQuality, IndexerConfig, IndexerError, IndexerProtocol,
-    ManualSearchRequest, NewznabClient, ReleaseFilterOptions, TorznabClient,
+    manual_search, AppState, AudioQuality, CustomFormatRule, IndexerConfig, IndexerError,
+    IndexerProtocol, ManualSearchRequest, NewznabClient, ReleaseFilterOptions, TorznabClient,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -20,6 +20,16 @@ pub struct ManualSearchApiRequest {
     pub preferred_release_groups: Vec<String>,
     #[serde(default)]
     pub preferred_words: Vec<String>,
+    #[serde(default)]
+    pub custom_format_rules: Vec<ManualSearchCustomFormatRule>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ManualSearchCustomFormatRule {
+    pub name: String,
+    #[serde(default)]
+    pub keywords: Vec<String>,
+    pub score_bonus: i32,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -117,6 +127,15 @@ pub async fn manual_search_endpoint(
         min_bitrate_kbps: request.min_bitrate_kbps,
         preferred_release_groups: request.preferred_release_groups,
         preferred_words: request.preferred_words,
+        custom_format_rules: request
+            .custom_format_rules
+            .into_iter()
+            .map(|rule| CustomFormatRule {
+                name: rule.name,
+                keywords: rule.keywords,
+                score_bonus: rule.score_bonus,
+            })
+            .collect(),
     };
 
     let manual_request = ManualSearchRequest {
@@ -317,6 +336,7 @@ mod tests {
                 min_bitrate_kbps: None,
                 preferred_release_groups: vec![],
                 preferred_words: vec![],
+                custom_format_rules: vec![],
             }),
         )
         .await
@@ -348,6 +368,7 @@ mod tests {
                 min_bitrate_kbps: None,
                 preferred_release_groups: vec![],
                 preferred_words: vec![],
+                custom_format_rules: vec![],
             }),
         )
         .await
@@ -372,6 +393,7 @@ mod tests {
                 min_bitrate_kbps: None,
                 preferred_release_groups: vec![],
                 preferred_words: vec![],
+                custom_format_rules: vec![],
             }),
         )
         .await
@@ -395,6 +417,7 @@ mod tests {
                 min_bitrate_kbps: None,
                 preferred_release_groups: vec![],
                 preferred_words: vec![],
+                custom_format_rules: vec![],
             }),
         )
         .await

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -284,8 +284,7 @@ fn parse_custom_format_rules(
         .into_iter()
         .enumerate()
         .map(|(index, rule)| {
-            let name = rule.name.trim();
-            if name.is_empty() {
+            if rule.name.trim().is_empty() {
                 return Err(format!(
                     "custom_format_rules[{index}].name must not be empty"
                 ));
@@ -312,7 +311,7 @@ fn parse_custom_format_rules(
             }
 
             Ok(CustomFormatRule {
-                name: name.to_string(),
+                name: rule.name.trim().to_string(),
                 keywords,
                 score_bonus: rule.score_bonus,
             })

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -86,7 +86,7 @@ pub use permission::{PermissionChecker, PermissionConfig, PermissionError, Permi
 pub use quality_upgrade::{QualityComparer, QualityUpgradeService, UpgradeDecision, UpgradeReason};
 pub use release_parsing::{
     deduplicate_releases, filter_releases, find_duplicate_keys, parse_release_title, rank_releases,
-    AudioQuality, ParsedReleaseTitle, ReleaseFilterOptions,
+    AudioQuality, CustomFormatRule, ParsedReleaseTitle, ReleaseFilterOptions,
 };
 pub use release_restrictions::{ReleaseRestrictionSet, RestrictionRule};
 pub use scan_cache::{cached_scan_audio_files, DirScanCache};

--- a/crates/chorrosion-application/src/release_parsing.rs
+++ b/crates/chorrosion-application/src/release_parsing.rs
@@ -46,6 +46,9 @@ struct NormalizedCustomFormatRule {
     score_bonus: i64,
 }
 
+const SCORE_MIN: i64 = i32::MIN as i64;
+const SCORE_MAX: i64 = i32::MAX as i64;
+
 pub fn parse_release_title(title: &str) -> ParsedReleaseTitle {
     let normalized = normalize_whitespace(title);
     let quality = detect_quality(&normalized);
@@ -212,16 +215,23 @@ fn score_release_with_words(
         })
         .unwrap_or(0) as i64;
 
-    let normalized_title = normalize_whitespace(&release.original_title).to_lowercase();
+    let normalized_title =
+        if normalized_preferred_words.is_empty() && normalized_custom_rules.is_empty() {
+            None
+        } else {
+            Some(normalize_whitespace(&release.original_title).to_lowercase())
+        };
 
-    let preferred_word_score =
-        (preferred_word_matches(release, &normalized_title, normalized_preferred_words) as i64)
-            * 30;
+    let preferred_word_score = normalized_title.as_deref().map_or(0, |title| {
+        (preferred_word_matches(release, title, normalized_preferred_words) as i64) * 30
+    });
 
-    let custom_format_score = custom_format_bonus(&normalized_title, normalized_custom_rules);
+    let custom_format_score = normalized_title.as_deref().map_or(0, |title| {
+        custom_format_bonus(title, normalized_custom_rules)
+    });
 
     (quality_score + bitrate_score + group_score + preferred_word_score + custom_format_score)
-        .clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
+        .clamp(SCORE_MIN, SCORE_MAX) as i32
 }
 
 fn custom_format_bonus(

--- a/crates/chorrosion-application/src/release_parsing.rs
+++ b/crates/chorrosion-application/src/release_parsing.rs
@@ -43,7 +43,7 @@ pub struct CustomFormatRule {
 #[derive(Debug, Clone)]
 struct NormalizedCustomFormatRule {
     keywords: Vec<String>,
-    score_bonus: i32,
+    score_bonus: i64,
 }
 
 pub fn parse_release_title(title: &str) -> ParsedReleaseTitle {
@@ -193,11 +193,11 @@ fn score_release_with_words(
         AudioQuality::Mp3 => 120,
         AudioQuality::Aac => 100,
         AudioQuality::Unknown => 20,
-    };
+    } as i64;
 
     let bitrate_score = release
         .bitrate_kbps
-        .map(|value| (value / 10) as i32)
+        .map(|value| (value / 10) as i64)
         .unwrap_or(0);
 
     let group_score = release
@@ -210,31 +210,34 @@ fn score_release_with_words(
                 .any(|preferred| preferred.eq_ignore_ascii_case(group))
                 .then_some(75)
         })
-        .unwrap_or(0);
+        .unwrap_or(0) as i64;
+
+    let normalized_title = normalize_whitespace(&release.original_title).to_lowercase();
 
     let preferred_word_score =
-        (preferred_word_matches(release, normalized_preferred_words) as i32) * 30;
+        (preferred_word_matches(release, &normalized_title, normalized_preferred_words) as i64)
+            * 30;
 
-    let custom_format_score = custom_format_bonus(release, normalized_custom_rules);
+    let custom_format_score = custom_format_bonus(&normalized_title, normalized_custom_rules);
 
-    quality_score + bitrate_score + group_score + preferred_word_score + custom_format_score
+    (quality_score + bitrate_score + group_score + preferred_word_score + custom_format_score)
+        .clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
 }
 
 fn custom_format_bonus(
-    release: &ParsedReleaseTitle,
+    normalized_title: &str,
     normalized_custom_rules: &[NormalizedCustomFormatRule],
-) -> i32 {
+) -> i64 {
     if normalized_custom_rules.is_empty() {
         return 0;
     }
 
-    let title = normalize_whitespace(&release.original_title).to_lowercase();
     normalized_custom_rules
         .iter()
         .filter(|rule| {
             rule.keywords
                 .iter()
-                .any(|keyword| title.contains(keyword.as_str()))
+                .any(|keyword| normalized_title.contains(keyword.as_str()))
         })
         .map(|rule| rule.score_bonus)
         .sum()
@@ -242,13 +245,13 @@ fn custom_format_bonus(
 
 fn preferred_word_matches(
     release: &ParsedReleaseTitle,
+    normalized_title: &str,
     normalized_preferred_words: &HashSet<String>,
 ) -> usize {
     if normalized_preferred_words.is_empty() {
         return 0;
     }
 
-    let original_title = normalize_whitespace(&release.original_title).to_lowercase();
     let artist = release.artist.as_ref().map(|value| value.to_lowercase());
     let album = release.album.as_ref().map(|value| value.to_lowercase());
     let group = release
@@ -260,7 +263,7 @@ fn preferred_word_matches(
         .iter()
         .filter(|word| {
             let word = word.as_str();
-            original_title.contains(word)
+            normalized_title.contains(word)
                 || artist.as_ref().is_some_and(|value| value.contains(word))
                 || album.as_ref().is_some_and(|value| value.contains(word))
                 || group.as_ref().is_some_and(|value| value.contains(word))
@@ -271,7 +274,7 @@ fn preferred_word_matches(
 fn normalize_preferred_words(preferred_words: &[String]) -> HashSet<String> {
     preferred_words
         .iter()
-        .map(|word| word.trim().to_lowercase())
+        .map(|word| normalize_whitespace(word).to_lowercase())
         .filter(|word| !word.is_empty())
         .collect()
 }
@@ -283,7 +286,7 @@ fn normalize_custom_format_rules(rules: &[CustomFormatRule]) -> Vec<NormalizedCu
             let keywords = rule
                 .keywords
                 .iter()
-                .map(|word| word.trim().to_lowercase())
+                .map(|word| normalize_whitespace(word).to_lowercase())
                 .filter(|word| !word.is_empty())
                 .collect::<Vec<_>>();
 
@@ -293,7 +296,7 @@ fn normalize_custom_format_rules(rules: &[CustomFormatRule]) -> Vec<NormalizedCu
 
             Some(NormalizedCustomFormatRule {
                 keywords,
-                score_bonus: rule.score_bonus,
+                score_bonus: i64::from(rule.score_bonus),
             })
         })
         .collect()
@@ -662,6 +665,62 @@ mod tests {
                 keywords: vec!["mqa".to_string()],
                 score_bonus: 60,
             }],
+        };
+
+        let ranked = rank_releases(releases, &options);
+        assert!(ranked[0].original_title.to_lowercase().contains("mqa"));
+    }
+
+    #[test]
+    fn custom_format_keyword_matches_with_irregular_whitespace() {
+        let releases = vec![
+            parse_release_title("Artist - Album MQA Deluxe Edition 320kbps MP3-GroupA"),
+            parse_release_title("Artist - Album Standard Edition 320kbps MP3-GroupB"),
+        ];
+
+        let options = ReleaseFilterOptions {
+            preferred_qualities: vec![],
+            min_bitrate_kbps: None,
+            preferred_release_groups: vec![],
+            preferred_words: vec![],
+            custom_format_rules: vec![CustomFormatRule {
+                name: "MQA Deluxe".to_string(),
+                keywords: vec!["mqa   deluxe".to_string()],
+                score_bonus: 80,
+            }],
+        };
+
+        let ranked = rank_releases(releases, &options);
+        assert!(ranked[0]
+            .original_title
+            .to_lowercase()
+            .contains("mqa deluxe"));
+    }
+
+    #[test]
+    fn custom_format_score_uses_saturating_total() {
+        let releases = vec![
+            parse_release_title("Artist - Album MQA 320kbps MP3-GroupA"),
+            parse_release_title("Artist - Album 320kbps MP3-GroupB"),
+        ];
+
+        let options = ReleaseFilterOptions {
+            preferred_qualities: vec![],
+            min_bitrate_kbps: None,
+            preferred_release_groups: vec![],
+            preferred_words: vec![],
+            custom_format_rules: vec![
+                CustomFormatRule {
+                    name: "Rule 1".to_string(),
+                    keywords: vec!["mqa".to_string()],
+                    score_bonus: i32::MAX,
+                },
+                CustomFormatRule {
+                    name: "Rule 2".to_string(),
+                    keywords: vec!["mqa".to_string()],
+                    score_bonus: i32::MAX,
+                },
+            ],
         };
 
         let ranked = rank_releases(releases, &options);

--- a/crates/chorrosion-application/src/release_parsing.rs
+++ b/crates/chorrosion-application/src/release_parsing.rs
@@ -30,6 +30,20 @@ pub struct ReleaseFilterOptions {
     pub min_bitrate_kbps: Option<u32>,
     pub preferred_release_groups: Vec<String>,
     pub preferred_words: Vec<String>,
+    pub custom_format_rules: Vec<CustomFormatRule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CustomFormatRule {
+    pub name: String,
+    pub keywords: Vec<String>,
+    pub score_bonus: i32,
+}
+
+#[derive(Debug, Clone)]
+struct NormalizedCustomFormatRule {
+    keywords: Vec<String>,
+    score_bonus: i32,
 }
 
 pub fn parse_release_title(title: &str) -> ParsedReleaseTitle {
@@ -84,11 +98,13 @@ pub fn rank_releases(
     options: &ReleaseFilterOptions,
 ) -> Vec<ParsedReleaseTitle> {
     let normalized_preferred_words = normalize_preferred_words(&options.preferred_words);
+    let normalized_custom_rules = normalize_custom_format_rules(&options.custom_format_rules);
     releases.sort_by_cached_key(|release| {
         std::cmp::Reverse(score_release_with_words(
             release,
             options,
             &normalized_preferred_words,
+            &normalized_custom_rules,
         ))
     });
     releases
@@ -98,15 +114,25 @@ pub fn deduplicate_releases(releases: &[ParsedReleaseTitle]) -> Vec<ParsedReleas
     let mut best_by_key: HashMap<String, ParsedReleaseTitle> = HashMap::new();
     let default_options = ReleaseFilterOptions::default();
     let normalized_default_words = normalize_preferred_words(&default_options.preferred_words);
+    let normalized_default_custom_rules =
+        normalize_custom_format_rules(&default_options.custom_format_rules);
 
     for release in releases {
         let key = duplicate_key(release);
         match best_by_key.get(&key) {
             Some(existing) => {
-                let existing_score =
-                    score_release_with_words(existing, &default_options, &normalized_default_words);
-                let candidate_score =
-                    score_release_with_words(release, &default_options, &normalized_default_words);
+                let existing_score = score_release_with_words(
+                    existing,
+                    &default_options,
+                    &normalized_default_words,
+                    &normalized_default_custom_rules,
+                );
+                let candidate_score = score_release_with_words(
+                    release,
+                    &default_options,
+                    &normalized_default_words,
+                    &normalized_default_custom_rules,
+                );
                 if candidate_score > existing_score {
                     best_by_key.insert(key, release.clone());
                 }
@@ -160,6 +186,7 @@ fn score_release_with_words(
     release: &ParsedReleaseTitle,
     options: &ReleaseFilterOptions,
     normalized_preferred_words: &HashSet<String>,
+    normalized_custom_rules: &[NormalizedCustomFormatRule],
 ) -> i32 {
     let quality_score = match release.quality {
         AudioQuality::Flac | AudioQuality::Alac => 200,
@@ -188,7 +215,29 @@ fn score_release_with_words(
     let preferred_word_score =
         (preferred_word_matches(release, normalized_preferred_words) as i32) * 30;
 
-    quality_score + bitrate_score + group_score + preferred_word_score
+    let custom_format_score = custom_format_bonus(release, normalized_custom_rules);
+
+    quality_score + bitrate_score + group_score + preferred_word_score + custom_format_score
+}
+
+fn custom_format_bonus(
+    release: &ParsedReleaseTitle,
+    normalized_custom_rules: &[NormalizedCustomFormatRule],
+) -> i32 {
+    if normalized_custom_rules.is_empty() {
+        return 0;
+    }
+
+    let title = normalize_whitespace(&release.original_title).to_lowercase();
+    normalized_custom_rules
+        .iter()
+        .filter(|rule| {
+            rule.keywords
+                .iter()
+                .any(|keyword| title.contains(keyword.as_str()))
+        })
+        .map(|rule| rule.score_bonus)
+        .sum()
 }
 
 fn preferred_word_matches(
@@ -224,6 +273,29 @@ fn normalize_preferred_words(preferred_words: &[String]) -> HashSet<String> {
         .iter()
         .map(|word| word.trim().to_lowercase())
         .filter(|word| !word.is_empty())
+        .collect()
+}
+
+fn normalize_custom_format_rules(rules: &[CustomFormatRule]) -> Vec<NormalizedCustomFormatRule> {
+    rules
+        .iter()
+        .filter_map(|rule| {
+            let keywords = rule
+                .keywords
+                .iter()
+                .map(|word| word.trim().to_lowercase())
+                .filter(|word| !word.is_empty())
+                .collect::<Vec<_>>();
+
+            if keywords.is_empty() {
+                return None;
+            }
+
+            Some(NormalizedCustomFormatRule {
+                keywords,
+                score_bonus: rule.score_bonus,
+            })
+        })
         .collect()
 }
 
@@ -359,7 +431,7 @@ impl ParsedReleaseTitle {
 mod tests {
     use super::{
         deduplicate_releases, filter_releases, find_duplicate_keys, parse_release_title,
-        rank_releases, AudioQuality, ParsedReleaseTitle, ReleaseFilterOptions,
+        rank_releases, AudioQuality, CustomFormatRule, ParsedReleaseTitle, ReleaseFilterOptions,
     };
 
     #[test]
@@ -397,6 +469,7 @@ mod tests {
             min_bitrate_kbps: Some(256),
             preferred_release_groups: vec![],
             preferred_words: vec![],
+            custom_format_rules: vec![],
         };
 
         let filtered = filter_releases(&releases, &options);
@@ -417,6 +490,7 @@ mod tests {
             min_bitrate_kbps: Some(256),
             preferred_release_groups: vec![],
             preferred_words: vec![],
+            custom_format_rules: vec![],
         };
 
         let filtered = filter_releases(&releases, &options);
@@ -445,6 +519,7 @@ mod tests {
             min_bitrate_kbps: None,
             preferred_release_groups: vec!["Preferred".to_string()],
             preferred_words: vec![],
+            custom_format_rules: vec![],
         };
 
         let ranked = rank_releases(releases, &options);
@@ -488,6 +563,7 @@ mod tests {
             min_bitrate_kbps: None,
             preferred_release_groups: vec![],
             preferred_words: vec!["DELUXE".to_string()],
+            custom_format_rules: vec![],
         };
 
         let ranked = rank_releases(releases, &options);
@@ -506,6 +582,7 @@ mod tests {
             min_bitrate_kbps: None,
             preferred_release_groups: vec![],
             preferred_words: vec!["sceneprime".to_string()],
+            custom_format_rules: vec![],
         };
 
         let ranked = rank_releases(releases, &options);
@@ -524,6 +601,7 @@ mod tests {
             min_bitrate_kbps: None,
             preferred_release_groups: vec![],
             preferred_words: vec!["daft punk".to_string()],
+            custom_format_rules: vec![],
         };
 
         let ranked = rank_releases(releases, &options);
@@ -565,5 +643,28 @@ mod tests {
                 .count()
                 == 1
         );
+    }
+
+    #[test]
+    fn ranks_custom_format_rule_higher_when_quality_same() {
+        let releases = vec![
+            parse_release_title("Artist - Album 320kbps MP3 [MQA]-GroupA"),
+            parse_release_title("Artist - Album 320kbps MP3-GroupB"),
+        ];
+
+        let options = ReleaseFilterOptions {
+            preferred_qualities: vec![],
+            min_bitrate_kbps: None,
+            preferred_release_groups: vec![],
+            preferred_words: vec![],
+            custom_format_rules: vec![CustomFormatRule {
+                name: "MQA".to_string(),
+                keywords: vec!["mqa".to_string()],
+                score_bonus: 60,
+            }],
+        };
+
+        let ranked = rank_releases(releases, &options);
+        assert!(ranked[0].original_title.to_lowercase().contains("mqa"));
     }
 }

--- a/crates/chorrosion-application/src/search_automation.rs
+++ b/crates/chorrosion-application/src/search_automation.rs
@@ -436,6 +436,7 @@ mod tests {
                 min_bitrate_kbps: Some(256),
                 preferred_release_groups: vec![],
                 preferred_words: vec![],
+                custom_format_rules: vec![],
             },
         )
         .await


### PR DESCRIPTION
## Overview

Implements custom format support for release ranking and handling (Issue #397).

## What Changed

- Added CustomFormatRule support in release filter options.
- Added custom format normalization and keyword-based score bonus evaluation.
- Integrated custom format scoring into release ranking.
- Exposed custom format rules in manual search API request payload.
- Updated tests and option initializers for the new field.

## Validation

- cargo test -p chorrosion-application release_parsing
- cargo test -p chorrosion-api handlers::search
- cargo clippy -p chorrosion-application -p chorrosion-api -- -D warnings

## Issue Links

Closes #397
Related to #400
Related to #401
Related to #402
