### PR TITLE
feat: add Extension API foundation (Issue #413)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -465,7 +465,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 ### 10.2 Community Features
 
 - [x] Plugin system architecture (Issue #411) ✓
-- [ ] Extension API
+- [x] Extension API (Issue #413) ✓
 - [ ] Community indexer definitions
 - [ ] Custom script hooks
 
@@ -532,4 +532,4 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 **Last Updated:** 2026-04-22  
 **Current Phase:** Phase 10: Optional Enhancements  
-**Next Milestone:** Extension API
+**Next Milestone:** Community indexer definitions

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -84,7 +84,10 @@ pub use notifications::{
     NotificationProviderKind, PushoverProvider, ScriptNotificationProvider, SlackWebhookProvider,
 };
 pub use permission::{PermissionChecker, PermissionConfig, PermissionError, PermissionManager};
-pub use plugins::{Plugin, PluginCapability, PluginManifest, PluginRegistry};
+pub use plugins::{
+    ExtensionApiHandler, ExtensionApiRequest, ExtensionApiResponse, Plugin, PluginCapability,
+    PluginManifest, PluginRegistry,
+};
 pub use quality_upgrade::{QualityComparer, QualityUpgradeService, UpgradeDecision, UpgradeReason};
 pub use release_parsing::{
     deduplicate_releases, filter_releases, find_duplicate_keys, parse_release_title, rank_releases,

--- a/crates/chorrosion-application/src/plugins.rs
+++ b/crates/chorrosion-application/src/plugins.rs
@@ -61,6 +61,18 @@ pub struct PluginRegistry {
     extension_apis: Arc<RwLock<HashMap<String, Arc<dyn ExtensionApiHandler>>>>,
 }
 
+fn validate_extension_namespace(namespace: &str) -> Result<()> {
+    if namespace.trim().is_empty() {
+        return Err(anyhow!("extension namespace cannot be empty"));
+    }
+    if namespace != namespace.trim() {
+        return Err(anyhow!(
+            "extension namespace cannot have leading or trailing whitespace"
+        ));
+    }
+    Ok(())
+}
+
 impl PluginRegistry {
     pub fn new() -> Self {
         Self {
@@ -123,14 +135,7 @@ impl PluginRegistry {
         namespace: &str,
         handler: Arc<dyn ExtensionApiHandler>,
     ) -> Result<()> {
-        if namespace.trim().is_empty() {
-            return Err(anyhow!("extension namespace cannot be empty"));
-        }
-        if namespace != namespace.trim() {
-            return Err(anyhow!(
-                "extension namespace cannot have leading or trailing whitespace"
-            ));
-        }
+        validate_extension_namespace(namespace)?;
 
         let mut apis = self.extension_apis.write().await;
         if apis.contains_key(namespace) {
@@ -156,14 +161,7 @@ impl PluginRegistry {
         namespace: &str,
         request: ExtensionApiRequest,
     ) -> Result<ExtensionApiResponse> {
-        if namespace.trim().is_empty() {
-            return Err(anyhow!("extension namespace cannot be empty"));
-        }
-        if namespace != namespace.trim() {
-            return Err(anyhow!(
-                "extension namespace cannot have leading or trailing whitespace"
-            ));
-        }
+        validate_extension_namespace(namespace)?;
 
         let handler = {
             let apis = self.extension_apis.read().await;

--- a/crates/chorrosion-application/src/plugins.rs
+++ b/crates/chorrosion-application/src/plugins.rs
@@ -123,9 +123,13 @@ impl PluginRegistry {
         namespace: &str,
         handler: Arc<dyn ExtensionApiHandler>,
     ) -> Result<()> {
-        let namespace = namespace.trim();
-        if namespace.is_empty() {
+        if namespace.trim().is_empty() {
             return Err(anyhow!("extension namespace cannot be empty"));
+        }
+        if namespace != namespace.trim() {
+            return Err(anyhow!(
+                "extension namespace cannot have leading or trailing whitespace"
+            ));
         }
 
         let mut apis = self.extension_apis.write().await;
@@ -152,6 +156,15 @@ impl PluginRegistry {
         namespace: &str,
         request: ExtensionApiRequest,
     ) -> Result<ExtensionApiResponse> {
+        if namespace.trim().is_empty() {
+            return Err(anyhow!("extension namespace cannot be empty"));
+        }
+        if namespace != namespace.trim() {
+            return Err(anyhow!(
+                "extension namespace cannot have leading or trailing whitespace"
+            ));
+        }
+
         let handler = {
             let apis = self.extension_apis.read().await;
             apis.get(namespace).cloned()
@@ -332,6 +345,49 @@ mod tests {
 
         let namespaces = registry.list_extension_namespaces().await;
         assert_eq!(namespaces, vec!["media.tools", "metadata.lookup"]);
+    }
+
+    #[tokio::test]
+    async fn rejects_extension_namespace_with_surrounding_whitespace() {
+        let registry = PluginRegistry::new();
+
+        let err = registry
+            .register_extension_api("  media.tools  ", Arc::new(EchoExtensionApi))
+            .await
+            .expect_err("namespace with surrounding whitespace must fail");
+
+        assert!(
+            err.to_string().contains("leading or trailing whitespace"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(registry.list_extension_namespaces().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn dispatch_rejects_namespace_with_surrounding_whitespace() {
+        let registry = PluginRegistry::new();
+
+        registry
+            .register_extension_api("media.tools", Arc::new(EchoExtensionApi))
+            .await
+            .expect("register extension api");
+
+        let err = registry
+            .dispatch_extension_api(
+                "  media.tools  ",
+                ExtensionApiRequest {
+                    method: "GET".to_string(),
+                    path: "/health".to_string(),
+                    body: None,
+                },
+            )
+            .await
+            .expect_err("namespace with surrounding whitespace must fail dispatch");
+
+        assert!(
+            err.to_string().contains("leading or trailing whitespace"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/chorrosion-application/src/plugins.rs
+++ b/crates/chorrosion-application/src/plugins.rs
@@ -169,7 +169,8 @@ impl PluginRegistry {
         }
         .ok_or_else(|| anyhow!("extension namespace '{}' is not registered", namespace))?;
 
-        handler.handle(request).await
+        let response = handler.handle(request).await;
+        response
     }
 }
 

--- a/crates/chorrosion-application/src/plugins.rs
+++ b/crates/chorrosion-application/src/plugins.rs
@@ -24,6 +24,24 @@ pub struct PluginManifest {
     pub capabilities: Vec<PluginCapability>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionApiRequest {
+    pub method: String,
+    pub path: String,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionApiResponse {
+    pub status: u16,
+    pub body: Option<String>,
+}
+
+#[async_trait]
+pub trait ExtensionApiHandler: Send + Sync {
+    async fn handle(&self, request: ExtensionApiRequest) -> Result<ExtensionApiResponse>;
+}
+
 #[async_trait]
 pub trait Plugin: Send + Sync {
     fn manifest(&self) -> PluginManifest;
@@ -40,12 +58,14 @@ pub trait Plugin: Send + Sync {
 #[derive(Clone, Default)]
 pub struct PluginRegistry {
     plugins: Arc<RwLock<HashMap<String, Arc<dyn Plugin>>>>,
+    extension_apis: Arc<RwLock<HashMap<String, Arc<dyn ExtensionApiHandler>>>>,
 }
 
 impl PluginRegistry {
     pub fn new() -> Self {
         Self {
             plugins: Arc::new(RwLock::new(HashMap::new())),
+            extension_apis: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -97,6 +117,49 @@ impl PluginRegistry {
         manifests.sort_by(|a, b| a.id.cmp(&b.id));
         manifests
     }
+
+    pub async fn register_extension_api(
+        &self,
+        namespace: &str,
+        handler: Arc<dyn ExtensionApiHandler>,
+    ) -> Result<()> {
+        let namespace = namespace.trim();
+        if namespace.is_empty() {
+            return Err(anyhow!("extension namespace cannot be empty"));
+        }
+
+        let mut apis = self.extension_apis.write().await;
+        if apis.contains_key(namespace) {
+            return Err(anyhow!(
+                "extension namespace '{}' is already registered",
+                namespace
+            ));
+        }
+
+        apis.insert(namespace.to_string(), handler);
+        Ok(())
+    }
+
+    pub async fn list_extension_namespaces(&self) -> Vec<String> {
+        let apis = self.extension_apis.read().await;
+        let mut namespaces = apis.keys().cloned().collect::<Vec<_>>();
+        namespaces.sort();
+        namespaces
+    }
+
+    pub async fn dispatch_extension_api(
+        &self,
+        namespace: &str,
+        request: ExtensionApiRequest,
+    ) -> Result<ExtensionApiResponse> {
+        let handler = {
+            let apis = self.extension_apis.read().await;
+            apis.get(namespace).cloned()
+        }
+        .ok_or_else(|| anyhow!("extension namespace '{}' is not registered", namespace))?;
+
+        handler.handle(request).await
+    }
 }
 
 #[cfg(test)]
@@ -107,10 +170,22 @@ mod tests {
         manifest: PluginManifest,
     }
 
+    struct EchoExtensionApi;
+
     #[async_trait]
     impl Plugin for MockPlugin {
         fn manifest(&self) -> PluginManifest {
             self.manifest.clone()
+        }
+    }
+
+    #[async_trait]
+    impl ExtensionApiHandler for EchoExtensionApi {
+        async fn handle(&self, request: ExtensionApiRequest) -> Result<ExtensionApiResponse> {
+            Ok(ExtensionApiResponse {
+                status: 200,
+                body: Some(format!("{} {}", request.method, request.path)),
+            })
         }
     }
 
@@ -239,5 +314,90 @@ mod tests {
         assert_eq!(manifests.len(), 2);
         assert_eq!(manifests[0].id, "builtin.indexer.torznab");
         assert_eq!(manifests[1].id, "builtin.notification.discord");
+    }
+
+    #[tokio::test]
+    async fn registers_and_lists_extension_namespaces() {
+        let registry = PluginRegistry::new();
+
+        registry
+            .register_extension_api("media.tools", Arc::new(EchoExtensionApi))
+            .await
+            .expect("register extension api");
+
+        registry
+            .register_extension_api("metadata.lookup", Arc::new(EchoExtensionApi))
+            .await
+            .expect("register second extension api");
+
+        let namespaces = registry.list_extension_namespaces().await;
+        assert_eq!(namespaces, vec!["media.tools", "metadata.lookup"]);
+    }
+
+    #[tokio::test]
+    async fn rejects_duplicate_extension_namespace() {
+        let registry = PluginRegistry::new();
+
+        registry
+            .register_extension_api("media.tools", Arc::new(EchoExtensionApi))
+            .await
+            .expect("first registration succeeds");
+
+        let err = registry
+            .register_extension_api("media.tools", Arc::new(EchoExtensionApi))
+            .await
+            .expect_err("duplicate namespace must fail");
+
+        assert!(
+            err.to_string().contains("already registered"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatches_to_registered_extension_namespace() {
+        let registry = PluginRegistry::new();
+
+        registry
+            .register_extension_api("media.tools", Arc::new(EchoExtensionApi))
+            .await
+            .expect("register extension api");
+
+        let response = registry
+            .dispatch_extension_api(
+                "media.tools",
+                ExtensionApiRequest {
+                    method: "GET".to_string(),
+                    path: "/health".to_string(),
+                    body: None,
+                },
+            )
+            .await
+            .expect("dispatch succeeds");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body.as_deref(), Some("GET /health"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_to_unknown_namespace_returns_error() {
+        let registry = PluginRegistry::new();
+
+        let err = registry
+            .dispatch_extension_api(
+                "unknown.namespace",
+                ExtensionApiRequest {
+                    method: "GET".to_string(),
+                    path: "/health".to_string(),
+                    body: None,
+                },
+            )
+            .await
+            .expect_err("unknown namespace must fail");
+
+        assert!(
+            err.to_string().contains("is not registered"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements Issue #413 by adding the Extension API foundation on top of the new plugin architecture.

## What Changed

- Added Extension API primitives in the plugin module:
- ExtensionApiRequest
- ExtensionApiResponse
- ExtensionApiHandler async trait
- Extended PluginRegistry with Extension API lifecycle:
- register_extension_api(namespace, handler)
- list_extension_namespaces()
- dispatch_extension_api(namespace, request)
- Added validation and error handling:
- reject empty namespace
- reject duplicate namespace
- return explicit error for unknown namespace dispatch
- Added tests for:
- namespace registration and sorted listing
- duplicate namespace rejection
- successful namespace dispatch
- unknown namespace dispatch failure
- Re-exported Extension API types from chorrosion-application crate root
- Updated roadmap status:
- marked Extension API complete with Issue #413
- advanced next milestone to Community indexer definitions

## Validation

- cargo test -p chorrosion-application
- cargo fmt --all
- cargo clippy -p chorrosion-application -- -D warnings

Closes #413