### PR TITLE
feat: add keyboard shortcut appearance settings (Issue #423)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -473,7 +473,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 - [x] Dark/light theme support (Issue #419) ✓
 - [x] Mobile-responsive design (Issue #421) ✓
-- [ ] Keyboard shortcuts
+- [x] Keyboard shortcuts (Issue #423) ✓
 - [ ] Bulk operations UI
 - [ ] Advanced filtering
 
@@ -530,6 +530,6 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ---
 
-**Last Updated:** 2026-04-24  
+**Last Updated:** 2026-04-27  
 **Current Phase:** Phase 10: Optional Enhancements  
-**Next Milestone:** Keyboard shortcuts
+**Next Milestone:** Bulk operations UI

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -125,7 +125,7 @@ pub async fn get_appearance_settings(
     request_body = UpdateAppearanceSettingsRequest,
     responses(
         (status = 200, description = "Updated appearance settings", body = AppearanceSettingsResponse),
-        (status = 400, description = "Invalid theme mode or mobile breakpoint", body = AppearanceErrorResponse)
+        (status = 400, description = "Invalid theme mode, mobile breakpoint, or shortcut profile", body = AppearanceErrorResponse)
     ),
     tag = "settings"
 )]

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use axum::{extract::State, http::StatusCode, Json};
-use chorrosion_application::{AppState, AppearanceSettings, ThemeMode};
+use chorrosion_application::{
+    AppState, AppearanceSettings, ShortcutProfile, ThemeMode, DEFAULT_SHORTCUT_PROFILE,
+};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use utoipa::ToSchema;
@@ -11,6 +13,24 @@ pub enum ThemeModeApi {
     System,
     Dark,
     Light,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ShortcutProfileApi {
+    Standard,
+    Vim,
+    Emacs,
+}
+
+impl From<ShortcutProfile> for ShortcutProfileApi {
+    fn from(value: ShortcutProfile) -> Self {
+        match value {
+            ShortcutProfile::Standard => Self::Standard,
+            ShortcutProfile::Vim => Self::Vim,
+            ShortcutProfile::Emacs => Self::Emacs,
+        }
+    }
 }
 
 impl From<ThemeMode> for ThemeModeApi {
@@ -29,6 +49,8 @@ pub struct AppearanceSettingsResponse {
     pub mobile_breakpoint_px: u16,
     pub mobile_compact_layout: bool,
     pub touch_targets_optimized: bool,
+    pub keyboard_shortcuts_enabled: bool,
+    pub shortcut_profile: ShortcutProfileApi,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -41,6 +63,11 @@ pub struct UpdateAppearanceSettingsRequest {
     pub mobile_compact_layout: bool,
     #[serde(default = "UpdateAppearanceSettingsRequest::default_touch_targets_optimized")]
     pub touch_targets_optimized: bool,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_keyboard_shortcuts_enabled")]
+    pub keyboard_shortcuts_enabled: bool,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_shortcut_profile")]
+    #[schema(value_type = ShortcutProfileApi)]
+    pub shortcut_profile: String,
 }
 
 impl UpdateAppearanceSettingsRequest {
@@ -54,6 +81,14 @@ impl UpdateAppearanceSettingsRequest {
 
     fn default_touch_targets_optimized() -> bool {
         AppearanceSettings::default().touch_targets_optimized
+    }
+
+    fn default_keyboard_shortcuts_enabled() -> bool {
+        AppearanceSettings::default().keyboard_shortcuts_enabled
+    }
+
+    fn default_shortcut_profile() -> String {
+        DEFAULT_SHORTCUT_PROFILE.as_str().to_string()
     }
 }
 
@@ -79,6 +114,8 @@ pub async fn get_appearance_settings(
         mobile_breakpoint_px: settings.mobile_breakpoint_px,
         mobile_compact_layout: settings.mobile_compact_layout,
         touch_targets_optimized: settings.touch_targets_optimized,
+        keyboard_shortcuts_enabled: settings.keyboard_shortcuts_enabled,
+        shortcut_profile: settings.shortcut_profile.into(),
     })
 }
 
@@ -105,12 +142,23 @@ pub async fn update_appearance_settings(
         )
     })?;
 
+    let shortcut_profile = ShortcutProfile::from_str(&request.shortcut_profile).map_err(|err| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(AppearanceErrorResponse {
+                error: err.to_string(),
+            }),
+        )
+    })?;
+
     let updated = state
         .set_appearance_settings(AppearanceSettings {
             theme_mode,
             mobile_breakpoint_px: request.mobile_breakpoint_px,
             mobile_compact_layout: request.mobile_compact_layout,
             touch_targets_optimized: request.touch_targets_optimized,
+            keyboard_shortcuts_enabled: request.keyboard_shortcuts_enabled,
+            shortcut_profile,
         })
         .await
         .map_err(|err| {
@@ -127,6 +175,8 @@ pub async fn update_appearance_settings(
         mobile_breakpoint_px: updated.mobile_breakpoint_px,
         mobile_compact_layout: updated.mobile_compact_layout,
         touch_targets_optimized: updated.touch_targets_optimized,
+        keyboard_shortcuts_enabled: updated.keyboard_shortcuts_enabled,
+        shortcut_profile: updated.shortcut_profile.into(),
     }))
 }
 
@@ -191,6 +241,11 @@ mod tests {
         assert_eq!(response.mobile_breakpoint_px, DEFAULT_MOBILE_BREAKPOINT_PX);
         assert!(response.mobile_compact_layout);
         assert!(response.touch_targets_optimized);
+        assert!(response.keyboard_shortcuts_enabled);
+        assert!(matches!(
+            response.shortcut_profile,
+            ShortcutProfileApi::Standard
+        ));
     }
 
     #[tokio::test]
@@ -204,6 +259,8 @@ mod tests {
                 mobile_breakpoint_px: 640,
                 mobile_compact_layout: false,
                 touch_targets_optimized: true,
+                keyboard_shortcuts_enabled: false,
+                shortcut_profile: "vim".to_string(),
             }),
         )
         .await
@@ -213,11 +270,15 @@ mod tests {
         assert_eq!(result.0.mobile_breakpoint_px, 640);
         assert!(!result.0.mobile_compact_layout);
         assert!(result.0.touch_targets_optimized);
+        assert!(!result.0.keyboard_shortcuts_enabled);
+        assert!(matches!(result.0.shortcut_profile, ShortcutProfileApi::Vim));
 
         let Json(check) = get_appearance_settings(State(state)).await;
         assert!(matches!(check.theme_mode, ThemeModeApi::Dark));
         assert_eq!(check.mobile_breakpoint_px, 640);
         assert!(!check.mobile_compact_layout);
+        assert!(!check.keyboard_shortcuts_enabled);
+        assert!(matches!(check.shortcut_profile, ShortcutProfileApi::Vim));
     }
 
     #[tokio::test]
@@ -231,6 +292,8 @@ mod tests {
                 mobile_breakpoint_px: 200,
                 mobile_compact_layout: true,
                 touch_targets_optimized: true,
+                keyboard_shortcuts_enabled: true,
+                shortcut_profile: "standard".to_string(),
             }),
         )
         .await;
@@ -238,6 +301,28 @@ mod tests {
         let (status, Json(error)) = result.expect_err("invalid breakpoint should fail");
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(error.error.contains("invalid mobile breakpoint"));
+    }
+
+    #[tokio::test]
+    async fn update_appearance_settings_rejects_invalid_shortcut_profile() {
+        let state = make_test_state().await;
+
+        let result = update_appearance_settings(
+            State(state),
+            Json(UpdateAppearanceSettingsRequest {
+                theme_mode: "dark".to_string(),
+                mobile_breakpoint_px: 768,
+                mobile_compact_layout: true,
+                touch_targets_optimized: true,
+                keyboard_shortcuts_enabled: true,
+                shortcut_profile: "gaming".to_string(),
+            }),
+        )
+        .await;
+
+        let (status, Json(error)) = result.expect_err("invalid profile should fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error.error.contains("invalid shortcut profile"));
     }
 
     #[tokio::test]
@@ -251,6 +336,8 @@ mod tests {
                 mobile_breakpoint_px: 768,
                 mobile_compact_layout: true,
                 touch_targets_optimized: true,
+                keyboard_shortcuts_enabled: true,
+                shortcut_profile: "standard".to_string(),
             }),
         )
         .await;

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -32,7 +32,7 @@ use handlers::albums::{
 };
 use handlers::appearance::{
     get_appearance_settings, update_appearance_settings, AppearanceErrorResponse,
-    AppearanceSettingsResponse, ThemeModeApi, UpdateAppearanceSettingsRequest,
+    AppearanceSettingsResponse, ShortcutProfileApi, ThemeModeApi, UpdateAppearanceSettingsRequest,
     __path_get_appearance_settings, __path_update_appearance_settings,
 };
 use handlers::artists::{
@@ -400,6 +400,7 @@ async fn metrics() -> axum::response::Response {
             UpdateAppearanceSettingsRequest,
             AppearanceErrorResponse,
             ThemeModeApi,
+            ShortcutProfileApi,
             ActivityItemResponse,
             ActivityListResponse,
             ActivityErrorResponse,

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -6,6 +6,44 @@ use thiserror::Error;
 pub const DEFAULT_MOBILE_BREAKPOINT_PX: u16 = 768;
 pub const MIN_MOBILE_BREAKPOINT_PX: u16 = 320;
 pub const MAX_MOBILE_BREAKPOINT_PX: u16 = 1440;
+pub const DEFAULT_SHORTCUT_PROFILE: ShortcutProfile = ShortcutProfile::Standard;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ShortcutProfile {
+    #[default]
+    Standard,
+    Vim,
+    Emacs,
+}
+
+impl ShortcutProfile {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Vim => "vim",
+            Self::Emacs => "emacs",
+        }
+    }
+}
+
+impl FromStr for ShortcutProfile {
+    type Err = AppearanceError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let trimmed = value.trim();
+
+        if trimmed.eq_ignore_ascii_case("standard") {
+            Ok(Self::Standard)
+        } else if trimmed.eq_ignore_ascii_case("vim") {
+            Ok(Self::Vim)
+        } else if trimmed.eq_ignore_ascii_case("emacs") {
+            Ok(Self::Emacs)
+        } else {
+            Err(AppearanceError::InvalidShortcutProfile(value.to_string()))
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -50,6 +88,8 @@ pub struct AppearanceSettings {
     pub mobile_breakpoint_px: u16,
     pub mobile_compact_layout: bool,
     pub touch_targets_optimized: bool,
+    pub keyboard_shortcuts_enabled: bool,
+    pub shortcut_profile: ShortcutProfile,
 }
 
 impl AppearanceSettings {
@@ -59,6 +99,8 @@ impl AppearanceSettings {
             mobile_breakpoint_px: DEFAULT_MOBILE_BREAKPOINT_PX,
             mobile_compact_layout: true,
             touch_targets_optimized: true,
+            keyboard_shortcuts_enabled: true,
+            shortcut_profile: DEFAULT_SHORTCUT_PROFILE,
         }
     }
 
@@ -85,6 +127,8 @@ pub enum AppearanceError {
         "invalid mobile breakpoint: {0}. expected {MIN_MOBILE_BREAKPOINT_PX}..={MAX_MOBILE_BREAKPOINT_PX} px"
     )]
     InvalidMobileBreakpoint(u16),
+    #[error("invalid shortcut profile: {0}")]
+    InvalidShortcutProfile(String),
 }
 
 #[cfg(test)]
@@ -101,6 +145,11 @@ mod tests {
         );
         assert!(AppearanceSettings::default().mobile_compact_layout);
         assert!(AppearanceSettings::default().touch_targets_optimized);
+        assert!(AppearanceSettings::default().keyboard_shortcuts_enabled);
+        assert_eq!(
+            AppearanceSettings::default().shortcut_profile,
+            ShortcutProfile::Standard
+        );
     }
 
     #[test]
@@ -135,10 +184,34 @@ mod tests {
     }
 
     #[test]
+    fn shortcut_profile_parse_accepts_valid_values() {
+        assert_eq!(
+            ShortcutProfile::from_str("standard").expect("standard"),
+            ShortcutProfile::Standard
+        );
+        assert_eq!(
+            ShortcutProfile::from_str("vim").expect("vim"),
+            ShortcutProfile::Vim
+        );
+        assert_eq!(
+            ShortcutProfile::from_str("EMACS").expect("emacs"),
+            ShortcutProfile::Emacs
+        );
+    }
+
+    #[test]
+    fn shortcut_profile_parse_rejects_invalid_values() {
+        let err = ShortcutProfile::from_str("gaming").expect_err("invalid should fail");
+        assert!(err.to_string().contains("invalid shortcut profile"));
+    }
+
+    #[test]
     fn appearance_settings_new_sets_theme_mode() {
         let settings = AppearanceSettings::new(ThemeMode::Light);
         assert_eq!(settings.theme_mode, ThemeMode::Light);
         assert_eq!(settings.mobile_breakpoint_px, DEFAULT_MOBILE_BREAKPOINT_PX);
+        assert!(settings.keyboard_shortcuts_enabled);
+        assert_eq!(settings.shortcut_profile, ShortcutProfile::Standard);
     }
 
     #[test]

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -115,7 +115,10 @@ pub use tag_embedding::{
 pub use tag_sanitation::TagSanitizer;
 
 // Re-export tag, smart playlist, and duplicate detection domain types for API layer
-pub use appearance::{AppearanceError, AppearanceSettings, ThemeMode, DEFAULT_MOBILE_BREAKPOINT_PX};
+pub use appearance::{
+    AppearanceError, AppearanceSettings, ShortcutProfile, ThemeMode, DEFAULT_MOBILE_BREAKPOINT_PX,
+    DEFAULT_SHORTCUT_PROFILE,
+};
 pub use chorrosion_domain::{
     DuplicateDetectionMethod, DuplicateFileDetail, DuplicateGroup, EntityType, SmartPlaylist,
     SmartPlaylistCriteria, SmartPlaylistId, Tag, TagId, TaggedEntity,


### PR DESCRIPTION
## Summary

Implements Phase 10.3 keyboard shortcuts support as backend-managed appearance preferences.

## Changes

### Application Layer
- Updated `crates/chorrosion-application/src/appearance.rs`
  - Added `ShortcutProfile` enum (`standard`, `vim`, `emacs`)
  - Added `keyboard_shortcuts_enabled` and `shortcut_profile` to `AppearanceSettings`
  - Added `DEFAULT_SHORTCUT_PROFILE`
  - Added `AppearanceError::InvalidShortcutProfile`
  - Added parser/validation tests for shortcut profile values
- Updated `crates/chorrosion-application/src/lib.rs`
  - Re-exported `ShortcutProfile` and `DEFAULT_SHORTCUT_PROFILE`

### API Layer
- Updated `crates/chorrosion-api/src/handlers/appearance.rs`
  - Added `ShortcutProfileApi` schema enum
  - Extended `AppearanceSettingsResponse` with keyboard shortcut fields
  - Extended `UpdateAppearanceSettingsRequest` with keyboard shortcut fields
  - Added shortcut profile parsing/validation in `update_appearance_settings`
  - Added/updated tests for default values, valid updates, and invalid profile rejection

### Roadmap
- Updated `ROADMAP.md`
  - Marked `Keyboard shortcuts` complete with Issue #423
  - Advanced `Next Milestone` to `Bulk operations UI`
  - Updated `Last Updated` date to `2026-04-27`

## Validation

- `cargo fmt --all`
- `cargo test -p chorrosion-application appearance -- --nocapture`
- `cargo test -p chorrosion-api appearance -- --nocapture`
- `cargo clippy -p chorrosion-application -p chorrosion-api -- -D warnings`

All checks pass.

Closes #423