### PR TITLE
feat: add bulk operation appearance settings (Issue #425)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -474,7 +474,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 - [x] Dark/light theme support (Issue #419) ✓
 - [x] Mobile-responsive design (Issue #421) ✓
 - [x] Keyboard shortcuts (Issue #423) ✓
-- [ ] Bulk operations UI
+- [x] Bulk operations UI (Issue #425) ✓
 - [ ] Advanced filtering
 
 ---
@@ -530,6 +530,6 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ---
 
-**Last Updated:** 2026-04-27  
+**Last Updated:** 2026-04-28  
 **Current Phase:** Phase 10: Optional Enhancements  
-**Next Milestone:** Bulk operations UI
+**Next Milestone:** Advanced filtering

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use axum::{extract::State, http::StatusCode, Json};
 use chorrosion_application::{
-    AppState, AppearanceSettings, ShortcutProfile, ThemeMode, DEFAULT_SHORTCUT_PROFILE,
+    AppState, AppearanceSettings, ShortcutProfile, ThemeMode, DEFAULT_BULK_SELECTION_LIMIT,
+    DEFAULT_SHORTCUT_PROFILE,
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -51,6 +52,9 @@ pub struct AppearanceSettingsResponse {
     pub touch_targets_optimized: bool,
     pub keyboard_shortcuts_enabled: bool,
     pub shortcut_profile: ShortcutProfileApi,
+    pub bulk_operations_enabled: bool,
+    pub bulk_selection_limit: u16,
+    pub bulk_action_confirmation: bool,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -68,6 +72,12 @@ pub struct UpdateAppearanceSettingsRequest {
     #[serde(default = "UpdateAppearanceSettingsRequest::default_shortcut_profile")]
     #[schema(value_type = ShortcutProfileApi)]
     pub shortcut_profile: String,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_bulk_operations_enabled")]
+    pub bulk_operations_enabled: bool,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_bulk_selection_limit")]
+    pub bulk_selection_limit: u16,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_bulk_action_confirmation")]
+    pub bulk_action_confirmation: bool,
 }
 
 impl UpdateAppearanceSettingsRequest {
@@ -89,6 +99,18 @@ impl UpdateAppearanceSettingsRequest {
 
     fn default_shortcut_profile() -> String {
         DEFAULT_SHORTCUT_PROFILE.as_str().to_string()
+    }
+
+    fn default_bulk_operations_enabled() -> bool {
+        AppearanceSettings::default().bulk_operations_enabled
+    }
+
+    fn default_bulk_selection_limit() -> u16 {
+        DEFAULT_BULK_SELECTION_LIMIT
+    }
+
+    fn default_bulk_action_confirmation() -> bool {
+        AppearanceSettings::default().bulk_action_confirmation
     }
 }
 
@@ -116,6 +138,9 @@ pub async fn get_appearance_settings(
         touch_targets_optimized: settings.touch_targets_optimized,
         keyboard_shortcuts_enabled: settings.keyboard_shortcuts_enabled,
         shortcut_profile: settings.shortcut_profile.into(),
+        bulk_operations_enabled: settings.bulk_operations_enabled,
+        bulk_selection_limit: settings.bulk_selection_limit,
+        bulk_action_confirmation: settings.bulk_action_confirmation,
     })
 }
 
@@ -151,6 +176,17 @@ pub async fn update_appearance_settings(
         )
     })?;
 
+    AppearanceSettings::validate_bulk_selection_limit(request.bulk_selection_limit).map_err(
+        |err| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(AppearanceErrorResponse {
+                    error: err.to_string(),
+                }),
+            )
+        },
+    )?;
+
     let updated = state
         .set_appearance_settings(AppearanceSettings {
             theme_mode,
@@ -159,6 +195,9 @@ pub async fn update_appearance_settings(
             touch_targets_optimized: request.touch_targets_optimized,
             keyboard_shortcuts_enabled: request.keyboard_shortcuts_enabled,
             shortcut_profile,
+            bulk_operations_enabled: request.bulk_operations_enabled,
+            bulk_selection_limit: request.bulk_selection_limit,
+            bulk_action_confirmation: request.bulk_action_confirmation,
         })
         .await
         .map_err(|err| {
@@ -177,6 +216,9 @@ pub async fn update_appearance_settings(
         touch_targets_optimized: updated.touch_targets_optimized,
         keyboard_shortcuts_enabled: updated.keyboard_shortcuts_enabled,
         shortcut_profile: updated.shortcut_profile.into(),
+        bulk_operations_enabled: updated.bulk_operations_enabled,
+        bulk_selection_limit: updated.bulk_selection_limit,
+        bulk_action_confirmation: updated.bulk_action_confirmation,
     }))
 }
 
@@ -246,6 +288,9 @@ mod tests {
             response.shortcut_profile,
             ShortcutProfileApi::Standard
         ));
+        assert!(response.bulk_operations_enabled);
+        assert_eq!(response.bulk_selection_limit, DEFAULT_BULK_SELECTION_LIMIT);
+        assert!(response.bulk_action_confirmation);
     }
 
     #[tokio::test]
@@ -261,6 +306,9 @@ mod tests {
                 touch_targets_optimized: true,
                 keyboard_shortcuts_enabled: false,
                 shortcut_profile: "vim".to_string(),
+                bulk_operations_enabled: true,
+                bulk_selection_limit: 250,
+                bulk_action_confirmation: false,
             }),
         )
         .await
@@ -272,6 +320,9 @@ mod tests {
         assert!(result.0.touch_targets_optimized);
         assert!(!result.0.keyboard_shortcuts_enabled);
         assert!(matches!(result.0.shortcut_profile, ShortcutProfileApi::Vim));
+        assert!(result.0.bulk_operations_enabled);
+        assert_eq!(result.0.bulk_selection_limit, 250);
+        assert!(!result.0.bulk_action_confirmation);
 
         let Json(check) = get_appearance_settings(State(state)).await;
         assert!(matches!(check.theme_mode, ThemeModeApi::Dark));
@@ -279,6 +330,9 @@ mod tests {
         assert!(!check.mobile_compact_layout);
         assert!(!check.keyboard_shortcuts_enabled);
         assert!(matches!(check.shortcut_profile, ShortcutProfileApi::Vim));
+        assert!(check.bulk_operations_enabled);
+        assert_eq!(check.bulk_selection_limit, 250);
+        assert!(!check.bulk_action_confirmation);
     }
 
     #[tokio::test]
@@ -294,6 +348,9 @@ mod tests {
                 touch_targets_optimized: true,
                 keyboard_shortcuts_enabled: true,
                 shortcut_profile: "standard".to_string(),
+                bulk_operations_enabled: true,
+                bulk_selection_limit: 100,
+                bulk_action_confirmation: true,
             }),
         )
         .await;
@@ -316,6 +373,9 @@ mod tests {
                 touch_targets_optimized: true,
                 keyboard_shortcuts_enabled: true,
                 shortcut_profile: "gaming".to_string(),
+                bulk_operations_enabled: true,
+                bulk_selection_limit: 100,
+                bulk_action_confirmation: true,
             }),
         )
         .await;
@@ -323,6 +383,31 @@ mod tests {
         let (status, Json(error)) = result.expect_err("invalid profile should fail");
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(error.error.contains("invalid shortcut profile"));
+    }
+
+    #[tokio::test]
+    async fn update_appearance_settings_rejects_invalid_bulk_selection_limit() {
+        let state = make_test_state().await;
+
+        let result = update_appearance_settings(
+            State(state),
+            Json(UpdateAppearanceSettingsRequest {
+                theme_mode: "dark".to_string(),
+                mobile_breakpoint_px: 768,
+                mobile_compact_layout: true,
+                touch_targets_optimized: true,
+                keyboard_shortcuts_enabled: true,
+                shortcut_profile: "standard".to_string(),
+                bulk_operations_enabled: true,
+                bulk_selection_limit: 5,
+                bulk_action_confirmation: true,
+            }),
+        )
+        .await;
+
+        let (status, Json(error)) = result.expect_err("invalid bulk limit should fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error.error.contains("invalid bulk selection limit"));
     }
 
     #[tokio::test]
@@ -338,6 +423,9 @@ mod tests {
                 touch_targets_optimized: true,
                 keyboard_shortcuts_enabled: true,
                 shortcut_profile: "standard".to_string(),
+                bulk_operations_enabled: true,
+                bulk_selection_limit: 100,
+                bulk_action_confirmation: true,
             }),
         )
         .await;

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -150,7 +150,7 @@ pub async fn get_appearance_settings(
     request_body = UpdateAppearanceSettingsRequest,
     responses(
         (status = 200, description = "Updated appearance settings", body = AppearanceSettingsResponse),
-        (status = 400, description = "Invalid theme mode, mobile breakpoint, or shortcut profile", body = AppearanceErrorResponse)
+        (status = 400, description = "Invalid theme mode, mobile breakpoint, shortcut profile, or bulk selection limit", body = AppearanceErrorResponse)
     ),
     tag = "settings"
 )]
@@ -175,17 +175,6 @@ pub async fn update_appearance_settings(
             }),
         )
     })?;
-
-    AppearanceSettings::validate_bulk_selection_limit(request.bulk_selection_limit).map_err(
-        |err| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(AppearanceErrorResponse {
-                    error: err.to_string(),
-                }),
-            )
-        },
-    )?;
 
     let updated = state
         .set_appearance_settings(AppearanceSettings {

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -128,6 +128,12 @@ impl AppearanceSettings {
             Err(AppearanceError::InvalidBulkSelectionLimit(value))
         }
     }
+
+    pub fn validate(&self) -> Result<(), AppearanceError> {
+        Self::validate_mobile_breakpoint_px(self.mobile_breakpoint_px)?;
+        Self::validate_bulk_selection_limit(self.bulk_selection_limit)?;
+        Ok(())
+    }
 }
 
 impl Default for AppearanceSettings {
@@ -292,5 +298,32 @@ mod tests {
         )
         .expect_err("above max should be invalid");
         assert!(above.to_string().contains("invalid bulk selection limit"));
+    }
+
+    #[test]
+    fn validate_accepts_default_settings() {
+        AppearanceSettings::default()
+            .validate()
+            .expect("default settings should be valid");
+    }
+
+    #[test]
+    fn validate_rejects_invalid_mobile_breakpoint() {
+        let mut settings = AppearanceSettings::default();
+        settings.mobile_breakpoint_px = MIN_MOBILE_BREAKPOINT_PX.saturating_sub(1);
+        let err = settings
+            .validate()
+            .expect_err("invalid breakpoint should fail");
+        assert!(err.to_string().contains("invalid mobile breakpoint"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_bulk_selection_limit() {
+        let mut settings = AppearanceSettings::default();
+        settings.bulk_selection_limit = MIN_BULK_SELECTION_LIMIT.saturating_sub(1);
+        let err = settings
+            .validate()
+            .expect_err("invalid bulk limit should fail");
+        assert!(err.to_string().contains("invalid bulk selection limit"));
     }
 }

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -7,6 +7,9 @@ pub const DEFAULT_MOBILE_BREAKPOINT_PX: u16 = 768;
 pub const MIN_MOBILE_BREAKPOINT_PX: u16 = 320;
 pub const MAX_MOBILE_BREAKPOINT_PX: u16 = 1440;
 pub const DEFAULT_SHORTCUT_PROFILE: ShortcutProfile = ShortcutProfile::Standard;
+pub const DEFAULT_BULK_SELECTION_LIMIT: u16 = 100;
+pub const MIN_BULK_SELECTION_LIMIT: u16 = 10;
+pub const MAX_BULK_SELECTION_LIMIT: u16 = 1000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -90,6 +93,9 @@ pub struct AppearanceSettings {
     pub touch_targets_optimized: bool,
     pub keyboard_shortcuts_enabled: bool,
     pub shortcut_profile: ShortcutProfile,
+    pub bulk_operations_enabled: bool,
+    pub bulk_selection_limit: u16,
+    pub bulk_action_confirmation: bool,
 }
 
 impl AppearanceSettings {
@@ -101,6 +107,9 @@ impl AppearanceSettings {
             touch_targets_optimized: true,
             keyboard_shortcuts_enabled: true,
             shortcut_profile: DEFAULT_SHORTCUT_PROFILE,
+            bulk_operations_enabled: true,
+            bulk_selection_limit: DEFAULT_BULK_SELECTION_LIMIT,
+            bulk_action_confirmation: true,
         }
     }
 
@@ -109,6 +118,14 @@ impl AppearanceSettings {
             Ok(())
         } else {
             Err(AppearanceError::InvalidMobileBreakpoint(value))
+        }
+    }
+
+    pub fn validate_bulk_selection_limit(value: u16) -> Result<(), AppearanceError> {
+        if (MIN_BULK_SELECTION_LIMIT..=MAX_BULK_SELECTION_LIMIT).contains(&value) {
+            Ok(())
+        } else {
+            Err(AppearanceError::InvalidBulkSelectionLimit(value))
         }
     }
 }
@@ -129,6 +146,10 @@ pub enum AppearanceError {
     InvalidMobileBreakpoint(u16),
     #[error("invalid shortcut profile: {0}")]
     InvalidShortcutProfile(String),
+    #[error(
+        "invalid bulk selection limit: {0}. expected {MIN_BULK_SELECTION_LIMIT}..={MAX_BULK_SELECTION_LIMIT}"
+    )]
+    InvalidBulkSelectionLimit(u16),
 }
 
 #[cfg(test)]
@@ -150,6 +171,12 @@ mod tests {
             AppearanceSettings::default().shortcut_profile,
             ShortcutProfile::Standard
         );
+        assert!(AppearanceSettings::default().bulk_operations_enabled);
+        assert_eq!(
+            AppearanceSettings::default().bulk_selection_limit,
+            DEFAULT_BULK_SELECTION_LIMIT
+        );
+        assert!(AppearanceSettings::default().bulk_action_confirmation);
     }
 
     #[test]
@@ -212,6 +239,9 @@ mod tests {
         assert_eq!(settings.mobile_breakpoint_px, DEFAULT_MOBILE_BREAKPOINT_PX);
         assert!(settings.keyboard_shortcuts_enabled);
         assert_eq!(settings.shortcut_profile, ShortcutProfile::Standard);
+        assert!(settings.bulk_operations_enabled);
+        assert_eq!(settings.bulk_selection_limit, DEFAULT_BULK_SELECTION_LIMIT);
+        assert!(settings.bulk_action_confirmation);
     }
 
     #[test]
@@ -237,5 +267,30 @@ mod tests {
         )
         .expect_err("above max should be invalid");
         assert!(above.to_string().contains("invalid mobile breakpoint"));
+    }
+
+    #[test]
+    fn validate_bulk_selection_limit_accepts_values_in_range() {
+        AppearanceSettings::validate_bulk_selection_limit(MIN_BULK_SELECTION_LIMIT)
+            .expect("min selection limit should be valid");
+        AppearanceSettings::validate_bulk_selection_limit(DEFAULT_BULK_SELECTION_LIMIT)
+            .expect("default selection limit should be valid");
+        AppearanceSettings::validate_bulk_selection_limit(MAX_BULK_SELECTION_LIMIT)
+            .expect("max selection limit should be valid");
+    }
+
+    #[test]
+    fn validate_bulk_selection_limit_rejects_out_of_range_values() {
+        let below = AppearanceSettings::validate_bulk_selection_limit(
+            MIN_BULK_SELECTION_LIMIT.saturating_sub(1),
+        )
+        .expect_err("below min should be invalid");
+        assert!(below.to_string().contains("invalid bulk selection limit"));
+
+        let above = AppearanceSettings::validate_bulk_selection_limit(
+            MAX_BULK_SELECTION_LIMIT.saturating_add(1),
+        )
+        .expect_err("above max should be invalid");
+        assert!(above.to_string().contains("invalid bulk selection limit"));
     }
 }

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -116,8 +116,8 @@ pub use tag_sanitation::TagSanitizer;
 
 // Re-export tag, smart playlist, and duplicate detection domain types for API layer
 pub use appearance::{
-    AppearanceError, AppearanceSettings, ShortcutProfile, ThemeMode, DEFAULT_MOBILE_BREAKPOINT_PX,
-    DEFAULT_SHORTCUT_PROFILE,
+    AppearanceError, AppearanceSettings, ShortcutProfile, ThemeMode, DEFAULT_BULK_SELECTION_LIMIT,
+    DEFAULT_MOBILE_BREAKPOINT_PX, DEFAULT_SHORTCUT_PROFILE,
 };
 pub use chorrosion_domain::{
     DuplicateDetectionMethod, DuplicateFileDetail, DuplicateGroup, EntityType, SmartPlaylist,

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -463,9 +463,7 @@ impl AppState {
         &self,
         settings: crate::appearance::AppearanceSettings,
     ) -> Result<crate::appearance::AppearanceSettings, crate::appearance::AppearanceError> {
-        crate::appearance::AppearanceSettings::validate_mobile_breakpoint_px(
-            settings.mobile_breakpoint_px,
-        )?;
+        settings.validate()?;
 
         let appearance_settings = Arc::clone(&self.appearance_settings);
 


### PR DESCRIPTION
## Summary

Implements Phase 10.3 bulk operations UI support as backend-managed appearance preferences.

## Changes

### Application Layer
- Updated `crates/chorrosion-application/src/appearance.rs`
  - Added bulk operation settings to `AppearanceSettings`
    - `bulk_operations_enabled`
    - `bulk_selection_limit`
    - `bulk_action_confirmation`
  - Added constants for bulk selection defaults and bounds:
    - `DEFAULT_BULK_SELECTION_LIMIT = 100`
    - `MIN_BULK_SELECTION_LIMIT = 10`
    - `MAX_BULK_SELECTION_LIMIT = 1000`
  - Added `AppearanceSettings::validate_bulk_selection_limit(...)`
  - Added `AppearanceError::InvalidBulkSelectionLimit`
  - Expanded unit tests for default values and validation
- Updated `crates/chorrosion-application/src/lib.rs`
  - Re-exported `DEFAULT_BULK_SELECTION_LIMIT`

### API Layer
- Updated `crates/chorrosion-api/src/handlers/appearance.rs`
  - Extended `AppearanceSettingsResponse` with bulk operation fields
  - Extended `UpdateAppearanceSettingsRequest` with bulk operation fields
  - Added bulk selection limit validation in `update_appearance_settings`
  - Added test coverage for invalid bulk selection limits and successful updates

### Roadmap
- Updated `ROADMAP.md`
  - Marked `Bulk operations UI` complete with Issue #425
  - Advanced `Next Milestone` to `Advanced filtering`
  - Updated `Last Updated` to `2026-04-28`

## Validation

- `cargo fmt --all`
- `cargo test -p chorrosion-application appearance -- --nocapture`
- `cargo test -p chorrosion-api appearance -- --nocapture`
- `cargo clippy -p chorrosion-application -p chorrosion-api -- -D warnings`

All checks pass.

Closes #425