### PR TITLE
feat: Phase 10 - Advanced duplicate detection and management (Issue #402)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -460,7 +460,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 - [x] Release restrictions (Issue #399, PR #405) ✓
 - [x] Tag-based organization (Issue #400, PR #408) ✓
 - [x] Smart playlists (Issue #401) ✓
-- [ ] Advanced duplicate detection and management (Issue #402)
+- [x] Advanced duplicate detection and management (Issue #402) ✓
 
 ### 10.2 Community Features
 
@@ -530,6 +530,6 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ---
 
-**Last Updated:** 2026-04-21  
+**Last Updated:** 2026-04-22  
 **Current Phase:** Phase 10: Optional Enhancements  
-**Next Milestone:** Issue #402 - advanced duplicate detection and management
+**Next Milestone:** Plugin system architecture

--- a/crates/chorrosion-api/benches/api_workflow_benchmarks.rs
+++ b/crates/chorrosion-api/benches/api_workflow_benchmarks.rs
@@ -14,9 +14,10 @@ use chorrosion_infrastructure::{
     repositories::Repository,
     sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
-        SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,
-        SqliteQualityProfileRepository, SqliteSmartPlaylistRepository, SqliteTagRepository,
-        SqliteTaggedEntityRepository, SqliteTrackRepository,
+        SqliteDuplicateRepository, SqliteIndexerDefinitionRepository,
+        SqliteMetadataProfileRepository, SqliteQualityProfileRepository,
+        SqliteSmartPlaylistRepository, SqliteTagRepository, SqliteTaggedEntityRepository,
+        SqliteTrackRepository,
     },
     ResponseCache,
 };
@@ -57,6 +58,7 @@ fn make_state(pool: SqlitePool) -> AppState {
         Arc::new(SqliteTagRepository::new(pool.clone())),
         Arc::new(SqliteTaggedEntityRepository::new(pool.clone())),
         Arc::new(SqliteSmartPlaylistRepository::new(pool.clone())),
+        Arc::new(SqliteDuplicateRepository::new(pool.clone())),
         ResponseCache::new(1_000, 0),
     )
 }

--- a/crates/chorrosion-api/src/handlers/activity.rs
+++ b/crates/chorrosion-api/src/handlers/activity.rs
@@ -410,6 +410,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/handlers/albums.rs
+++ b/crates/chorrosion-api/src/handlers/albums.rs
@@ -760,6 +760,11 @@ mod tests {
                         pool.clone(),
                     ),
                 ),
+                Arc::new(
+                    chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                        pool.clone(),
+                    ),
+                ),
                 chorrosion_infrastructure::ResponseCache::new(100, 60),
             )
         }

--- a/crates/chorrosion-api/src/handlers/artists.rs
+++ b/crates/chorrosion-api/src/handlers/artists.rs
@@ -945,6 +945,11 @@ mod tests {
                         pool.clone(),
                     ),
                 ),
+                Arc::new(
+                    chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                        pool.clone(),
+                    ),
+                ),
                 chorrosion_infrastructure::ResponseCache::new(100, 60),
             )
         }

--- a/crates/chorrosion-api/src/handlers/auth.rs
+++ b/crates/chorrosion-api/src/handlers/auth.rs
@@ -528,6 +528,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }
@@ -744,6 +749,11 @@ mod tests {
             Arc::new(SqliteTaggedEntityRepository::new(pool.clone())),
             Arc::new(
                 chorrosion_infrastructure::sqlite_adapters::SqliteSmartPlaylistRepository::new(
+                    pool.clone(),
+                ),
+            ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
                     pool.clone(),
                 ),
             ),

--- a/crates/chorrosion-api/src/handlers/calendar.rs
+++ b/crates/chorrosion-api/src/handlers/calendar.rs
@@ -386,6 +386,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         );
         (pool, state)

--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -615,6 +615,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/handlers/duplicates.rs
+++ b/crates/chorrosion-api/src/handlers/duplicates.rs
@@ -1,0 +1,573 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use chorrosion_application::AppState;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error};
+use utoipa::{IntoParams, ToSchema};
+
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
+pub struct ListDuplicatesQuery {
+    /// Detection method: "fingerprint" or "hash"
+    #[serde(default = "default_method")]
+    pub method: String,
+    /// Maximum number of groups to return (1–500)
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+    /// Number of groups to skip
+    #[serde(default)]
+    pub offset: i64,
+}
+
+fn default_method() -> String {
+    "fingerprint".to_string()
+}
+
+fn default_limit() -> i64 {
+    50
+}
+
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
+pub struct DuplicateGroupQuery {
+    /// Detection method: "fingerprint" or "hash"
+    #[serde(default = "default_method")]
+    pub method: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DuplicateGroupResponse {
+    pub key: String,
+    pub method: String,
+    pub file_count: i64,
+    pub first_seen_at: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListDuplicatesResponse {
+    pub items: Vec<DuplicateGroupResponse>,
+    pub total: i64,
+    pub limit: i64,
+    pub offset: i64,
+    pub method: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DuplicateFileResponse {
+    pub track_file_id: String,
+    pub track_id: String,
+    pub path: String,
+    pub size_bytes: u64,
+    pub quality: Option<String>,
+    pub bitrate_kbps: Option<u32>,
+    pub codec: Option<String>,
+    pub fingerprint_hash: Option<String>,
+    pub file_hash: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DuplicateGroupDetailResponse {
+    pub key: String,
+    pub method: String,
+    pub files: Vec<DuplicateFileResponse>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ResolveDuplicateRequest {
+    /// Action: "delete_specific"
+    pub action: String,
+    /// ID of the track file to delete (required for "delete_specific")
+    pub track_file_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ResolveDuplicateResponse {
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[schema(as = DuplicateErrorResponse)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+fn error_response(
+    status: StatusCode,
+    message: impl Into<String>,
+) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        status,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn group_to_response(group: chorrosion_application::DuplicateGroup) -> DuplicateGroupResponse {
+    DuplicateGroupResponse {
+        key: group.key,
+        method: format!("{:?}", group.method).to_lowercase(),
+        file_count: group.file_count,
+        first_seen_at: group.first_seen_at.to_rfc3339(),
+    }
+}
+
+fn file_to_response(file: chorrosion_application::DuplicateFileDetail) -> DuplicateFileResponse {
+    DuplicateFileResponse {
+        track_file_id: file.track_file_id.to_string(),
+        track_id: file.track_id.to_string(),
+        path: file.path,
+        size_bytes: file.size_bytes,
+        quality: file.quality,
+        bitrate_kbps: file.bitrate_kbps,
+        codec: file.codec,
+        fingerprint_hash: file.fingerprint_hash,
+        file_hash: file.file_hash,
+        created_at: file.created_at.to_rfc3339(),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/duplicates",
+    params(ListDuplicatesQuery),
+    responses(
+        (status = 200, description = "List duplicate groups", body = ListDuplicatesResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "duplicates"
+)]
+pub async fn list_duplicate_groups(
+    State(state): State<AppState>,
+    Query(query): Query<ListDuplicatesQuery>,
+) -> Result<Json<ListDuplicatesResponse>, (StatusCode, Json<ErrorResponse>)> {
+    if !(1..=500).contains(&query.limit) {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "limit must be between 1 and 500",
+        ));
+    }
+    if query.offset < 0 {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "offset must be greater than or equal to 0",
+        ));
+    }
+
+    debug!(target: "api", method = %query.method, limit = query.limit, offset = query.offset, "listing duplicate groups");
+
+    match query.method.as_str() {
+        "fingerprint" => {
+            let total = state
+                .duplicate_repository
+                .count_fingerprint_duplicate_groups()
+                .await
+                .map_err(|err| {
+                    error!(target: "api", error = %err, "failed to count fingerprint duplicate groups");
+                    error_response(StatusCode::INTERNAL_SERVER_ERROR, "failed to list duplicates")
+                })?;
+
+            let items = state
+                .duplicate_repository
+                .find_fingerprint_duplicate_groups(query.limit, query.offset)
+                .await
+                .map_err(|err| {
+                    error!(target: "api", error = %err, "failed to list fingerprint duplicate groups");
+                    error_response(StatusCode::INTERNAL_SERVER_ERROR, "failed to list duplicates")
+                })?
+                .into_iter()
+                .map(group_to_response)
+                .collect();
+
+            Ok(Json(ListDuplicatesResponse {
+                items,
+                total,
+                limit: query.limit,
+                offset: query.offset,
+                method: "fingerprint".to_string(),
+            }))
+        }
+        "hash" => {
+            let total = state
+                .duplicate_repository
+                .count_hash_duplicate_groups()
+                .await
+                .map_err(|err| {
+                    error!(target: "api", error = %err, "failed to count hash duplicate groups");
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to list duplicates",
+                    )
+                })?;
+
+            let items = state
+                .duplicate_repository
+                .find_hash_duplicate_groups(query.limit, query.offset)
+                .await
+                .map_err(|err| {
+                    error!(target: "api", error = %err, "failed to list hash duplicate groups");
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to list duplicates",
+                    )
+                })?
+                .into_iter()
+                .map(group_to_response)
+                .collect();
+
+            Ok(Json(ListDuplicatesResponse {
+                items,
+                total,
+                limit: query.limit,
+                offset: query.offset,
+                method: "hash".to_string(),
+            }))
+        }
+        _ => Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "method must be 'fingerprint' or 'hash'",
+        )),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/duplicates/{key}",
+    params(
+        ("key" = String, Path, description = "Duplicate group key (fingerprint hash or file hash)"),
+        DuplicateGroupQuery
+    ),
+    responses(
+        (status = 200, description = "Duplicate group detail", body = DuplicateGroupDetailResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "duplicates"
+)]
+pub async fn get_duplicate_group(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    Query(query): Query<DuplicateGroupQuery>,
+) -> Result<Json<DuplicateGroupDetailResponse>, (StatusCode, Json<ErrorResponse>)> {
+    debug!(target: "api", key = %key, method = %query.method, "getting duplicate group detail");
+
+    match query.method.as_str() {
+        "fingerprint" => {
+            let files = state
+                .duplicate_repository
+                .get_files_by_fingerprint(&key)
+                .await
+                .map_err(|err| {
+                    error!(target: "api", error = %err, "failed to get files by fingerprint");
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to get duplicate group",
+                    )
+                })?;
+
+            if files.is_empty() {
+                return Err(error_response(
+                    StatusCode::NOT_FOUND,
+                    "duplicate group not found",
+                ));
+            }
+
+            Ok(Json(DuplicateGroupDetailResponse {
+                key,
+                method: "fingerprint".to_string(),
+                files: files.into_iter().map(file_to_response).collect(),
+            }))
+        }
+        "hash" => {
+            let files = state
+                .duplicate_repository
+                .get_files_by_hash(&key)
+                .await
+                .map_err(|err| {
+                    error!(target: "api", error = %err, "failed to get files by hash");
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to get duplicate group",
+                    )
+                })?;
+
+            if files.is_empty() {
+                return Err(error_response(
+                    StatusCode::NOT_FOUND,
+                    "duplicate group not found",
+                ));
+            }
+
+            Ok(Json(DuplicateGroupDetailResponse {
+                key,
+                method: "hash".to_string(),
+                files: files.into_iter().map(file_to_response).collect(),
+            }))
+        }
+        _ => Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "method must be 'fingerprint' or 'hash'",
+        )),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/duplicates/{key}/resolve",
+    params(
+        ("key" = String, Path, description = "Duplicate group key"),
+        DuplicateGroupQuery
+    ),
+    request_body = ResolveDuplicateRequest,
+    responses(
+        (status = 200, description = "Duplicate resolved", body = ResolveDuplicateResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 404, description = "Track file not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "duplicates"
+)]
+pub async fn resolve_duplicate_group(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    Json(payload): Json<ResolveDuplicateRequest>,
+) -> Result<Json<ResolveDuplicateResponse>, (StatusCode, Json<ErrorResponse>)> {
+    debug!(target: "api", key = %key, action = %payload.action, "resolving duplicate group");
+
+    match payload.action.as_str() {
+        "delete_specific" => {
+            let track_file_id = payload.track_file_id.ok_or_else(|| {
+                error_response(
+                    StatusCode::BAD_REQUEST,
+                    "track_file_id is required for delete_specific action",
+                )
+            })?;
+
+            let deleted = state
+                .duplicate_repository
+                .delete_track_file(&track_file_id)
+                .await
+                .map_err(|err| {
+                    error!(target: "api", error = %err, "failed to delete track file");
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to delete track file",
+                    )
+                })?;
+
+            if !deleted {
+                return Err(error_response(
+                    StatusCode::NOT_FOUND,
+                    "track file not found",
+                ));
+            }
+
+            Ok(Json(ResolveDuplicateResponse {
+                message: format!("track file {} deleted", track_file_id),
+            }))
+        }
+        _ => Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "action must be 'delete_specific'",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::{Query, State};
+    use chorrosion_config::AppConfig;
+    use std::sync::Arc;
+
+    use chorrosion_infrastructure::sqlite_adapters::{
+        SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
+        SqliteDuplicateRepository, SqliteIndexerDefinitionRepository,
+        SqliteMetadataProfileRepository, SqliteQualityProfileRepository,
+        SqliteSmartPlaylistRepository, SqliteTagRepository, SqliteTaggedEntityRepository,
+        SqliteTrackRepository,
+    };
+
+    async fn make_test_state() -> AppState {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite");
+        sqlx::migrate!("../../migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+
+        AppState::new(
+            AppConfig::default(),
+            Arc::new(SqliteArtistRepository::new(pool.clone())),
+            Arc::new(SqliteAlbumRepository::new(pool.clone())),
+            Arc::new(SqliteTrackRepository::new(pool.clone())),
+            Arc::new(SqliteQualityProfileRepository::new(pool.clone())),
+            Arc::new(SqliteMetadataProfileRepository::new(pool.clone())),
+            Arc::new(SqliteIndexerDefinitionRepository::new(pool.clone())),
+            Arc::new(SqliteDownloadClientDefinitionRepository::new(pool.clone())),
+            Arc::new(SqliteTagRepository::new(pool.clone())),
+            Arc::new(SqliteTaggedEntityRepository::new(pool.clone())),
+            Arc::new(SqliteSmartPlaylistRepository::new(pool.clone())),
+            Arc::new(SqliteDuplicateRepository::new(pool.clone())),
+            chorrosion_infrastructure::ResponseCache::new(100, 60),
+        )
+    }
+
+    #[tokio::test]
+    async fn list_duplicates_returns_empty_on_fresh_db() {
+        let state = make_test_state().await;
+
+        let result = list_duplicate_groups(
+            State(state),
+            Query(ListDuplicatesQuery {
+                method: "fingerprint".to_string(),
+                limit: 50,
+                offset: 0,
+            }),
+        )
+        .await
+        .expect("list duplicate groups should succeed");
+
+        assert_eq!(result.total, 0);
+        assert!(result.items.is_empty());
+        assert_eq!(result.method, "fingerprint");
+    }
+
+    #[tokio::test]
+    async fn list_duplicates_hash_returns_empty_on_fresh_db() {
+        let state = make_test_state().await;
+
+        let result = list_duplicate_groups(
+            State(state),
+            Query(ListDuplicatesQuery {
+                method: "hash".to_string(),
+                limit: 50,
+                offset: 0,
+            }),
+        )
+        .await
+        .expect("list hash duplicate groups should succeed");
+
+        assert_eq!(result.total, 0);
+        assert!(result.items.is_empty());
+        assert_eq!(result.method, "hash");
+    }
+
+    #[tokio::test]
+    async fn list_duplicates_rejects_invalid_limit() {
+        let state = make_test_state().await;
+
+        let result = list_duplicate_groups(
+            State(state),
+            Query(ListDuplicatesQuery {
+                method: "fingerprint".to_string(),
+                limit: 0,
+                offset: 0,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn list_duplicates_rejects_invalid_method() {
+        let state = make_test_state().await;
+
+        let result = list_duplicate_groups(
+            State(state),
+            Query(ListDuplicatesQuery {
+                method: "invalid".to_string(),
+                limit: 50,
+                offset: 0,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn get_duplicate_group_returns_404_when_not_found() {
+        let state = make_test_state().await;
+
+        let result = get_duplicate_group(
+            State(state),
+            Path("nonexistent_hash".to_string()),
+            Query(DuplicateGroupQuery {
+                method: "fingerprint".to_string(),
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn resolve_duplicate_rejects_missing_track_file_id() {
+        let state = make_test_state().await;
+
+        let result = resolve_duplicate_group(
+            State(state),
+            Path("some_key".to_string()),
+            Json(ResolveDuplicateRequest {
+                action: "delete_specific".to_string(),
+                track_file_id: None,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn resolve_duplicate_returns_404_for_nonexistent_file() {
+        let state = make_test_state().await;
+
+        let result = resolve_duplicate_group(
+            State(state),
+            Path("some_key".to_string()),
+            Json(ResolveDuplicateRequest {
+                action: "delete_specific".to_string(),
+                track_file_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn resolve_duplicate_rejects_unknown_action() {
+        let state = make_test_state().await;
+
+        let result = resolve_duplicate_group(
+            State(state),
+            Path("some_key".to_string()),
+            Json(ResolveDuplicateRequest {
+                action: "keep_best".to_string(),
+                track_file_id: None,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/chorrosion-api/src/handlers/duplicates.rs
+++ b/crates/chorrosion-api/src/handlers/duplicates.rs
@@ -353,7 +353,13 @@ pub async fn resolve_duplicate_group(
                     "track_file_id is required for delete_specific action",
                 )
             })?;
-            let track_file_id = Uuid::parse_str(&track_file_id_raw).map_err(|_| {
+            let track_file_id = Uuid::parse_str(&track_file_id_raw).map_err(|err| {
+                error!(
+                    target: "api",
+                    track_file_id = %track_file_id_raw,
+                    error = %err,
+                    "invalid track_file_id format for duplicate resolution"
+                );
                 error_response(
                     StatusCode::BAD_REQUEST,
                     "track_file_id must be a valid UUID",

--- a/crates/chorrosion-api/src/handlers/duplicates.rs
+++ b/crates/chorrosion-api/src/handlers/duplicates.rs
@@ -7,6 +7,7 @@ use chorrosion_application::AppState;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error};
 use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
 
 #[derive(Debug, Deserialize, ToSchema, IntoParams)]
 pub struct ListDuplicatesQuery {
@@ -106,9 +107,14 @@ fn error_response(
 }
 
 fn group_to_response(group: chorrosion_application::DuplicateGroup) -> DuplicateGroupResponse {
+    let method = match group.method {
+        chorrosion_application::DuplicateDetectionMethod::FingerprintHash => "fingerprint",
+        chorrosion_application::DuplicateDetectionMethod::FileHash => "hash",
+    };
+
     DuplicateGroupResponse {
         key: group.key,
-        method: format!("{:?}", group.method).to_lowercase(),
+        method: method.to_string(),
         file_count: group.file_count,
         first_seen_at: group.first_seen_at.to_rfc3339(),
     }
@@ -334,22 +340,86 @@ pub async fn get_duplicate_group(
 pub async fn resolve_duplicate_group(
     State(state): State<AppState>,
     Path(key): Path<String>,
+    Query(query): Query<DuplicateGroupQuery>,
     Json(payload): Json<ResolveDuplicateRequest>,
 ) -> Result<Json<ResolveDuplicateResponse>, (StatusCode, Json<ErrorResponse>)> {
-    debug!(target: "api", key = %key, action = %payload.action, "resolving duplicate group");
+    debug!(target: "api", key = %key, method = %query.method, action = %payload.action, "resolving duplicate group");
 
     match payload.action.as_str() {
         "delete_specific" => {
-            let track_file_id = payload.track_file_id.ok_or_else(|| {
+            let track_file_id_raw = payload.track_file_id.ok_or_else(|| {
                 error_response(
                     StatusCode::BAD_REQUEST,
                     "track_file_id is required for delete_specific action",
                 )
             })?;
+            let track_file_id = Uuid::parse_str(&track_file_id_raw).map_err(|_| {
+                error_response(
+                    StatusCode::BAD_REQUEST,
+                    "track_file_id must be a valid UUID",
+                )
+            })?;
+
+            let group_files = match query.method.as_str() {
+                "fingerprint" => state
+                    .duplicate_repository
+                    .get_files_by_fingerprint(&key)
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            target: "api",
+                            error = %err,
+                            "failed to get duplicate group by fingerprint for resolution"
+                        );
+                        error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "failed to resolve duplicate group",
+                        )
+                    })?,
+                "hash" => state
+                    .duplicate_repository
+                    .get_files_by_hash(&key)
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            target: "api",
+                            error = %err,
+                            "failed to get duplicate group by hash for resolution"
+                        );
+                        error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "failed to resolve duplicate group",
+                        )
+                    })?,
+                _ => {
+                    return Err(error_response(
+                        StatusCode::BAD_REQUEST,
+                        "method must be 'fingerprint' or 'hash'",
+                    ));
+                }
+            };
+
+            if group_files.is_empty() {
+                return Err(error_response(
+                    StatusCode::NOT_FOUND,
+                    "duplicate group not found",
+                ));
+            }
+
+            let track_file_id_str = track_file_id.to_string();
+            if !group_files
+                .iter()
+                .any(|file| file.track_file_id.to_string() == track_file_id_str)
+            {
+                return Err(error_response(
+                    StatusCode::NOT_FOUND,
+                    "track file not found in duplicate group",
+                ));
+            }
 
             let deleted = state
                 .duplicate_repository
-                .delete_track_file(&track_file_id)
+                .delete_track_file(&track_file_id_str)
                 .await
                 .map_err(|err| {
                     error!(target: "api", error = %err, "failed to delete track file");
@@ -367,7 +437,7 @@ pub async fn resolve_duplicate_group(
             }
 
             Ok(Json(ResolveDuplicateResponse {
-                message: format!("track file {} deleted", track_file_id),
+                message: format!("track file {} deleted", track_file_id_str),
             }))
         }
         _ => Err(error_response(
@@ -416,6 +486,34 @@ mod tests {
             Arc::new(SqliteDuplicateRepository::new(pool.clone())),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
+    }
+
+    async fn make_test_state_with_pool() -> (AppState, sqlx::SqlitePool) {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite");
+        sqlx::migrate!("../../migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+
+        let state = AppState::new(
+            AppConfig::default(),
+            Arc::new(SqliteArtistRepository::new(pool.clone())),
+            Arc::new(SqliteAlbumRepository::new(pool.clone())),
+            Arc::new(SqliteTrackRepository::new(pool.clone())),
+            Arc::new(SqliteQualityProfileRepository::new(pool.clone())),
+            Arc::new(SqliteMetadataProfileRepository::new(pool.clone())),
+            Arc::new(SqliteIndexerDefinitionRepository::new(pool.clone())),
+            Arc::new(SqliteDownloadClientDefinitionRepository::new(pool.clone())),
+            Arc::new(SqliteTagRepository::new(pool.clone())),
+            Arc::new(SqliteTaggedEntityRepository::new(pool.clone())),
+            Arc::new(SqliteSmartPlaylistRepository::new(pool.clone())),
+            Arc::new(SqliteDuplicateRepository::new(pool.clone())),
+            chorrosion_infrastructure::ResponseCache::new(100, 60),
+        );
+
+        (state, pool)
     }
 
     #[tokio::test]
@@ -521,6 +619,9 @@ mod tests {
         let result = resolve_duplicate_group(
             State(state),
             Path("some_key".to_string()),
+            Query(DuplicateGroupQuery {
+                method: "fingerprint".to_string(),
+            }),
             Json(ResolveDuplicateRequest {
                 action: "delete_specific".to_string(),
                 track_file_id: None,
@@ -540,6 +641,9 @@ mod tests {
         let result = resolve_duplicate_group(
             State(state),
             Path("some_key".to_string()),
+            Query(DuplicateGroupQuery {
+                method: "fingerprint".to_string(),
+            }),
             Json(ResolveDuplicateRequest {
                 action: "delete_specific".to_string(),
                 track_file_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
@@ -559,9 +663,192 @@ mod tests {
         let result = resolve_duplicate_group(
             State(state),
             Path("some_key".to_string()),
+            Query(DuplicateGroupQuery {
+                method: "fingerprint".to_string(),
+            }),
             Json(ResolveDuplicateRequest {
                 action: "keep_best".to_string(),
                 track_file_id: None,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn list_duplicates_returns_non_empty_with_expected_method_and_ordering() {
+        let (state, pool) = make_test_state_with_pool().await;
+
+        sqlx::query(
+            r#"
+            INSERT INTO artists (id, name, monitored, status, created_at, updated_at)
+            VALUES (?, ?, 1, 'continuing', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            "#,
+        )
+        .bind("11111111-1111-1111-1111-111111111111")
+        .bind("Test Artist")
+        .execute(&pool)
+        .await
+        .expect("insert artist");
+
+        sqlx::query(
+            r#"
+            INSERT INTO albums (id, artist_id, title, monitored, status, created_at, updated_at)
+            VALUES (?, ?, ?, 1, 'wanted', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            "#,
+        )
+        .bind("22222222-2222-2222-2222-222222222222")
+        .bind("11111111-1111-1111-1111-111111111111")
+        .bind("Test Album")
+        .execute(&pool)
+        .await
+        .expect("insert album");
+
+        sqlx::query(
+            r#"
+            INSERT INTO tracks (id, album_id, artist_id, title, track_number, has_file, monitored, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 1, 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            "#,
+        )
+        .bind("33333333-3333-3333-3333-333333333333")
+        .bind("22222222-2222-2222-2222-222222222222")
+        .bind("11111111-1111-1111-1111-111111111111")
+        .bind("Track 1")
+        .execute(&pool)
+        .await
+        .expect("insert track 1");
+
+        sqlx::query(
+            r#"
+            INSERT INTO tracks (id, album_id, artist_id, title, track_number, has_file, monitored, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 2, 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            "#,
+        )
+        .bind("44444444-4444-4444-4444-444444444444")
+        .bind("22222222-2222-2222-2222-222222222222")
+        .bind("11111111-1111-1111-1111-111111111111")
+        .bind("Track 2")
+        .execute(&pool)
+        .await
+        .expect("insert track 2");
+
+        sqlx::query(
+            r#"
+            INSERT INTO tracks (id, album_id, artist_id, title, track_number, has_file, monitored, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 3, 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            "#,
+        )
+        .bind("55555555-5555-5555-5555-555555555555")
+        .bind("22222222-2222-2222-2222-222222222222")
+        .bind("11111111-1111-1111-1111-111111111111")
+        .bind("Track 3")
+        .execute(&pool)
+        .await
+        .expect("insert track 3");
+
+        sqlx::query(
+            r#"
+            INSERT INTO track_files (id, track_id, path, size_bytes, quality, bitrate_kbps, codec, hash, fingerprint_hash, created_at)
+            VALUES (?, ?, ?, 100, 'flac', 1000, 'flac', 'hash_a', 'fp_a', '2026-01-01T00:00:00Z')
+            "#,
+        )
+        .bind("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        .bind("33333333-3333-3333-3333-333333333333")
+        .bind("/music/a.flac")
+        .execute(&pool)
+        .await
+        .expect("insert file a");
+
+        sqlx::query(
+            r#"
+            INSERT INTO track_files (id, track_id, path, size_bytes, quality, bitrate_kbps, codec, hash, fingerprint_hash, created_at)
+            VALUES (?, ?, ?, 100, 'flac', 1000, 'flac', 'hash_a', 'fp_a', '2026-01-02T00:00:00Z')
+            "#,
+        )
+        .bind("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        .bind("44444444-4444-4444-4444-444444444444")
+        .bind("/music/b.flac")
+        .execute(&pool)
+        .await
+        .expect("insert file b");
+
+        sqlx::query(
+            r#"
+            INSERT INTO track_files (id, track_id, path, size_bytes, quality, bitrate_kbps, codec, hash, fingerprint_hash, created_at)
+            VALUES (?, ?, ?, 100, 'flac', 1000, 'flac', 'hash_b', 'fp_b', '2026-01-03T00:00:00Z')
+            "#,
+        )
+        .bind("cccccccc-cccc-cccc-cccc-cccccccccccc")
+        .bind("55555555-5555-5555-5555-555555555555")
+        .bind("/music/c.flac")
+        .execute(&pool)
+        .await
+        .expect("insert file c");
+
+        sqlx::query(
+            r#"
+            INSERT INTO track_files (id, track_id, path, size_bytes, quality, bitrate_kbps, codec, hash, fingerprint_hash, created_at)
+            VALUES (?, ?, ?, 100, 'flac', 1000, 'flac', 'hash_b', 'fp_b', '2026-01-04T00:00:00Z')
+            "#,
+        )
+        .bind("dddddddd-dddd-dddd-dddd-dddddddddddd")
+        .bind("33333333-3333-3333-3333-333333333333")
+        .bind("/music/d.flac")
+        .execute(&pool)
+        .await
+        .expect("insert file d");
+
+        sqlx::query(
+            r#"
+            INSERT INTO track_files (id, track_id, path, size_bytes, quality, bitrate_kbps, codec, hash, fingerprint_hash, created_at)
+            VALUES (?, ?, ?, 100, 'flac', 1000, 'flac', 'hash_b', 'fp_b', '2026-01-05T00:00:00Z')
+            "#,
+        )
+        .bind("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+        .bind("44444444-4444-4444-4444-444444444444")
+        .bind("/music/e.flac")
+        .execute(&pool)
+        .await
+        .expect("insert file e");
+
+        let result = list_duplicate_groups(
+            State(state),
+            Query(ListDuplicatesQuery {
+                method: "hash".to_string(),
+                limit: 50,
+                offset: 0,
+            }),
+        )
+        .await
+        .expect("list hash duplicate groups should succeed");
+
+        assert_eq!(result.method, "hash");
+        assert_eq!(result.total, 2);
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.items[0].key, "hash_b");
+        assert_eq!(result.items[0].method, "hash");
+        assert_eq!(result.items[0].file_count, 3);
+        assert_eq!(result.items[1].key, "hash_a");
+        assert_eq!(result.items[1].method, "hash");
+        assert_eq!(result.items[1].file_count, 2);
+    }
+
+    #[tokio::test]
+    async fn resolve_duplicate_rejects_invalid_track_file_id_format() {
+        let state = make_test_state().await;
+
+        let result = resolve_duplicate_group(
+            State(state),
+            Path("some_key".to_string()),
+            Query(DuplicateGroupQuery {
+                method: "fingerprint".to_string(),
+            }),
+            Json(ResolveDuplicateRequest {
+                action: "delete_specific".to_string(),
+                track_file_id: Some("not-a-uuid".to_string()),
             }),
         )
         .await;

--- a/crates/chorrosion-api/src/handlers/events.rs
+++ b/crates/chorrosion-api/src/handlers/events.rs
@@ -497,6 +497,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -685,6 +685,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -437,6 +437,11 @@ mod tests {
                         pool.clone(),
                     ),
                 ),
+                Arc::new(
+                    chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                        pool.clone(),
+                    ),
+                ),
                 chorrosion_infrastructure::ResponseCache::new(100, 60),
             )
         }

--- a/crates/chorrosion-api/src/handlers/mod.rs
+++ b/crates/chorrosion-api/src/handlers/mod.rs
@@ -5,6 +5,7 @@ pub mod artists;
 pub mod auth;
 pub mod calendar;
 pub mod download_clients;
+pub mod duplicates;
 pub mod events;
 pub mod imports;
 pub mod indexers;

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -448,6 +448,11 @@ mod tests {
                         pool.clone(),
                     ),
                 ),
+                Arc::new(
+                    chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                        pool.clone(),
+                    ),
+                ),
                 chorrosion_infrastructure::ResponseCache::new(100, 60),
             )
         }

--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -360,6 +360,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/handlers/smart_playlists.rs
+++ b/crates/chorrosion-api/src/handlers/smart_playlists.rs
@@ -570,6 +570,11 @@ mod tests {
             Arc::new(SqliteTagRepository::new(pool.clone())),
             Arc::new(SqliteTaggedEntityRepository::new(pool.clone())),
             Arc::new(SqliteSmartPlaylistRepository::new(pool.clone())),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/handlers/system.rs
+++ b/crates/chorrosion-api/src/handlers/system.rs
@@ -396,6 +396,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/handlers/tags.rs
+++ b/crates/chorrosion-api/src/handlers/tags.rs
@@ -563,6 +563,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/handlers/tracks.rs
+++ b/crates/chorrosion-api/src/handlers/tracks.rs
@@ -808,6 +808,11 @@ mod tests {
                         pool.clone(),
                     ),
                 ),
+                Arc::new(
+                    chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                        pool.clone(),
+                    ),
+                ),
                 chorrosion_infrastructure::ResponseCache::new(100, 60),
             )
         }

--- a/crates/chorrosion-api/src/handlers/wanted.rs
+++ b/crates/chorrosion-api/src/handlers/wanted.rs
@@ -400,6 +400,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         );
         (pool, state)

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -54,6 +54,13 @@ use handlers::download_clients::{
     __path_create_download_client, __path_delete_download_client, __path_get_download_client,
     __path_list_download_clients, __path_update_download_client,
 };
+use handlers::duplicates::{
+    get_duplicate_group, list_duplicate_groups, resolve_duplicate_group, DuplicateFileResponse,
+    DuplicateGroupDetailResponse, DuplicateGroupQuery, DuplicateGroupResponse,
+    ErrorResponse as DuplicateErrorResponse, ListDuplicatesQuery, ListDuplicatesResponse,
+    ResolveDuplicateRequest, ResolveDuplicateResponse, __path_get_duplicate_group,
+    __path_list_duplicate_groups, __path_resolve_duplicate_group,
+};
 use handlers::events::{
     __path_get_sse_connections, __path_post_broadcast_event,
     __path_stream_download_progress_events, __path_stream_events,
@@ -337,6 +344,9 @@ async fn metrics() -> axum::response::Response {
         update_smart_playlist,
         delete_smart_playlist,
         get_smart_playlist_items,
+        list_duplicate_groups,
+        get_duplicate_group,
+        resolve_duplicate_group,
     ),
     components(
         schemas(
@@ -440,6 +450,15 @@ async fn metrics() -> axum::response::Response {
             CreateSmartPlaylistRequest,
             SmartPlaylistItemsResponse,
             SmartPlaylistErrorResponse,
+            ListDuplicatesResponse,
+            DuplicateGroupResponse,
+            DuplicateGroupDetailResponse,
+            DuplicateFileResponse,
+            ResolveDuplicateRequest,
+            ResolveDuplicateResponse,
+            DuplicateErrorResponse,
+            ListDuplicatesQuery,
+            DuplicateGroupQuery,
         )
     ),
     tags(
@@ -456,7 +475,8 @@ async fn metrics() -> axum::response::Response {
         (name = "wanted", description = "Wanted and missing album tracking"),
         (name = "calendar", description = "Upcoming releases calendar"),
         (name = "tags", description = "Tag organization endpoints"),
-        (name = "smart_playlists", description = "Dynamic smart playlist endpoints")
+        (name = "smart_playlists", description = "Dynamic smart playlist endpoints"),
+        (name = "duplicates", description = "Duplicate file detection and management endpoints")
     ),
     modifiers(&SecurityAddon),
     info(
@@ -575,6 +595,9 @@ pub fn router(state: AppState) -> Router {
             "/smart-playlists/:playlist_id/items",
             get(get_smart_playlist_items),
         )
+        .route("/duplicates", get(list_duplicate_groups))
+        .route("/duplicates/:key", get(get_duplicate_group))
+        .route("/duplicates/:key/resolve", post(resolve_duplicate_group))
         .route("/tags", get(list_tags).post(create_tag))
         .route(
             "/tags/:tag_id",
@@ -645,6 +668,11 @@ mod health_tests {
             Arc::new(SqliteTaggedEntityRepository::new(pool.clone())),
             Arc::new(
                 chorrosion_infrastructure::sqlite_adapters::SqliteSmartPlaylistRepository::new(
+                    pool.clone(),
+                ),
+            ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
                     pool.clone(),
                 ),
             ),

--- a/crates/chorrosion-api/src/middleware/auth.rs
+++ b/crates/chorrosion-api/src/middleware/auth.rs
@@ -387,6 +387,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }

--- a/crates/chorrosion-api/src/middleware/tracing.rs
+++ b/crates/chorrosion-api/src/middleware/tracing.rs
@@ -110,6 +110,11 @@ mod tests {
                     pool.clone(),
                 ),
             ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
             chorrosion_infrastructure::ResponseCache::new(100, 60),
         )
     }
@@ -201,6 +206,11 @@ mod tests {
             Arc::new(SqliteTaggedEntityRepository::new(pool_handle.clone())),
             Arc::new(
                 chorrosion_infrastructure::sqlite_adapters::SqliteSmartPlaylistRepository::new(
+                    pool_handle.clone(),
+                ),
+            ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
                     pool_handle.clone(),
                 ),
             ),

--- a/crates/chorrosion-api/tests/full_workflow_tests.rs
+++ b/crates/chorrosion-api/tests/full_workflow_tests.rs
@@ -52,6 +52,11 @@ fn make_state(pool: SqlitePool) -> AppState {
                 pool.clone(),
             ),
         ),
+        Arc::new(
+            chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                pool.clone(),
+            ),
+        ),
         chorrosion_infrastructure::ResponseCache::new(100, 60),
     )
 }

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -2,7 +2,7 @@
 use chorrosion_config::AppConfig;
 use chorrosion_infrastructure::{
     repositories::{
-        AlbumRepository, ArtistRepository, DownloadClientDefinitionRepository,
+        AlbumRepository, ArtistRepository, DownloadClientDefinitionRepository, DuplicateRepository,
         IndexerDefinitionRepository, MetadataProfileRepository, QualityProfileRepository,
         SmartPlaylistRepository, TagRepository, TaggedEntityRepository, TrackRepository,
     },
@@ -101,9 +101,10 @@ pub use tag_embedding::{
 };
 pub use tag_sanitation::TagSanitizer;
 
-// Re-export tag and smart playlist domain types for API layer
+// Re-export tag, smart playlist, and duplicate detection domain types for API layer
 pub use chorrosion_domain::{
-    EntityType, SmartPlaylist, SmartPlaylistCriteria, SmartPlaylistId, Tag, TagId, TaggedEntity,
+    DuplicateDetectionMethod, DuplicateFileDetail, DuplicateGroup, EntityType, SmartPlaylist,
+    SmartPlaylistCriteria, SmartPlaylistId, Tag, TagId, TaggedEntity,
 };
 
 use tracing::info;
@@ -354,6 +355,7 @@ pub struct AppState {
     pub tag_repository: Arc<dyn TagRepository>,
     pub tagged_entity_repository: Arc<dyn TaggedEntityRepository>,
     pub smart_playlist_repository: Arc<dyn SmartPlaylistRepository>,
+    pub duplicate_repository: Arc<dyn DuplicateRepository>,
     /// In-memory cache for serialized API GET responses.
     pub response_cache: ResponseCache,
     /// Short-lived cache for the polled download-client activity snapshot.
@@ -378,6 +380,7 @@ impl AppState {
         tag_repository: Arc<dyn TagRepository>,
         tagged_entity_repository: Arc<dyn TaggedEntityRepository>,
         smart_playlist_repository: Arc<dyn SmartPlaylistRepository>,
+        duplicate_repository: Arc<dyn DuplicateRepository>,
         response_cache: ResponseCache,
     ) -> Self {
         Self {
@@ -395,6 +398,7 @@ impl AppState {
             tag_repository,
             tagged_entity_repository,
             smart_playlist_repository,
+            duplicate_repository,
             response_cache,
         }
     }

--- a/crates/chorrosion-cli/src/main.rs
+++ b/crates/chorrosion-cli/src/main.rs
@@ -10,9 +10,10 @@ use chorrosion_infrastructure::{
     init_database,
     sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
-        SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,
-        SqliteQualityProfileRepository, SqliteSmartPlaylistRepository, SqliteTagRepository,
-        SqliteTaggedEntityRepository, SqliteTrackRepository,
+        SqliteDuplicateRepository, SqliteIndexerDefinitionRepository,
+        SqliteMetadataProfileRepository, SqliteQualityProfileRepository,
+        SqliteSmartPlaylistRepository, SqliteTagRepository, SqliteTaggedEntityRepository,
+        SqliteTrackRepository,
     },
     ResponseCache,
 };
@@ -49,6 +50,7 @@ async fn main() -> Result<()> {
     let tag_repository = Arc::new(SqliteTagRepository::new(pool.clone()));
     let tagged_entity_repository = Arc::new(SqliteTaggedEntityRepository::new(pool.clone()));
     let smart_playlist_repository = Arc::new(SqliteSmartPlaylistRepository::new(pool.clone()));
+    let duplicate_repository = Arc::new(SqliteDuplicateRepository::new(pool.clone()));
 
     let response_cache = ResponseCache::new(
         config.cache.api_response_max_capacity,
@@ -67,6 +69,7 @@ async fn main() -> Result<()> {
         tag_repository,
         tagged_entity_repository,
         smart_playlist_repository,
+        duplicate_repository,
         response_cache,
     );
     state.on_start();

--- a/crates/chorrosion-domain/src/lib.rs
+++ b/crates/chorrosion-domain/src/lib.rs
@@ -855,6 +855,51 @@ impl SmartPlaylist {
     }
 }
 
+// ============================================================================
+// Duplicate Detection
+// ============================================================================
+
+/// How a duplicate group was detected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DuplicateDetectionMethod {
+    /// Duplicate detected via matching Chromaprint fingerprint hash.
+    FingerprintHash,
+    /// Duplicate detected via identical file content hash.
+    FileHash,
+}
+
+/// A summary of a group of files identified as duplicates.
+///
+/// Groups are synthetic — computed on-the-fly from `track_files` data and
+/// never persisted in their own table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DuplicateGroup {
+    /// The shared hash key that identifies this group.
+    pub key: String,
+    /// Detection strategy that produced this group.
+    pub method: DuplicateDetectionMethod,
+    /// Number of files in this group.
+    pub file_count: i64,
+    /// Earliest `created_at` timestamp across all files in the group.
+    pub first_seen_at: DateTime<Utc>,
+}
+
+/// Detailed information about a single file within a duplicate group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DuplicateFileDetail {
+    pub track_file_id: TrackFileId,
+    pub track_id: TrackId,
+    pub path: String,
+    pub size_bytes: u64,
+    pub quality: Option<String>,
+    pub bitrate_kbps: Option<u32>,
+    pub codec: Option<String>,
+    pub fingerprint_hash: Option<String>,
+    pub file_hash: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DownloadClientDefinition {
     pub id: DownloadClientDefinitionId,

--- a/crates/chorrosion-infrastructure/src/repositories.rs
+++ b/crates/chorrosion-infrastructure/src/repositories.rs
@@ -2,8 +2,9 @@
 use anyhow::Result;
 use chorrosion_domain::{
     Album, AlbumId, AlbumStatus, Artist, ArtistId, ArtistRelationship, ArtistStatus,
-    DownloadClientDefinition, EntityType, IndexerDefinition, MetadataProfile, QualityProfile,
-    SmartPlaylist, Tag, TagId, TaggedEntity, Track, TrackFile, TrackId,
+    DownloadClientDefinition, DuplicateFileDetail, DuplicateGroup, EntityType, IndexerDefinition,
+    MetadataProfile, QualityProfile, SmartPlaylist, Tag, TagId, TaggedEntity, Track, TrackFile,
+    TrackId,
 };
 use chrono::NaiveDate;
 
@@ -251,4 +252,45 @@ pub trait SmartPlaylistRepository: Repository<SmartPlaylist> {
 
     /// Count all smart playlists.
     async fn count(&self) -> Result<i64>;
+}
+
+/// Repository for detecting and managing duplicate track files.
+///
+/// Duplicates are computed by querying the existing `track_files` table;
+/// no separate storage table is required.
+#[async_trait::async_trait]
+pub trait DuplicateRepository: Send + Sync {
+    /// Find groups of track files that share the same Chromaprint fingerprint hash.
+    async fn find_fingerprint_duplicate_groups(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<DuplicateGroup>>;
+
+    /// Count total fingerprint duplicate groups (for pagination metadata).
+    async fn count_fingerprint_duplicate_groups(&self) -> Result<i64>;
+
+    /// Find groups of track files that share the same content hash.
+    async fn find_hash_duplicate_groups(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<DuplicateGroup>>;
+
+    /// Count total hash duplicate groups (for pagination metadata).
+    async fn count_hash_duplicate_groups(&self) -> Result<i64>;
+
+    /// Return all files that share the given Chromaprint fingerprint hash.
+    async fn get_files_by_fingerprint(
+        &self,
+        fingerprint_hash: &str,
+    ) -> Result<Vec<DuplicateFileDetail>>;
+
+    /// Return all files that share the given content hash.
+    async fn get_files_by_hash(&self, file_hash: &str) -> Result<Vec<DuplicateFileDetail>>;
+
+    /// Delete a specific track file record by ID.
+    ///
+    /// Returns `true` if a row was deleted, `false` if the ID was not found.
+    async fn delete_track_file(&self, track_file_id: &str) -> Result<bool>;
 }

--- a/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
@@ -2874,11 +2874,18 @@ fn row_to_smart_playlist(row: &sqlx::sqlite::SqliteRow) -> Result<SmartPlaylist>
 
 pub struct SqliteDuplicateRepository {
     pool: SqlitePool,
+    profiler: QueryProfiler,
 }
 
 impl SqliteDuplicateRepository {
     pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+        let profiler = QueryProfiler::new(pool.clone(), 0);
+        Self { pool, profiler }
+    }
+
+    pub fn new_with_threshold(pool: SqlitePool, threshold_ms: u64) -> Self {
+        let profiler = QueryProfiler::new(pool.clone(), threshold_ms);
+        Self { pool, profiler }
     }
 }
 
@@ -2889,23 +2896,28 @@ impl DuplicateRepository for SqliteDuplicateRepository {
         limit: i64,
         offset: i64,
     ) -> Result<Vec<DuplicateGroup>> {
-        let rows = sqlx::query(
-            r#"
-            SELECT fingerprint_hash AS key,
-                   COUNT(*) AS file_count,
-                   MIN(created_at) AS first_seen_at
-            FROM track_files
-            WHERE fingerprint_hash IS NOT NULL
-            GROUP BY fingerprint_hash
-            HAVING COUNT(*) > 1
-            ORDER BY file_count DESC, first_seen_at ASC
-            LIMIT ? OFFSET ?
-            "#,
-        )
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
-        .await?;
+        let rows = self
+            .profiler
+            .timed("duplicates::find_fingerprint_duplicate_groups", || async {
+                sqlx::query(
+                    r#"
+                    SELECT fingerprint_hash AS key,
+                           COUNT(*) AS file_count,
+                           MIN(created_at) AS first_seen_at
+                    FROM track_files
+                    WHERE fingerprint_hash IS NOT NULL
+                    GROUP BY fingerprint_hash
+                    HAVING COUNT(*) > 1
+                    ORDER BY file_count DESC, first_seen_at ASC
+                    LIMIT ? OFFSET ?
+                    "#,
+                )
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(&self.pool)
+                .await
+            })
+            .await?;
 
         rows.iter()
             .map(|row| row_to_duplicate_group(row, DuplicateDetectionMethod::FingerprintHash))
@@ -2913,19 +2925,24 @@ impl DuplicateRepository for SqliteDuplicateRepository {
     }
 
     async fn count_fingerprint_duplicate_groups(&self) -> Result<i64> {
-        let row = sqlx::query(
-            r#"
-            SELECT COUNT(*) AS cnt FROM (
-                SELECT fingerprint_hash
-                FROM track_files
-                WHERE fingerprint_hash IS NOT NULL
-                GROUP BY fingerprint_hash
-                HAVING COUNT(*) > 1
-            )
-            "#,
-        )
-        .fetch_one(&self.pool)
-        .await?;
+        let row = self
+            .profiler
+            .timed("duplicates::count_fingerprint_duplicate_groups", || async {
+                sqlx::query(
+                    r#"
+                    SELECT COUNT(*) AS cnt FROM (
+                        SELECT fingerprint_hash
+                        FROM track_files
+                        WHERE fingerprint_hash IS NOT NULL
+                        GROUP BY fingerprint_hash
+                        HAVING COUNT(*) > 1
+                    )
+                    "#,
+                )
+                .fetch_one(&self.pool)
+                .await
+            })
+            .await?;
 
         let cnt: i64 = row.try_get("cnt")?;
         Ok(cnt)
@@ -2936,23 +2953,28 @@ impl DuplicateRepository for SqliteDuplicateRepository {
         limit: i64,
         offset: i64,
     ) -> Result<Vec<DuplicateGroup>> {
-        let rows = sqlx::query(
-            r#"
-            SELECT hash AS key,
-                   COUNT(*) AS file_count,
-                   MIN(created_at) AS first_seen_at
-            FROM track_files
-            WHERE hash IS NOT NULL
-            GROUP BY hash
-            HAVING COUNT(*) > 1
-            ORDER BY file_count DESC, first_seen_at ASC
-            LIMIT ? OFFSET ?
-            "#,
-        )
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
-        .await?;
+        let rows = self
+            .profiler
+            .timed("duplicates::find_hash_duplicate_groups", || async {
+                sqlx::query(
+                    r#"
+                    SELECT hash AS key,
+                           COUNT(*) AS file_count,
+                           MIN(created_at) AS first_seen_at
+                    FROM track_files
+                    WHERE hash IS NOT NULL
+                    GROUP BY hash
+                    HAVING COUNT(*) > 1
+                    ORDER BY file_count DESC, first_seen_at ASC
+                    LIMIT ? OFFSET ?
+                    "#,
+                )
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(&self.pool)
+                .await
+            })
+            .await?;
 
         rows.iter()
             .map(|row| row_to_duplicate_group(row, DuplicateDetectionMethod::FileHash))
@@ -2960,19 +2982,24 @@ impl DuplicateRepository for SqliteDuplicateRepository {
     }
 
     async fn count_hash_duplicate_groups(&self) -> Result<i64> {
-        let row = sqlx::query(
-            r#"
-            SELECT COUNT(*) AS cnt FROM (
-                SELECT hash
-                FROM track_files
-                WHERE hash IS NOT NULL
-                GROUP BY hash
-                HAVING COUNT(*) > 1
-            )
-            "#,
-        )
-        .fetch_one(&self.pool)
-        .await?;
+        let row = self
+            .profiler
+            .timed("duplicates::count_hash_duplicate_groups", || async {
+                sqlx::query(
+                    r#"
+                    SELECT COUNT(*) AS cnt FROM (
+                        SELECT hash
+                        FROM track_files
+                        WHERE hash IS NOT NULL
+                        GROUP BY hash
+                        HAVING COUNT(*) > 1
+                    )
+                    "#,
+                )
+                .fetch_one(&self.pool)
+                .await
+            })
+            .await?;
 
         let cnt: i64 = row.try_get("cnt")?;
         Ok(cnt)
@@ -2982,35 +3009,45 @@ impl DuplicateRepository for SqliteDuplicateRepository {
         &self,
         fingerprint_hash: &str,
     ) -> Result<Vec<DuplicateFileDetail>> {
-        let rows = sqlx::query(
-            r#"
-            SELECT id, track_id, path, size_bytes, quality, bitrate_kbps, codec,
-                   fingerprint_hash, hash, created_at
-            FROM track_files
-            WHERE fingerprint_hash = ?
-            ORDER BY bitrate_kbps DESC, size_bytes DESC
-            "#,
-        )
-        .bind(fingerprint_hash)
-        .fetch_all(&self.pool)
-        .await?;
+        let rows = self
+            .profiler
+            .timed("duplicates::get_files_by_fingerprint", || async {
+                sqlx::query(
+                    r#"
+                    SELECT id, track_id, path, size_bytes, quality, bitrate_kbps, codec,
+                           fingerprint_hash, hash, created_at
+                    FROM track_files
+                    WHERE fingerprint_hash = ?
+                    ORDER BY bitrate_kbps DESC, size_bytes DESC
+                    "#,
+                )
+                .bind(fingerprint_hash)
+                .fetch_all(&self.pool)
+                .await
+            })
+            .await?;
 
         rows.iter().map(row_to_duplicate_file_detail).collect()
     }
 
     async fn get_files_by_hash(&self, file_hash: &str) -> Result<Vec<DuplicateFileDetail>> {
-        let rows = sqlx::query(
-            r#"
-            SELECT id, track_id, path, size_bytes, quality, bitrate_kbps, codec,
-                   fingerprint_hash, hash, created_at
-            FROM track_files
-            WHERE hash = ?
-            ORDER BY bitrate_kbps DESC, size_bytes DESC
-            "#,
-        )
-        .bind(file_hash)
-        .fetch_all(&self.pool)
-        .await?;
+        let rows = self
+            .profiler
+            .timed("duplicates::get_files_by_hash", || async {
+                sqlx::query(
+                    r#"
+                    SELECT id, track_id, path, size_bytes, quality, bitrate_kbps, codec,
+                           fingerprint_hash, hash, created_at
+                    FROM track_files
+                    WHERE hash = ?
+                    ORDER BY bitrate_kbps DESC, size_bytes DESC
+                    "#,
+                )
+                .bind(file_hash)
+                .fetch_all(&self.pool)
+                .await
+            })
+            .await?;
 
         rows.iter().map(row_to_duplicate_file_detail).collect()
     }
@@ -3018,9 +3055,14 @@ impl DuplicateRepository for SqliteDuplicateRepository {
     async fn delete_track_file(&self, track_file_id: &str) -> Result<bool> {
         debug!(target: "repository", track_file_id, "deleting track file (duplicate resolution)");
 
-        let result = sqlx::query("DELETE FROM track_files WHERE id = ?")
-            .bind(track_file_id)
-            .execute(&self.pool)
+        let result = self
+            .profiler
+            .timed("duplicates::delete_track_file", || async {
+                sqlx::query("DELETE FROM track_files WHERE id = ?")
+                    .bind(track_file_id)
+                    .execute(&self.pool)
+                    .await
+            })
             .await?;
 
         Ok(result.rows_affected() > 0)

--- a/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
+++ b/crates/chorrosion-infrastructure/src/sqlite_adapters.rs
@@ -2,10 +2,10 @@
 use anyhow::{anyhow, Result};
 use chorrosion_domain::{
     Album, AlbumId, AlbumStatus, Artist, ArtistId, ArtistRelationship, ArtistRelationshipId,
-    ArtistStatus, DownloadClientDefinition, DownloadClientDefinitionId, EntityType,
-    IndexerDefinition, IndexerDefinitionId, MetadataProfile, ProfileId, QualityProfile,
-    SmartPlaylist, SmartPlaylistCriteria, SmartPlaylistId, Tag, TagId, TaggedEntity, Track,
-    TrackFile, TrackFileId, TrackId,
+    ArtistStatus, DownloadClientDefinition, DownloadClientDefinitionId, DuplicateDetectionMethod,
+    DuplicateFileDetail, DuplicateGroup, EntityType, IndexerDefinition, IndexerDefinitionId,
+    MetadataProfile, ProfileId, QualityProfile, SmartPlaylist, SmartPlaylistCriteria,
+    SmartPlaylistId, Tag, TagId, TaggedEntity, Track, TrackFile, TrackFileId, TrackId,
 };
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use sqlx::Row;
@@ -16,9 +16,9 @@ use uuid::Uuid;
 use crate::profiler::QueryProfiler;
 use crate::repositories::{
     AlbumRepository, ArtistRelationshipRepository, ArtistRepository,
-    DownloadClientDefinitionRepository, IndexerDefinitionRepository, MetadataProfileRepository,
-    QualityProfileRepository, Repository, SmartPlaylistRepository, TrackFileRepository,
-    TrackRepository,
+    DownloadClientDefinitionRepository, DuplicateRepository, IndexerDefinitionRepository,
+    MetadataProfileRepository, QualityProfileRepository, Repository, SmartPlaylistRepository,
+    TagRepository, TaggedEntityRepository, TrackFileRepository, TrackRepository,
 };
 
 /// SQLx-backed Artist repository
@@ -2374,8 +2374,6 @@ impl Repository<Tag> for SqliteTagRepository {
     }
 }
 
-use crate::repositories::TagRepository;
-
 #[async_trait::async_trait]
 impl TagRepository for SqliteTagRepository {
     async fn get_by_name(&self, name: &str) -> Result<Option<Tag>> {
@@ -2539,8 +2537,6 @@ impl Repository<TaggedEntity> for SqliteTaggedEntityRepository {
         ))
     }
 }
-
-use crate::repositories::TaggedEntityRepository;
 
 #[async_trait::async_trait]
 impl TaggedEntityRepository for SqliteTaggedEntityRepository {
@@ -2869,6 +2865,210 @@ fn row_to_smart_playlist(row: &sqlx::sqlite::SqliteRow) -> Result<SmartPlaylist>
         criteria,
         created_at: parse_dt(created_at_str)?,
         updated_at: parse_dt(updated_at_str)?,
+    })
+}
+
+// ============================================================================
+// Duplicate Detection Repository
+// ============================================================================
+
+pub struct SqliteDuplicateRepository {
+    pool: SqlitePool,
+}
+
+impl SqliteDuplicateRepository {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl DuplicateRepository for SqliteDuplicateRepository {
+    async fn find_fingerprint_duplicate_groups(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<DuplicateGroup>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT fingerprint_hash AS key,
+                   COUNT(*) AS file_count,
+                   MIN(created_at) AS first_seen_at
+            FROM track_files
+            WHERE fingerprint_hash IS NOT NULL
+            GROUP BY fingerprint_hash
+            HAVING COUNT(*) > 1
+            ORDER BY file_count DESC, first_seen_at ASC
+            LIMIT ? OFFSET ?
+            "#,
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter()
+            .map(|row| row_to_duplicate_group(row, DuplicateDetectionMethod::FingerprintHash))
+            .collect()
+    }
+
+    async fn count_fingerprint_duplicate_groups(&self) -> Result<i64> {
+        let row = sqlx::query(
+            r#"
+            SELECT COUNT(*) AS cnt FROM (
+                SELECT fingerprint_hash
+                FROM track_files
+                WHERE fingerprint_hash IS NOT NULL
+                GROUP BY fingerprint_hash
+                HAVING COUNT(*) > 1
+            )
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        let cnt: i64 = row.try_get("cnt")?;
+        Ok(cnt)
+    }
+
+    async fn find_hash_duplicate_groups(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<DuplicateGroup>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT hash AS key,
+                   COUNT(*) AS file_count,
+                   MIN(created_at) AS first_seen_at
+            FROM track_files
+            WHERE hash IS NOT NULL
+            GROUP BY hash
+            HAVING COUNT(*) > 1
+            ORDER BY file_count DESC, first_seen_at ASC
+            LIMIT ? OFFSET ?
+            "#,
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter()
+            .map(|row| row_to_duplicate_group(row, DuplicateDetectionMethod::FileHash))
+            .collect()
+    }
+
+    async fn count_hash_duplicate_groups(&self) -> Result<i64> {
+        let row = sqlx::query(
+            r#"
+            SELECT COUNT(*) AS cnt FROM (
+                SELECT hash
+                FROM track_files
+                WHERE hash IS NOT NULL
+                GROUP BY hash
+                HAVING COUNT(*) > 1
+            )
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        let cnt: i64 = row.try_get("cnt")?;
+        Ok(cnt)
+    }
+
+    async fn get_files_by_fingerprint(
+        &self,
+        fingerprint_hash: &str,
+    ) -> Result<Vec<DuplicateFileDetail>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, track_id, path, size_bytes, quality, bitrate_kbps, codec,
+                   fingerprint_hash, hash, created_at
+            FROM track_files
+            WHERE fingerprint_hash = ?
+            ORDER BY bitrate_kbps DESC, size_bytes DESC
+            "#,
+        )
+        .bind(fingerprint_hash)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_duplicate_file_detail).collect()
+    }
+
+    async fn get_files_by_hash(&self, file_hash: &str) -> Result<Vec<DuplicateFileDetail>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, track_id, path, size_bytes, quality, bitrate_kbps, codec,
+                   fingerprint_hash, hash, created_at
+            FROM track_files
+            WHERE hash = ?
+            ORDER BY bitrate_kbps DESC, size_bytes DESC
+            "#,
+        )
+        .bind(file_hash)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_duplicate_file_detail).collect()
+    }
+
+    async fn delete_track_file(&self, track_file_id: &str) -> Result<bool> {
+        debug!(target: "repository", track_file_id, "deleting track file (duplicate resolution)");
+
+        let result = sqlx::query("DELETE FROM track_files WHERE id = ?")
+            .bind(track_file_id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}
+
+fn row_to_duplicate_group(
+    row: &sqlx::sqlite::SqliteRow,
+    method: DuplicateDetectionMethod,
+) -> Result<DuplicateGroup> {
+    let key: String = row.try_get("key")?;
+    let file_count: i64 = row.try_get("file_count")?;
+    let first_seen_at_str: String = row.try_get("first_seen_at")?;
+    Ok(DuplicateGroup {
+        key,
+        method,
+        file_count,
+        first_seen_at: parse_dt(first_seen_at_str)?,
+    })
+}
+
+fn row_to_duplicate_file_detail(row: &sqlx::sqlite::SqliteRow) -> Result<DuplicateFileDetail> {
+    let id_str: String = row.try_get("id")?;
+    let track_id_str: String = row.try_get("track_id")?;
+    let path: String = row.try_get("path")?;
+    let size_bytes: i64 = row.try_get("size_bytes")?;
+    let quality: Option<String> = row.try_get("quality")?;
+    let bitrate_kbps: Option<i64> = row.try_get("bitrate_kbps")?;
+    let codec: Option<String> = row.try_get("codec")?;
+    let fingerprint_hash: Option<String> = row.try_get("fingerprint_hash")?;
+    let file_hash: Option<String> = row.try_get("hash")?;
+    let created_at_str: String = row.try_get("created_at")?;
+
+    Ok(DuplicateFileDetail {
+        track_file_id: TrackFileId::from_uuid(
+            Uuid::parse_str(&id_str).map_err(|e| anyhow!("Invalid UUID: {}", e))?,
+        ),
+        track_id: TrackId::from_uuid(
+            Uuid::parse_str(&track_id_str).map_err(|e| anyhow!("Invalid track UUID: {}", e))?,
+        ),
+        path,
+        size_bytes: size_bytes as u64,
+        quality,
+        bitrate_kbps: bitrate_kbps.map(|b| b as u32),
+        codec,
+        fingerprint_hash,
+        file_hash,
+        created_at: parse_dt(created_at_str)?,
     })
 }
 

--- a/migrations/20260423000000_add_track_files_hash_index.sql
+++ b/migrations/20260423000000_add_track_files_hash_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_track_files_hash_created_at
+    ON track_files(hash, created_at DESC);

--- a/migrations/postgres/20260423000000_add_track_files_hash_index.sql
+++ b/migrations/postgres/20260423000000_add_track_files_hash_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_track_files_hash_created_at
+    ON track_files(hash, created_at DESC);


### PR DESCRIPTION
## Summary

Implements Issue #402 by adding advanced duplicate detection and management end-to-end across domain, infrastructure, application, CLI, and API layers.

### What changed

- Added duplicate detection domain models:
  - `DuplicateDetectionMethod`
  - `DuplicateGroup`
  - `DuplicateFileDetail`
- Added `DuplicateRepository` trait and SQLite implementation:
  - duplicate-group discovery by fingerprint hash and file hash
  - group counts for pagination
  - file-level detail retrieval for a group key
  - duplicate resolution action to delete a specific track file
- Extended `AppState` with `duplicate_repository`
  - updated constructor call sites across handlers/middleware tests, benches, API health tests, and CLI wiring
- Added API duplicate management endpoints:
  - `GET /api/v1/duplicates?method=fingerprint|hash&limit=&offset=`
  - `GET /api/v1/duplicates/:key?method=fingerprint|hash`
  - `POST /api/v1/duplicates/:key/resolve`
- Added OpenAPI wiring:
  - new paths
  - new schemas
  - new `duplicates` tag
- Added focused API handler tests for duplicate endpoints
- Updated roadmap status for Issue #402 completion

## Validation

- `cargo build -p chorrosion-api`
- `cargo build -p chorrosion-cli`
- `cargo test -p chorrosion-api` (246 unit/integration tests + full workflow test passed)
- `cargo fmt --all`
- `cargo clippy --workspace -- -D warnings`

Closes #402
