### PR TITLE
feat: add mobile-responsive appearance settings (Issue #421)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -472,7 +472,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 ### 10.3 UI Improvements
 
 - [x] Dark/light theme support (Issue #419) ✓
-- [ ] Mobile-responsive design
+- [x] Mobile-responsive design (Issue #421) ✓
 - [ ] Keyboard shortcuts
 - [ ] Bulk operations UI
 - [ ] Advanced filtering
@@ -532,4 +532,4 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 **Last Updated:** 2026-04-24  
 **Current Phase:** Phase 10: Optional Enhancements  
-**Next Milestone:** Mobile-responsive design
+**Next Milestone:** Keyboard shortcuts

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -35,9 +35,26 @@ pub struct AppearanceSettingsResponse {
 pub struct UpdateAppearanceSettingsRequest {
     #[schema(value_type = ThemeModeApi)]
     pub theme_mode: String,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_mobile_breakpoint_px")]
     pub mobile_breakpoint_px: u16,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_mobile_compact_layout")]
     pub mobile_compact_layout: bool,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_touch_targets_optimized")]
     pub touch_targets_optimized: bool,
+}
+
+impl UpdateAppearanceSettingsRequest {
+    fn default_mobile_breakpoint_px() -> u16 {
+        AppearanceSettings::default().mobile_breakpoint_px
+    }
+
+    fn default_mobile_compact_layout() -> bool {
+        AppearanceSettings::default().mobile_compact_layout
+    }
+
+    fn default_touch_targets_optimized() -> bool {
+        AppearanceSettings::default().touch_targets_optimized
+    }
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -71,7 +88,7 @@ pub async fn get_appearance_settings(
     request_body = UpdateAppearanceSettingsRequest,
     responses(
         (status = 200, description = "Updated appearance settings", body = AppearanceSettingsResponse),
-        (status = 400, description = "Invalid theme mode", body = AppearanceErrorResponse)
+        (status = 400, description = "Invalid theme mode or mobile breakpoint", body = AppearanceErrorResponse)
     ),
     tag = "settings"
 )]
@@ -88,17 +105,6 @@ pub async fn update_appearance_settings(
         )
     })?;
 
-    AppearanceSettings::validate_mobile_breakpoint_px(request.mobile_breakpoint_px).map_err(
-        |err| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(AppearanceErrorResponse {
-                    error: err.to_string(),
-                }),
-            )
-        },
-    )?;
-
     let updated = state
         .set_appearance_settings(AppearanceSettings {
             theme_mode,
@@ -106,7 +112,16 @@ pub async fn update_appearance_settings(
             mobile_compact_layout: request.mobile_compact_layout,
             touch_targets_optimized: request.touch_targets_optimized,
         })
-        .await;
+        .await
+        .map_err(|err| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(AppearanceErrorResponse {
+                    error: err.to_string(),
+                }),
+            )
+        })?;
+
     Ok(Json(AppearanceSettingsResponse {
         theme_mode: updated.theme_mode.into(),
         mobile_breakpoint_px: updated.mobile_breakpoint_px,
@@ -118,6 +133,7 @@ pub async fn update_appearance_settings(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chorrosion_application::DEFAULT_MOBILE_BREAKPOINT_PX;
     use chorrosion_config::AppConfig;
     use chorrosion_infrastructure::sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
@@ -172,7 +188,7 @@ mod tests {
         let Json(response) = get_appearance_settings(State(state)).await;
 
         assert!(matches!(response.theme_mode, ThemeModeApi::System));
-        assert_eq!(response.mobile_breakpoint_px, 768);
+        assert_eq!(response.mobile_breakpoint_px, DEFAULT_MOBILE_BREAKPOINT_PX);
         assert!(response.mobile_compact_layout);
         assert!(response.touch_targets_optimized);
     }

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use axum::{extract::State, http::StatusCode, Json};
-use chorrosion_application::{AppState, ThemeMode};
+use chorrosion_application::{AppState, AppearanceSettings, ThemeMode};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use utoipa::ToSchema;
@@ -26,12 +26,18 @@ impl From<ThemeMode> for ThemeModeApi {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AppearanceSettingsResponse {
     pub theme_mode: ThemeModeApi,
+    pub mobile_breakpoint_px: u16,
+    pub mobile_compact_layout: bool,
+    pub touch_targets_optimized: bool,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAppearanceSettingsRequest {
     #[schema(value_type = ThemeModeApi)]
     pub theme_mode: String,
+    pub mobile_breakpoint_px: u16,
+    pub mobile_compact_layout: bool,
+    pub touch_targets_optimized: bool,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -53,6 +59,9 @@ pub async fn get_appearance_settings(
     let settings = state.appearance_settings().await;
     Json(AppearanceSettingsResponse {
         theme_mode: settings.theme_mode.into(),
+        mobile_breakpoint_px: settings.mobile_breakpoint_px,
+        mobile_compact_layout: settings.mobile_compact_layout,
+        touch_targets_optimized: settings.touch_targets_optimized,
     })
 }
 
@@ -79,9 +88,30 @@ pub async fn update_appearance_settings(
         )
     })?;
 
-    let updated = state.set_theme_mode(theme_mode).await;
+    AppearanceSettings::validate_mobile_breakpoint_px(request.mobile_breakpoint_px).map_err(
+        |err| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(AppearanceErrorResponse {
+                    error: err.to_string(),
+                }),
+            )
+        },
+    )?;
+
+    let updated = state
+        .set_appearance_settings(AppearanceSettings {
+            theme_mode,
+            mobile_breakpoint_px: request.mobile_breakpoint_px,
+            mobile_compact_layout: request.mobile_compact_layout,
+            touch_targets_optimized: request.touch_targets_optimized,
+        })
+        .await;
     Ok(Json(AppearanceSettingsResponse {
         theme_mode: updated.theme_mode.into(),
+        mobile_breakpoint_px: updated.mobile_breakpoint_px,
+        mobile_compact_layout: updated.mobile_compact_layout,
+        touch_targets_optimized: updated.touch_targets_optimized,
     }))
 }
 
@@ -142,6 +172,9 @@ mod tests {
         let Json(response) = get_appearance_settings(State(state)).await;
 
         assert!(matches!(response.theme_mode, ThemeModeApi::System));
+        assert_eq!(response.mobile_breakpoint_px, 768);
+        assert!(response.mobile_compact_layout);
+        assert!(response.touch_targets_optimized);
     }
 
     #[tokio::test]
@@ -152,15 +185,43 @@ mod tests {
             State(state.clone()),
             Json(UpdateAppearanceSettingsRequest {
                 theme_mode: "dark".to_string(),
+                mobile_breakpoint_px: 640,
+                mobile_compact_layout: false,
+                touch_targets_optimized: true,
             }),
         )
         .await
         .expect("valid update");
 
         assert!(matches!(result.0.theme_mode, ThemeModeApi::Dark));
+        assert_eq!(result.0.mobile_breakpoint_px, 640);
+        assert!(!result.0.mobile_compact_layout);
+        assert!(result.0.touch_targets_optimized);
 
         let Json(check) = get_appearance_settings(State(state)).await;
         assert!(matches!(check.theme_mode, ThemeModeApi::Dark));
+        assert_eq!(check.mobile_breakpoint_px, 640);
+        assert!(!check.mobile_compact_layout);
+    }
+
+    #[tokio::test]
+    async fn update_appearance_settings_rejects_invalid_breakpoint() {
+        let state = make_test_state().await;
+
+        let result = update_appearance_settings(
+            State(state),
+            Json(UpdateAppearanceSettingsRequest {
+                theme_mode: "dark".to_string(),
+                mobile_breakpoint_px: 200,
+                mobile_compact_layout: true,
+                touch_targets_optimized: true,
+            }),
+        )
+        .await;
+
+        let (status, Json(error)) = result.expect_err("invalid breakpoint should fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error.error.contains("invalid mobile breakpoint"));
     }
 
     #[tokio::test]
@@ -171,6 +232,9 @@ mod tests {
             State(state),
             Json(UpdateAppearanceSettingsRequest {
                 theme_mode: "midnight".to_string(),
+                mobile_breakpoint_px: 768,
+                mobile_compact_layout: true,
+                touch_targets_optimized: true,
             }),
         )
         .await;

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use thiserror::Error;
 
+pub const DEFAULT_MOBILE_BREAKPOINT_PX: u16 = 768;
+pub const MIN_MOBILE_BREAKPOINT_PX: u16 = 320;
+pub const MAX_MOBILE_BREAKPOINT_PX: u16 = 1440;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ThemeMode {
@@ -43,19 +47,33 @@ impl FromStr for ThemeMode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppearanceSettings {
     pub theme_mode: ThemeMode,
+    pub mobile_breakpoint_px: u16,
+    pub mobile_compact_layout: bool,
+    pub touch_targets_optimized: bool,
 }
 
 impl AppearanceSettings {
     pub fn new(theme_mode: ThemeMode) -> Self {
-        Self { theme_mode }
+        Self {
+            theme_mode,
+            mobile_breakpoint_px: DEFAULT_MOBILE_BREAKPOINT_PX,
+            mobile_compact_layout: true,
+            touch_targets_optimized: true,
+        }
+    }
+
+    pub fn validate_mobile_breakpoint_px(value: u16) -> Result<(), AppearanceError> {
+        if (MIN_MOBILE_BREAKPOINT_PX..=MAX_MOBILE_BREAKPOINT_PX).contains(&value) {
+            Ok(())
+        } else {
+            Err(AppearanceError::InvalidMobileBreakpoint(value))
+        }
     }
 }
 
 impl Default for AppearanceSettings {
     fn default() -> Self {
-        Self {
-            theme_mode: ThemeMode::System,
-        }
+        Self::new(ThemeMode::System)
     }
 }
 
@@ -63,6 +81,10 @@ impl Default for AppearanceSettings {
 pub enum AppearanceError {
     #[error("invalid theme mode: {0}")]
     InvalidThemeMode(String),
+    #[error(
+        "invalid mobile breakpoint: {0}. expected {MIN_MOBILE_BREAKPOINT_PX}..={MAX_MOBILE_BREAKPOINT_PX} px"
+    )]
+    InvalidMobileBreakpoint(u16),
 }
 
 #[cfg(test)]
@@ -73,6 +95,12 @@ mod tests {
     fn default_theme_mode_is_system() {
         assert_eq!(ThemeMode::default(), ThemeMode::System);
         assert_eq!(AppearanceSettings::default().theme_mode, ThemeMode::System);
+        assert_eq!(
+            AppearanceSettings::default().mobile_breakpoint_px,
+            DEFAULT_MOBILE_BREAKPOINT_PX
+        );
+        assert!(AppearanceSettings::default().mobile_compact_layout);
+        assert!(AppearanceSettings::default().touch_targets_optimized);
     }
 
     #[test]
@@ -110,5 +138,31 @@ mod tests {
     fn appearance_settings_new_sets_theme_mode() {
         let settings = AppearanceSettings::new(ThemeMode::Light);
         assert_eq!(settings.theme_mode, ThemeMode::Light);
+        assert_eq!(settings.mobile_breakpoint_px, DEFAULT_MOBILE_BREAKPOINT_PX);
+    }
+
+    #[test]
+    fn validate_mobile_breakpoint_accepts_values_in_range() {
+        AppearanceSettings::validate_mobile_breakpoint_px(MIN_MOBILE_BREAKPOINT_PX)
+            .expect("min breakpoint should be valid");
+        AppearanceSettings::validate_mobile_breakpoint_px(DEFAULT_MOBILE_BREAKPOINT_PX)
+            .expect("default breakpoint should be valid");
+        AppearanceSettings::validate_mobile_breakpoint_px(MAX_MOBILE_BREAKPOINT_PX)
+            .expect("max breakpoint should be valid");
+    }
+
+    #[test]
+    fn validate_mobile_breakpoint_rejects_out_of_range_values() {
+        let below = AppearanceSettings::validate_mobile_breakpoint_px(
+            MIN_MOBILE_BREAKPOINT_PX.saturating_sub(1),
+        )
+        .expect_err("below min should be invalid");
+        assert!(below.to_string().contains("invalid mobile breakpoint"));
+
+        let above = AppearanceSettings::validate_mobile_breakpoint_px(
+            MAX_MOBILE_BREAKPOINT_PX.saturating_add(1),
+        )
+        .expect_err("above max should be invalid");
+        assert!(above.to_string().contains("invalid mobile breakpoint"));
     }
 }

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -115,7 +115,7 @@ pub use tag_embedding::{
 pub use tag_sanitation::TagSanitizer;
 
 // Re-export tag, smart playlist, and duplicate detection domain types for API layer
-pub use appearance::{AppearanceError, AppearanceSettings, ThemeMode};
+pub use appearance::{AppearanceError, AppearanceSettings, ThemeMode, DEFAULT_MOBILE_BREAKPOINT_PX};
 pub use chorrosion_domain::{
     DuplicateDetectionMethod, DuplicateFileDetail, DuplicateGroup, EntityType, SmartPlaylist,
     SmartPlaylistCriteria, SmartPlaylistId, Tag, TagId, TaggedEntity,
@@ -459,10 +459,14 @@ impl AppState {
     pub async fn set_appearance_settings(
         &self,
         settings: crate::appearance::AppearanceSettings,
-    ) -> crate::appearance::AppearanceSettings {
+    ) -> Result<crate::appearance::AppearanceSettings, crate::appearance::AppearanceError> {
+        crate::appearance::AppearanceSettings::validate_mobile_breakpoint_px(
+            settings.mobile_breakpoint_px,
+        )?;
+
         let appearance_settings = Arc::clone(&self.appearance_settings);
 
-        tokio::task::spawn_blocking(move || {
+        let updated = tokio::task::spawn_blocking(move || {
             let mut current = appearance_settings
                 .lock()
                 .expect("appearance settings lock");
@@ -470,7 +474,9 @@ impl AppState {
             current.clone()
         })
         .await
-        .expect("appearance settings task")
+        .expect("appearance settings task");
+
+        Ok(updated)
     }
 }
 

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -455,6 +455,23 @@ impl AppState {
         .await
         .expect("appearance settings task")
     }
+
+    pub async fn set_appearance_settings(
+        &self,
+        settings: crate::appearance::AppearanceSettings,
+    ) -> crate::appearance::AppearanceSettings {
+        let appearance_settings = Arc::clone(&self.appearance_settings);
+
+        tokio::task::spawn_blocking(move || {
+            let mut current = appearance_settings
+                .lock()
+                .expect("appearance settings lock");
+            *current = settings;
+            current.clone()
+        })
+        .await
+        .expect("appearance settings task")
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Implements Phase 10.3 mobile-responsive design support as backend-managed appearance settings extensions.

## Changes

### Application Layer
- Updated `crates/chorrosion-application/src/appearance.rs`
  - Added mobile-responsive fields to `AppearanceSettings`:
    - `mobile_breakpoint_px`
    - `mobile_compact_layout`
    - `touch_targets_optimized`
  - Added constants for responsive defaults and bounds:
    - `DEFAULT_MOBILE_BREAKPOINT_PX = 768`
    - `MIN_MOBILE_BREAKPOINT_PX = 320`
    - `MAX_MOBILE_BREAKPOINT_PX = 1440`
  - Added `AppearanceSettings::validate_mobile_breakpoint_px(...)`
  - Added `AppearanceError::InvalidMobileBreakpoint`
  - Expanded unit tests for valid/invalid breakpoint validation
- Updated `crates/chorrosion-application/src/lib.rs`
  - Added `AppState::set_appearance_settings(...)` for atomic settings updates

### API Layer
- Updated `crates/chorrosion-api/src/handlers/appearance.rs`
  - Extended `AppearanceSettingsResponse` with mobile-responsive fields
  - Extended `UpdateAppearanceSettingsRequest` with mobile-responsive fields
  - Added breakpoint validation in `update_appearance_settings`
  - Updated handler tests for:
    - default responsive values
    - successful responsive updates
    - invalid breakpoint rejection

### Roadmap
- Updated `ROADMAP.md`
  - Marked `Mobile-responsive design` complete with Issue #421
  - Advanced `Next Milestone` to `Keyboard shortcuts`

## Validation

- `cargo fmt --all`
- `cargo test -p chorrosion-application appearance -- --nocapture`
- `cargo test -p chorrosion-api appearance -- --nocapture`
- `cargo clippy -p chorrosion-application -p chorrosion-api -- -D warnings`

All checks pass.

Closes #421