### PR TITLE
feat: add dark/light theme settings API (Issue #419)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -471,7 +471,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ### 10.3 UI Improvements
 
-- [ ] Dark/light theme support
+- [x] Dark/light theme support (Issue #419) ✓
 - [ ] Mobile-responsive design
 - [ ] Keyboard shortcuts
 - [ ] Bulk operations UI
@@ -530,6 +530,6 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ---
 
-**Last Updated:** 2026-04-22  
+**Last Updated:** 2026-04-24  
 **Current Phase:** Phase 10: Optional Enhancements  
-**Next Milestone:** Dark/light theme support
+**Next Milestone:** Mobile-responsive design

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+use axum::{extract::State, http::StatusCode, Json};
+use chorrosion_application::{AppState, ThemeMode};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Copy, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ThemeModeApi {
+    System,
+    Dark,
+    Light,
+}
+
+impl From<ThemeMode> for ThemeModeApi {
+    fn from(value: ThemeMode) -> Self {
+        match value {
+            ThemeMode::System => Self::System,
+            ThemeMode::Dark => Self::Dark,
+            ThemeMode::Light => Self::Light,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AppearanceSettingsResponse {
+    pub theme_mode: ThemeModeApi,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateAppearanceSettingsRequest {
+    pub theme_mode: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AppearanceErrorResponse {
+    pub error: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/settings/appearance",
+    responses(
+        (status = 200, description = "Current appearance settings", body = AppearanceSettingsResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn get_appearance_settings(
+    State(state): State<AppState>,
+) -> Json<AppearanceSettingsResponse> {
+    let settings = state.appearance_settings();
+    Json(AppearanceSettingsResponse {
+        theme_mode: settings.theme_mode.into(),
+    })
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/v1/settings/appearance",
+    request_body = UpdateAppearanceSettingsRequest,
+    responses(
+        (status = 200, description = "Updated appearance settings", body = AppearanceSettingsResponse),
+        (status = 400, description = "Invalid theme mode", body = AppearanceErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn update_appearance_settings(
+    State(state): State<AppState>,
+    Json(request): Json<UpdateAppearanceSettingsRequest>,
+) -> Result<Json<AppearanceSettingsResponse>, (StatusCode, Json<AppearanceErrorResponse>)> {
+    let theme_mode = ThemeMode::from_str(&request.theme_mode).map_err(|err| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(AppearanceErrorResponse {
+                error: err.to_string(),
+            }),
+        )
+    })?;
+
+    let updated = state.set_theme_mode(theme_mode);
+    Ok(Json(AppearanceSettingsResponse {
+        theme_mode: updated.theme_mode.into(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chorrosion_config::AppConfig;
+    use chorrosion_infrastructure::sqlite_adapters::{
+        SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
+        SqliteIndexerDefinitionRepository, SqliteMetadataProfileRepository,
+        SqliteQualityProfileRepository, SqliteTagRepository, SqliteTaggedEntityRepository,
+        SqliteTrackRepository,
+    };
+    use std::sync::Arc;
+
+    async fn make_test_state() -> AppState {
+        use sqlx::sqlite::SqlitePoolOptions;
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite");
+        sqlx::migrate!("../../migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+
+        AppState::new(
+            AppConfig::default(),
+            Arc::new(SqliteArtistRepository::new(pool.clone())),
+            Arc::new(SqliteAlbumRepository::new(pool.clone())),
+            Arc::new(SqliteTrackRepository::new(pool.clone())),
+            Arc::new(SqliteQualityProfileRepository::new(pool.clone())),
+            Arc::new(SqliteMetadataProfileRepository::new(pool.clone())),
+            Arc::new(SqliteIndexerDefinitionRepository::new(pool.clone())),
+            Arc::new(SqliteDownloadClientDefinitionRepository::new(pool.clone())),
+            Arc::new(SqliteTagRepository::new(pool.clone())),
+            Arc::new(SqliteTaggedEntityRepository::new(pool.clone())),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteSmartPlaylistRepository::new(
+                    pool.clone(),
+                ),
+            ),
+            Arc::new(
+                chorrosion_infrastructure::sqlite_adapters::SqliteDuplicateRepository::new(
+                    pool.clone(),
+                ),
+            ),
+            chorrosion_infrastructure::ResponseCache::new(100, 60),
+        )
+    }
+
+    #[tokio::test]
+    async fn get_appearance_settings_returns_default_system_theme() {
+        let state = make_test_state().await;
+
+        let Json(response) = get_appearance_settings(State(state)).await;
+
+        assert!(matches!(response.theme_mode, ThemeModeApi::System));
+    }
+
+    #[tokio::test]
+    async fn update_appearance_settings_updates_theme_mode() {
+        let state = make_test_state().await;
+
+        let result = update_appearance_settings(
+            State(state.clone()),
+            Json(UpdateAppearanceSettingsRequest {
+                theme_mode: "dark".to_string(),
+            }),
+        )
+        .await
+        .expect("valid update");
+
+        assert!(matches!(result.0.theme_mode, ThemeModeApi::Dark));
+
+        let Json(check) = get_appearance_settings(State(state)).await;
+        assert!(matches!(check.theme_mode, ThemeModeApi::Dark));
+    }
+
+    #[tokio::test]
+    async fn update_appearance_settings_rejects_invalid_mode() {
+        let state = make_test_state().await;
+
+        let result = update_appearance_settings(
+            State(state),
+            Json(UpdateAppearanceSettingsRequest {
+                theme_mode: "midnight".to_string(),
+            }),
+        )
+        .await;
+
+        let (status, Json(error)) = result.expect_err("invalid mode should fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error.error.contains("invalid theme mode"));
+    }
+}

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -30,6 +30,7 @@ pub struct AppearanceSettingsResponse {
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAppearanceSettingsRequest {
+    #[schema(value_type = ThemeModeApi)]
     pub theme_mode: String,
 }
 
@@ -49,7 +50,7 @@ pub struct AppearanceErrorResponse {
 pub async fn get_appearance_settings(
     State(state): State<AppState>,
 ) -> Json<AppearanceSettingsResponse> {
-    let settings = state.appearance_settings();
+    let settings = state.appearance_settings().await;
     Json(AppearanceSettingsResponse {
         theme_mode: settings.theme_mode.into(),
     })
@@ -78,7 +79,7 @@ pub async fn update_appearance_settings(
         )
     })?;
 
-    let updated = state.set_theme_mode(theme_mode);
+    let updated = state.set_theme_mode(theme_mode).await;
     Ok(Json(AppearanceSettingsResponse {
         theme_mode: updated.theme_mode.into(),
     }))

--- a/crates/chorrosion-api/src/handlers/mod.rs
+++ b/crates/chorrosion-api/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pub mod activity;
 pub mod albums;
+pub mod appearance;
 pub mod artists;
 pub mod auth;
 pub mod calendar;

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -30,6 +30,11 @@ use handlers::albums::{
     __path_list_albums, __path_list_albums_by_artist, __path_trigger_album_search,
     __path_update_album,
 };
+use handlers::appearance::{
+    get_appearance_settings, update_appearance_settings, AppearanceErrorResponse,
+    AppearanceSettingsResponse, ThemeModeApi, UpdateAppearanceSettingsRequest,
+    __path_get_appearance_settings, __path_update_appearance_settings,
+};
 use handlers::artists::{
     create_artist, delete_artist, get_artist, get_artist_statistics, list_artists, update_artist,
     ArtistResponse, ArtistStatisticsResponse, CreateArtistRequest, ErrorResponse,
@@ -289,6 +294,8 @@ async fn metrics() -> axum::response::Response {
         get_system_logs,
         get_system_notifications,
         post_system_notifications_test,
+        get_appearance_settings,
+        update_appearance_settings,
         get_activity_queue,
         get_activity_history,
         get_activity_failed,
@@ -389,6 +396,10 @@ async fn metrics() -> axum::response::Response {
             NotificationStatusResponse,
             NotificationProviderStatusResponse,
             NotificationTestResponse,
+            AppearanceSettingsResponse,
+            UpdateAppearanceSettingsRequest,
+            AppearanceErrorResponse,
+            ThemeModeApi,
             ActivityItemResponse,
             ActivityListResponse,
             ActivityErrorResponse,
@@ -541,6 +552,10 @@ pub fn router(state: AppState) -> Router {
             get(stream_import_progress_events),
         )
         .route("/events/job-status", get(stream_job_status_events))
+        .route(
+            "/settings/appearance",
+            get(get_appearance_settings).put(update_appearance_settings),
+        )
         .route(
             "/settings/quality-profiles",
             get(list_quality_profiles).post(create_quality_profile),

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -26,11 +26,16 @@ impl FromStr for ThemeMode {
     type Err = AppearanceError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "system" => Ok(Self::System),
-            "dark" => Ok(Self::Dark),
-            "light" => Ok(Self::Light),
-            _ => Err(AppearanceError::InvalidThemeMode(value.to_string())),
+        let trimmed = value.trim();
+
+        if trimmed.eq_ignore_ascii_case("system") {
+            Ok(Self::System)
+        } else if trimmed.eq_ignore_ascii_case("dark") {
+            Ok(Self::Dark)
+        } else if trimmed.eq_ignore_ascii_case("light") {
+            Ok(Self::Light)
+        } else {
+            Err(AppearanceError::InvalidThemeMode(value.to_string()))
         }
     }
 }

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ThemeMode {
+    #[default]
+    System,
+    Dark,
+    Light,
+}
+
+impl ThemeMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::Dark => "dark",
+            Self::Light => "light",
+        }
+    }
+}
+
+impl FromStr for ThemeMode {
+    type Err = AppearanceError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "system" => Ok(Self::System),
+            "dark" => Ok(Self::Dark),
+            "light" => Ok(Self::Light),
+            _ => Err(AppearanceError::InvalidThemeMode(value.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppearanceSettings {
+    pub theme_mode: ThemeMode,
+}
+
+impl AppearanceSettings {
+    pub fn new(theme_mode: ThemeMode) -> Self {
+        Self { theme_mode }
+    }
+}
+
+impl Default for AppearanceSettings {
+    fn default() -> Self {
+        Self {
+            theme_mode: ThemeMode::System,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AppearanceError {
+    #[error("invalid theme mode: {0}")]
+    InvalidThemeMode(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_theme_mode_is_system() {
+        assert_eq!(ThemeMode::default(), ThemeMode::System);
+        assert_eq!(AppearanceSettings::default().theme_mode, ThemeMode::System);
+    }
+
+    #[test]
+    fn theme_mode_parse_accepts_valid_values() {
+        assert_eq!(
+            ThemeMode::from_str("system").expect("system"),
+            ThemeMode::System
+        );
+        assert_eq!(ThemeMode::from_str("dark").expect("dark"), ThemeMode::Dark);
+        assert_eq!(
+            ThemeMode::from_str("light").expect("light"),
+            ThemeMode::Light
+        );
+        assert_eq!(
+            ThemeMode::from_str(" DARK ").expect("trimmed"),
+            ThemeMode::Dark
+        );
+    }
+
+    #[test]
+    fn theme_mode_parse_rejects_invalid_values() {
+        let err = ThemeMode::from_str("midnight").expect_err("invalid should fail");
+        assert!(err.to_string().contains("invalid theme mode"));
+    }
+
+    #[test]
+    fn theme_mode_serde_roundtrip() {
+        let json = serde_json::to_string(&ThemeMode::Dark).expect("serialize");
+        assert_eq!(json, "\"dark\"");
+        let mode: ThemeMode = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(mode, ThemeMode::Dark);
+    }
+
+    #[test]
+    fn appearance_settings_new_sets_theme_mode() {
+        let settings = AppearanceSettings::new(ThemeMode::Light);
+        assert_eq!(settings.theme_mode, ThemeMode::Light);
+    }
+}

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
+pub mod appearance;
 pub mod community_indexers;
 pub mod download_clients;
 pub mod embedded_tags;
@@ -114,6 +115,7 @@ pub use tag_embedding::{
 pub use tag_sanitation::TagSanitizer;
 
 // Re-export tag, smart playlist, and duplicate detection domain types for API layer
+pub use appearance::{AppearanceError, AppearanceSettings, ThemeMode};
 pub use chorrosion_domain::{
     DuplicateDetectionMethod, DuplicateFileDetail, DuplicateGroup, EntityType, SmartPlaylist,
     SmartPlaylistCriteria, SmartPlaylistId, Tag, TagId, TaggedEntity,
@@ -376,6 +378,8 @@ pub struct AppState {
     pub activity_history_store: ActivityHistoryStore,
     /// In-memory tracker used to detect downloads that stop making progress.
     pub activity_stall_tracker: ActivityStallTracker,
+    /// In-memory appearance settings for UI-related preferences.
+    pub appearance_settings: Arc<Mutex<crate::appearance::AppearanceSettings>>,
 }
 
 impl AppState {
@@ -399,6 +403,9 @@ impl AppState {
             activity_snapshot_cache: ActivitySnapshotCache::default(),
             activity_history_store: ActivityHistoryStore::default(),
             activity_stall_tracker: ActivityStallTracker::new(config.activity.stall_after_seconds),
+            appearance_settings: Arc::new(Mutex::new(
+                crate::appearance::AppearanceSettings::default(),
+            )),
             config,
             artist_repository,
             album_repository,
@@ -417,6 +424,25 @@ impl AppState {
 
     pub fn on_start(&self) {
         info!(target: "application", "application state initialized");
+    }
+
+    pub fn appearance_settings(&self) -> crate::appearance::AppearanceSettings {
+        self.appearance_settings
+            .lock()
+            .expect("appearance settings lock")
+            .clone()
+    }
+
+    pub fn set_theme_mode(
+        &self,
+        theme_mode: crate::appearance::ThemeMode,
+    ) -> crate::appearance::AppearanceSettings {
+        let mut settings = self
+            .appearance_settings
+            .lock()
+            .expect("appearance settings lock");
+        settings.theme_mode = theme_mode;
+        settings.clone()
     }
 }
 

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -426,23 +426,34 @@ impl AppState {
         info!(target: "application", "application state initialized");
     }
 
-    pub fn appearance_settings(&self) -> crate::appearance::AppearanceSettings {
-        self.appearance_settings
-            .lock()
-            .expect("appearance settings lock")
-            .clone()
+    pub async fn appearance_settings(&self) -> crate::appearance::AppearanceSettings {
+        let appearance_settings = Arc::clone(&self.appearance_settings);
+
+        tokio::task::spawn_blocking(move || {
+            appearance_settings
+                .lock()
+                .expect("appearance settings lock")
+                .clone()
+        })
+        .await
+        .expect("appearance settings task")
     }
 
-    pub fn set_theme_mode(
+    pub async fn set_theme_mode(
         &self,
         theme_mode: crate::appearance::ThemeMode,
     ) -> crate::appearance::AppearanceSettings {
-        let mut settings = self
-            .appearance_settings
-            .lock()
-            .expect("appearance settings lock");
-        settings.theme_mode = theme_mode;
-        settings.clone()
+        let appearance_settings = Arc::clone(&self.appearance_settings);
+
+        tokio::task::spawn_blocking(move || {
+            let mut settings = appearance_settings
+                .lock()
+                .expect("appearance settings lock");
+            settings.theme_mode = theme_mode;
+            settings.clone()
+        })
+        .await
+        .expect("appearance settings task")
     }
 }
 


### PR DESCRIPTION
## Summary

Implements Phase 10.3 dark/light theme support as backend-managed appearance settings with API endpoints for read/update.

## Changes

### Application Layer
- Added `crates/chorrosion-application/src/appearance.rs`
  - `ThemeMode` enum (`system`, `dark`, `light`) with parsing and serde support
  - `AppearanceSettings` model with default `system` theme
  - `AppearanceError` for invalid theme mode input
  - Unit tests for parsing, defaults, and serialization
- Updated `crates/chorrosion-application/src/lib.rs`
  - Added `appearance` module + re-exports
  - Extended `AppState` with in-memory appearance settings store
  - Added `appearance_settings()` getter
  - Added `set_theme_mode()` updater

### API Layer
- Added `crates/chorrosion-api/src/handlers/appearance.rs`
  - `GET /api/v1/settings/appearance` returns current theme mode
  - `PUT /api/v1/settings/appearance` updates theme mode with validation
  - Returns `400` for unsupported modes
  - Handler tests for default, update, and validation failure cases
- Updated `crates/chorrosion-api/src/handlers/mod.rs` to register appearance handler
- Updated `crates/chorrosion-api/src/lib.rs`
  - Wired routes into v1 router
  - Added OpenAPI paths and schemas

### Roadmap
- Updated `ROADMAP.md`
  - Marked `Dark/light theme support` complete with Issue #419
  - Advanced next milestone to `Mobile-responsive design`
  - Updated `Last Updated` date to `2026-04-24`

## Validation

- `cargo fmt --all`
- `cargo test -p chorrosion-application appearance -- --nocapture`
- `cargo test -p chorrosion-api appearance -- --nocapture`
- `cargo clippy -p chorrosion-application -p chorrosion-api -- -D warnings`

All checks pass.

Closes #419