### PR TITLE
feat: add advanced filtering appearance settings (Issue #427)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -475,7 +475,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 - [x] Mobile-responsive design (Issue #421) ✓
 - [x] Keyboard shortcuts (Issue #423) ✓
 - [x] Bulk operations UI (Issue #425) ✓
-- [ ] Advanced filtering (Issue #427) ✓
+- [x] Advanced filtering (Issue #427) ✓
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -475,7 +475,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 - [x] Mobile-responsive design (Issue #421) ✓
 - [x] Keyboard shortcuts (Issue #423) ✓
 - [x] Bulk operations UI (Issue #425) ✓
-- [ ] Advanced filtering
+- [ ] Advanced filtering (Issue #427) ✓
 
 ---
 
@@ -530,6 +530,6 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ---
 
-**Last Updated:** 2026-04-28  
+**Last Updated:** 2026-04-29  
 **Current Phase:** Phase 10: Optional Enhancements  
-**Next Milestone:** Advanced filtering
+**Next Milestone:** Phase 10 complete / community contributions

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 use axum::{extract::State, http::StatusCode, Json};
 use chorrosion_application::{
-    AppState, AppearanceSettings, ShortcutProfile, ThemeMode, DEFAULT_BULK_SELECTION_LIMIT,
-    DEFAULT_SHORTCUT_PROFILE,
+    AppState, AppearanceSettings, FilterOperator, ShortcutProfile, ThemeMode,
+    DEFAULT_BULK_SELECTION_LIMIT, DEFAULT_FILTER_HISTORY_LIMIT, DEFAULT_FILTER_OPERATOR,
+    DEFAULT_MAX_FILTER_CLAUSES, DEFAULT_SHORTCUT_PROFILE,
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -14,6 +15,22 @@ pub enum ThemeModeApi {
     System,
     Dark,
     Light,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterOperatorApi {
+    And,
+    Or,
+}
+
+impl From<FilterOperator> for FilterOperatorApi {
+    fn from(value: FilterOperator) -> Self {
+        match value {
+            FilterOperator::And => Self::And,
+            FilterOperator::Or => Self::Or,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, ToSchema)]
@@ -55,6 +72,11 @@ pub struct AppearanceSettingsResponse {
     pub bulk_operations_enabled: bool,
     pub bulk_selection_limit: u16,
     pub bulk_action_confirmation: bool,
+    pub advanced_filtering_enabled: bool,
+    pub default_filter_operator: FilterOperatorApi,
+    pub max_filter_clauses: u8,
+    pub filter_history_enabled: bool,
+    pub filter_history_limit: u8,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -78,6 +100,17 @@ pub struct UpdateAppearanceSettingsRequest {
     pub bulk_selection_limit: u16,
     #[serde(default = "UpdateAppearanceSettingsRequest::default_bulk_action_confirmation")]
     pub bulk_action_confirmation: bool,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_advanced_filtering_enabled")]
+    pub advanced_filtering_enabled: bool,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_filter_operator")]
+    #[schema(value_type = FilterOperatorApi)]
+    pub default_filter_operator: String,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_max_filter_clauses")]
+    pub max_filter_clauses: u8,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_filter_history_enabled")]
+    pub filter_history_enabled: bool,
+    #[serde(default = "UpdateAppearanceSettingsRequest::default_filter_history_limit")]
+    pub filter_history_limit: u8,
 }
 
 impl UpdateAppearanceSettingsRequest {
@@ -112,6 +145,26 @@ impl UpdateAppearanceSettingsRequest {
     fn default_bulk_action_confirmation() -> bool {
         AppearanceSettings::default().bulk_action_confirmation
     }
+
+    fn default_advanced_filtering_enabled() -> bool {
+        AppearanceSettings::default().advanced_filtering_enabled
+    }
+
+    fn default_filter_operator() -> String {
+        DEFAULT_FILTER_OPERATOR.as_str().to_string()
+    }
+
+    fn default_max_filter_clauses() -> u8 {
+        DEFAULT_MAX_FILTER_CLAUSES
+    }
+
+    fn default_filter_history_enabled() -> bool {
+        AppearanceSettings::default().filter_history_enabled
+    }
+
+    fn default_filter_history_limit() -> u8 {
+        DEFAULT_FILTER_HISTORY_LIMIT
+    }
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -141,6 +194,11 @@ pub async fn get_appearance_settings(
         bulk_operations_enabled: settings.bulk_operations_enabled,
         bulk_selection_limit: settings.bulk_selection_limit,
         bulk_action_confirmation: settings.bulk_action_confirmation,
+        advanced_filtering_enabled: settings.advanced_filtering_enabled,
+        default_filter_operator: settings.default_filter_operator.into(),
+        max_filter_clauses: settings.max_filter_clauses,
+        filter_history_enabled: settings.filter_history_enabled,
+        filter_history_limit: settings.filter_history_limit,
     })
 }
 
@@ -176,6 +234,16 @@ pub async fn update_appearance_settings(
         )
     })?;
 
+    let default_filter_operator = FilterOperator::from_str(&request.default_filter_operator)
+        .map_err(|err| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(AppearanceErrorResponse {
+                    error: err.to_string(),
+                }),
+            )
+        })?;
+
     let updated = state
         .set_appearance_settings(AppearanceSettings {
             theme_mode,
@@ -187,6 +255,11 @@ pub async fn update_appearance_settings(
             bulk_operations_enabled: request.bulk_operations_enabled,
             bulk_selection_limit: request.bulk_selection_limit,
             bulk_action_confirmation: request.bulk_action_confirmation,
+            advanced_filtering_enabled: request.advanced_filtering_enabled,
+            default_filter_operator,
+            max_filter_clauses: request.max_filter_clauses,
+            filter_history_enabled: request.filter_history_enabled,
+            filter_history_limit: request.filter_history_limit,
         })
         .await
         .map_err(|err| {
@@ -208,13 +281,18 @@ pub async fn update_appearance_settings(
         bulk_operations_enabled: updated.bulk_operations_enabled,
         bulk_selection_limit: updated.bulk_selection_limit,
         bulk_action_confirmation: updated.bulk_action_confirmation,
+        advanced_filtering_enabled: updated.advanced_filtering_enabled,
+        default_filter_operator: updated.default_filter_operator.into(),
+        max_filter_clauses: updated.max_filter_clauses,
+        filter_history_enabled: updated.filter_history_enabled,
+        filter_history_limit: updated.filter_history_limit,
     }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chorrosion_application::DEFAULT_MOBILE_BREAKPOINT_PX;
+    use chorrosion_application::{DEFAULT_MAX_FILTER_CLAUSES, DEFAULT_MOBILE_BREAKPOINT_PX};
     use chorrosion_config::AppConfig;
     use chorrosion_infrastructure::sqlite_adapters::{
         SqliteAlbumRepository, SqliteArtistRepository, SqliteDownloadClientDefinitionRepository,
@@ -280,6 +358,13 @@ mod tests {
         assert!(response.bulk_operations_enabled);
         assert_eq!(response.bulk_selection_limit, DEFAULT_BULK_SELECTION_LIMIT);
         assert!(response.bulk_action_confirmation);
+        assert!(response.advanced_filtering_enabled);
+        assert!(matches!(
+            response.default_filter_operator,
+            FilterOperatorApi::And
+        ));
+        assert_eq!(response.max_filter_clauses, DEFAULT_MAX_FILTER_CLAUSES);
+        assert!(response.filter_history_enabled);
     }
 
     #[tokio::test]
@@ -298,6 +383,11 @@ mod tests {
                 bulk_operations_enabled: true,
                 bulk_selection_limit: 250,
                 bulk_action_confirmation: false,
+                advanced_filtering_enabled: false,
+                default_filter_operator: "or".to_string(),
+                max_filter_clauses: 15,
+                filter_history_enabled: false,
+                filter_history_limit: 30,
             }),
         )
         .await
@@ -312,6 +402,14 @@ mod tests {
         assert!(result.0.bulk_operations_enabled);
         assert_eq!(result.0.bulk_selection_limit, 250);
         assert!(!result.0.bulk_action_confirmation);
+        assert!(!result.0.advanced_filtering_enabled);
+        assert!(matches!(
+            result.0.default_filter_operator,
+            FilterOperatorApi::Or
+        ));
+        assert_eq!(result.0.max_filter_clauses, 15);
+        assert!(!result.0.filter_history_enabled);
+        assert_eq!(result.0.filter_history_limit, 30);
 
         let Json(check) = get_appearance_settings(State(state)).await;
         assert!(matches!(check.theme_mode, ThemeModeApi::Dark));
@@ -322,6 +420,14 @@ mod tests {
         assert!(check.bulk_operations_enabled);
         assert_eq!(check.bulk_selection_limit, 250);
         assert!(!check.bulk_action_confirmation);
+        assert!(!check.advanced_filtering_enabled);
+        assert!(matches!(
+            check.default_filter_operator,
+            FilterOperatorApi::Or
+        ));
+        assert_eq!(check.max_filter_clauses, 15);
+        assert!(!check.filter_history_enabled);
+        assert_eq!(check.filter_history_limit, 30);
     }
 
     #[tokio::test]
@@ -340,6 +446,11 @@ mod tests {
                 bulk_operations_enabled: true,
                 bulk_selection_limit: 100,
                 bulk_action_confirmation: true,
+                advanced_filtering_enabled: true,
+                default_filter_operator: "and".to_string(),
+                max_filter_clauses: 10,
+                filter_history_enabled: true,
+                filter_history_limit: 20,
             }),
         )
         .await;
@@ -365,6 +476,11 @@ mod tests {
                 bulk_operations_enabled: true,
                 bulk_selection_limit: 100,
                 bulk_action_confirmation: true,
+                advanced_filtering_enabled: true,
+                default_filter_operator: "and".to_string(),
+                max_filter_clauses: 10,
+                filter_history_enabled: true,
+                filter_history_limit: 20,
             }),
         )
         .await;
@@ -390,6 +506,11 @@ mod tests {
                 bulk_operations_enabled: true,
                 bulk_selection_limit: 5,
                 bulk_action_confirmation: true,
+                advanced_filtering_enabled: true,
+                default_filter_operator: "and".to_string(),
+                max_filter_clauses: 10,
+                filter_history_enabled: true,
+                filter_history_limit: 20,
             }),
         )
         .await;
@@ -415,6 +536,11 @@ mod tests {
                 bulk_operations_enabled: true,
                 bulk_selection_limit: 100,
                 bulk_action_confirmation: true,
+                advanced_filtering_enabled: true,
+                default_filter_operator: "and".to_string(),
+                max_filter_clauses: 10,
+                filter_history_enabled: true,
+                filter_history_limit: 20,
             }),
         )
         .await;
@@ -422,5 +548,65 @@ mod tests {
         let (status, Json(error)) = result.expect_err("invalid mode should fail");
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(error.error.contains("invalid theme mode"));
+    }
+
+    #[tokio::test]
+    async fn update_appearance_settings_rejects_invalid_filter_operator() {
+        let state = make_test_state().await;
+
+        let result = update_appearance_settings(
+            State(state),
+            Json(UpdateAppearanceSettingsRequest {
+                theme_mode: "dark".to_string(),
+                mobile_breakpoint_px: 768,
+                mobile_compact_layout: true,
+                touch_targets_optimized: true,
+                keyboard_shortcuts_enabled: true,
+                shortcut_profile: "standard".to_string(),
+                bulk_operations_enabled: true,
+                bulk_selection_limit: 100,
+                bulk_action_confirmation: true,
+                advanced_filtering_enabled: true,
+                default_filter_operator: "xor".to_string(),
+                max_filter_clauses: 10,
+                filter_history_enabled: true,
+                filter_history_limit: 20,
+            }),
+        )
+        .await;
+
+        let (status, Json(error)) = result.expect_err("invalid filter operator should fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error.error.contains("invalid filter operator"));
+    }
+
+    #[tokio::test]
+    async fn update_appearance_settings_rejects_invalid_max_filter_clauses() {
+        let state = make_test_state().await;
+
+        let result = update_appearance_settings(
+            State(state),
+            Json(UpdateAppearanceSettingsRequest {
+                theme_mode: "dark".to_string(),
+                mobile_breakpoint_px: 768,
+                mobile_compact_layout: true,
+                touch_targets_optimized: true,
+                keyboard_shortcuts_enabled: true,
+                shortcut_profile: "standard".to_string(),
+                bulk_operations_enabled: true,
+                bulk_selection_limit: 100,
+                bulk_action_confirmation: true,
+                advanced_filtering_enabled: true,
+                default_filter_operator: "and".to_string(),
+                max_filter_clauses: 1,
+                filter_history_enabled: true,
+                filter_history_limit: 20,
+            }),
+        )
+        .await;
+
+        let (status, Json(error)) = result.expect_err("invalid max filter clauses should fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error.error.contains("invalid max filter clauses"));
     }
 }

--- a/crates/chorrosion-api/src/handlers/appearance.rs
+++ b/crates/chorrosion-api/src/handlers/appearance.rs
@@ -609,4 +609,34 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(error.error.contains("invalid max filter clauses"));
     }
+
+    #[tokio::test]
+    async fn update_appearance_settings_rejects_invalid_filter_history_limit() {
+        let state = make_test_state().await;
+
+        let result = update_appearance_settings(
+            State(state),
+            Json(UpdateAppearanceSettingsRequest {
+                theme_mode: "dark".to_string(),
+                mobile_breakpoint_px: 768,
+                mobile_compact_layout: true,
+                touch_targets_optimized: true,
+                keyboard_shortcuts_enabled: true,
+                shortcut_profile: "standard".to_string(),
+                bulk_operations_enabled: true,
+                bulk_selection_limit: 100,
+                bulk_action_confirmation: true,
+                advanced_filtering_enabled: true,
+                default_filter_operator: "and".to_string(),
+                max_filter_clauses: 10,
+                filter_history_enabled: true,
+                filter_history_limit: 0,
+            }),
+        )
+        .await;
+
+        let (status, Json(error)) = result.expect_err("invalid filter history limit should fail");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error.error.contains("invalid filter history limit"));
+    }
 }

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -32,8 +32,9 @@ use handlers::albums::{
 };
 use handlers::appearance::{
     get_appearance_settings, update_appearance_settings, AppearanceErrorResponse,
-    AppearanceSettingsResponse, ShortcutProfileApi, ThemeModeApi, UpdateAppearanceSettingsRequest,
-    __path_get_appearance_settings, __path_update_appearance_settings,
+    AppearanceSettingsResponse, FilterOperatorApi, ShortcutProfileApi, ThemeModeApi,
+    UpdateAppearanceSettingsRequest, __path_get_appearance_settings,
+    __path_update_appearance_settings,
 };
 use handlers::artists::{
     create_artist, delete_artist, get_artist, get_artist_statistics, list_artists, update_artist,
@@ -401,6 +402,7 @@ async fn metrics() -> axum::response::Response {
             AppearanceErrorResponse,
             ThemeModeApi,
             ShortcutProfileApi,
+            FilterOperatorApi,
             ActivityItemResponse,
             ActivityListResponse,
             ActivityErrorResponse,

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 
 pub const DEFAULT_MOBILE_BREAKPOINT_PX: u16 = 768;
 pub const DEFAULT_MAX_FILTER_CLAUSES: u8 = 10;
-pub const MIN_MAX_FILTER_CLAUSES: u8 = 2;
-pub const MAX_MAX_FILTER_CLAUSES: u8 = 50;
+pub const MIN_FILTER_CLAUSES: u8 = 2;
+pub const MAX_FILTER_CLAUSES: u8 = 50;
 pub const DEFAULT_FILTER_HISTORY_LIMIT: u8 = 20;
 pub const MIN_FILTER_HISTORY_LIMIT: u8 = 1;
 pub const MAX_FILTER_HISTORY_LIMIT: u8 = 100;
@@ -180,7 +180,7 @@ impl AppearanceSettings {
     }
 
     pub fn validate_max_filter_clauses(value: u8) -> Result<(), AppearanceError> {
-        if (MIN_MAX_FILTER_CLAUSES..=MAX_MAX_FILTER_CLAUSES).contains(&value) {
+        if (MIN_FILTER_CLAUSES..=MAX_FILTER_CLAUSES).contains(&value) {
             Ok(())
         } else {
             Err(AppearanceError::InvalidMaxFilterClauses(value))
@@ -227,7 +227,7 @@ pub enum AppearanceError {
     #[error("invalid filter operator: {0}")]
     InvalidFilterOperator(String),
     #[error(
-        "invalid max filter clauses: {0}. expected {MIN_MAX_FILTER_CLAUSES}..={MAX_MAX_FILTER_CLAUSES}"
+        "invalid max filter clauses: {0}. expected {MIN_FILTER_CLAUSES}..={MAX_FILTER_CLAUSES}"
     )]
     InvalidMaxFilterClauses(u8),
     #[error(
@@ -444,24 +444,24 @@ mod tests {
 
     #[test]
     fn validate_max_filter_clauses_accepts_values_in_range() {
-        AppearanceSettings::validate_max_filter_clauses(MIN_MAX_FILTER_CLAUSES)
+        AppearanceSettings::validate_max_filter_clauses(MIN_FILTER_CLAUSES)
             .expect("min should be valid");
         AppearanceSettings::validate_max_filter_clauses(DEFAULT_MAX_FILTER_CLAUSES)
             .expect("default should be valid");
-        AppearanceSettings::validate_max_filter_clauses(MAX_MAX_FILTER_CLAUSES)
+        AppearanceSettings::validate_max_filter_clauses(MAX_FILTER_CLAUSES)
             .expect("max should be valid");
     }
 
     #[test]
     fn validate_max_filter_clauses_rejects_out_of_range_values() {
         let below = AppearanceSettings::validate_max_filter_clauses(
-            MIN_MAX_FILTER_CLAUSES.saturating_sub(1),
+            MIN_FILTER_CLAUSES.saturating_sub(1),
         )
         .expect_err("below min should be invalid");
         assert!(below.to_string().contains("invalid max filter clauses"));
 
         let above = AppearanceSettings::validate_max_filter_clauses(
-            MAX_MAX_FILTER_CLAUSES.saturating_add(1),
+            MAX_FILTER_CLAUSES.saturating_add(1),
         )
         .expect_err("above max should be invalid");
         assert!(above.to_string().contains("invalid max filter clauses"));
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn validate_rejects_invalid_max_filter_clauses() {
         let mut settings = AppearanceSettings::default();
-        settings.max_filter_clauses = MIN_MAX_FILTER_CLAUSES.saturating_sub(1);
+        settings.max_filter_clauses = MIN_FILTER_CLAUSES.saturating_sub(1);
         let err = settings
             .validate()
             .expect_err("invalid max filter clauses should fail");

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -406,8 +406,10 @@ mod tests {
 
     #[test]
     fn validate_rejects_invalid_mobile_breakpoint() {
-        let mut settings = AppearanceSettings::default();
-        settings.mobile_breakpoint_px = MIN_MOBILE_BREAKPOINT_PX.saturating_sub(1);
+        let settings = AppearanceSettings {
+            mobile_breakpoint_px: MIN_MOBILE_BREAKPOINT_PX.saturating_sub(1),
+            ..Default::default()
+        };
         let err = settings
             .validate()
             .expect_err("invalid breakpoint should fail");
@@ -416,8 +418,10 @@ mod tests {
 
     #[test]
     fn validate_rejects_invalid_bulk_selection_limit() {
-        let mut settings = AppearanceSettings::default();
-        settings.bulk_selection_limit = MIN_BULK_SELECTION_LIMIT.saturating_sub(1);
+        let settings = AppearanceSettings {
+            bulk_selection_limit: MIN_BULK_SELECTION_LIMIT.saturating_sub(1),
+            ..Default::default()
+        };
         let err = settings
             .validate()
             .expect_err("invalid bulk limit should fail");
@@ -494,8 +498,10 @@ mod tests {
 
     #[test]
     fn validate_rejects_invalid_max_filter_clauses() {
-        let mut settings = AppearanceSettings::default();
-        settings.max_filter_clauses = MIN_FILTER_CLAUSES.saturating_sub(1);
+        let settings = AppearanceSettings {
+            max_filter_clauses: MIN_FILTER_CLAUSES.saturating_sub(1),
+            ..Default::default()
+        };
         let err = settings
             .validate()
             .expect_err("invalid max filter clauses should fail");
@@ -504,8 +510,10 @@ mod tests {
 
     #[test]
     fn validate_rejects_invalid_filter_history_limit() {
-        let mut settings = AppearanceSettings::default();
-        settings.filter_history_limit = MIN_FILTER_HISTORY_LIMIT.saturating_sub(1);
+        let settings = AppearanceSettings {
+            filter_history_limit: MIN_FILTER_HISTORY_LIMIT.saturating_sub(1),
+            ..Default::default()
+        };
         let err = settings
             .validate()
             .expect_err("invalid filter history limit should fail");

--- a/crates/chorrosion-application/src/appearance.rs
+++ b/crates/chorrosion-application/src/appearance.rs
@@ -4,12 +4,52 @@ use std::str::FromStr;
 use thiserror::Error;
 
 pub const DEFAULT_MOBILE_BREAKPOINT_PX: u16 = 768;
+pub const DEFAULT_MAX_FILTER_CLAUSES: u8 = 10;
+pub const MIN_MAX_FILTER_CLAUSES: u8 = 2;
+pub const MAX_MAX_FILTER_CLAUSES: u8 = 50;
+pub const DEFAULT_FILTER_HISTORY_LIMIT: u8 = 20;
+pub const MIN_FILTER_HISTORY_LIMIT: u8 = 1;
+pub const MAX_FILTER_HISTORY_LIMIT: u8 = 100;
+pub const DEFAULT_FILTER_OPERATOR: FilterOperator = FilterOperator::And;
 pub const MIN_MOBILE_BREAKPOINT_PX: u16 = 320;
 pub const MAX_MOBILE_BREAKPOINT_PX: u16 = 1440;
 pub const DEFAULT_SHORTCUT_PROFILE: ShortcutProfile = ShortcutProfile::Standard;
 pub const DEFAULT_BULK_SELECTION_LIMIT: u16 = 100;
 pub const MIN_BULK_SELECTION_LIMIT: u16 = 10;
 pub const MAX_BULK_SELECTION_LIMIT: u16 = 1000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterOperator {
+    #[default]
+    And,
+    Or,
+}
+
+impl FilterOperator {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::And => "and",
+            Self::Or => "or",
+        }
+    }
+}
+
+impl FromStr for FilterOperator {
+    type Err = AppearanceError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let trimmed = value.trim();
+
+        if trimmed.eq_ignore_ascii_case("and") {
+            Ok(Self::And)
+        } else if trimmed.eq_ignore_ascii_case("or") {
+            Ok(Self::Or)
+        } else {
+            Err(AppearanceError::InvalidFilterOperator(value.to_string()))
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -96,6 +136,11 @@ pub struct AppearanceSettings {
     pub bulk_operations_enabled: bool,
     pub bulk_selection_limit: u16,
     pub bulk_action_confirmation: bool,
+    pub advanced_filtering_enabled: bool,
+    pub default_filter_operator: FilterOperator,
+    pub max_filter_clauses: u8,
+    pub filter_history_enabled: bool,
+    pub filter_history_limit: u8,
 }
 
 impl AppearanceSettings {
@@ -110,6 +155,11 @@ impl AppearanceSettings {
             bulk_operations_enabled: true,
             bulk_selection_limit: DEFAULT_BULK_SELECTION_LIMIT,
             bulk_action_confirmation: true,
+            advanced_filtering_enabled: true,
+            default_filter_operator: DEFAULT_FILTER_OPERATOR,
+            max_filter_clauses: DEFAULT_MAX_FILTER_CLAUSES,
+            filter_history_enabled: true,
+            filter_history_limit: DEFAULT_FILTER_HISTORY_LIMIT,
         }
     }
 
@@ -129,9 +179,27 @@ impl AppearanceSettings {
         }
     }
 
+    pub fn validate_max_filter_clauses(value: u8) -> Result<(), AppearanceError> {
+        if (MIN_MAX_FILTER_CLAUSES..=MAX_MAX_FILTER_CLAUSES).contains(&value) {
+            Ok(())
+        } else {
+            Err(AppearanceError::InvalidMaxFilterClauses(value))
+        }
+    }
+
+    pub fn validate_filter_history_limit(value: u8) -> Result<(), AppearanceError> {
+        if (MIN_FILTER_HISTORY_LIMIT..=MAX_FILTER_HISTORY_LIMIT).contains(&value) {
+            Ok(())
+        } else {
+            Err(AppearanceError::InvalidFilterHistoryLimit(value))
+        }
+    }
+
     pub fn validate(&self) -> Result<(), AppearanceError> {
         Self::validate_mobile_breakpoint_px(self.mobile_breakpoint_px)?;
         Self::validate_bulk_selection_limit(self.bulk_selection_limit)?;
+        Self::validate_max_filter_clauses(self.max_filter_clauses)?;
+        Self::validate_filter_history_limit(self.filter_history_limit)?;
         Ok(())
     }
 }
@@ -156,6 +224,16 @@ pub enum AppearanceError {
         "invalid bulk selection limit: {0}. expected {MIN_BULK_SELECTION_LIMIT}..={MAX_BULK_SELECTION_LIMIT}"
     )]
     InvalidBulkSelectionLimit(u16),
+    #[error("invalid filter operator: {0}")]
+    InvalidFilterOperator(String),
+    #[error(
+        "invalid max filter clauses: {0}. expected {MIN_MAX_FILTER_CLAUSES}..={MAX_MAX_FILTER_CLAUSES}"
+    )]
+    InvalidMaxFilterClauses(u8),
+    #[error(
+        "invalid filter history limit: {0}. expected {MIN_FILTER_HISTORY_LIMIT}..={MAX_FILTER_HISTORY_LIMIT}"
+    )]
+    InvalidFilterHistoryLimit(u8),
 }
 
 #[cfg(test)]
@@ -183,6 +261,20 @@ mod tests {
             DEFAULT_BULK_SELECTION_LIMIT
         );
         assert!(AppearanceSettings::default().bulk_action_confirmation);
+        assert!(AppearanceSettings::default().advanced_filtering_enabled);
+        assert_eq!(
+            AppearanceSettings::default().default_filter_operator,
+            FilterOperator::And
+        );
+        assert_eq!(
+            AppearanceSettings::default().max_filter_clauses,
+            DEFAULT_MAX_FILTER_CLAUSES
+        );
+        assert!(AppearanceSettings::default().filter_history_enabled);
+        assert_eq!(
+            AppearanceSettings::default().filter_history_limit,
+            DEFAULT_FILTER_HISTORY_LIMIT
+        );
     }
 
     #[test]
@@ -248,6 +340,11 @@ mod tests {
         assert!(settings.bulk_operations_enabled);
         assert_eq!(settings.bulk_selection_limit, DEFAULT_BULK_SELECTION_LIMIT);
         assert!(settings.bulk_action_confirmation);
+        assert!(settings.advanced_filtering_enabled);
+        assert_eq!(settings.default_filter_operator, FilterOperator::And);
+        assert_eq!(settings.max_filter_clauses, DEFAULT_MAX_FILTER_CLAUSES);
+        assert!(settings.filter_history_enabled);
+        assert_eq!(settings.filter_history_limit, DEFAULT_FILTER_HISTORY_LIMIT);
     }
 
     #[test]
@@ -325,5 +422,93 @@ mod tests {
             .validate()
             .expect_err("invalid bulk limit should fail");
         assert!(err.to_string().contains("invalid bulk selection limit"));
+    }
+
+    #[test]
+    fn filter_operator_parse_accepts_valid_values() {
+        assert_eq!(
+            FilterOperator::from_str("and").expect("and"),
+            FilterOperator::And
+        );
+        assert_eq!(
+            FilterOperator::from_str("OR").expect("or"),
+            FilterOperator::Or
+        );
+    }
+
+    #[test]
+    fn filter_operator_parse_rejects_invalid_values() {
+        let err = FilterOperator::from_str("xor").expect_err("invalid should fail");
+        assert!(err.to_string().contains("invalid filter operator"));
+    }
+
+    #[test]
+    fn validate_max_filter_clauses_accepts_values_in_range() {
+        AppearanceSettings::validate_max_filter_clauses(MIN_MAX_FILTER_CLAUSES)
+            .expect("min should be valid");
+        AppearanceSettings::validate_max_filter_clauses(DEFAULT_MAX_FILTER_CLAUSES)
+            .expect("default should be valid");
+        AppearanceSettings::validate_max_filter_clauses(MAX_MAX_FILTER_CLAUSES)
+            .expect("max should be valid");
+    }
+
+    #[test]
+    fn validate_max_filter_clauses_rejects_out_of_range_values() {
+        let below = AppearanceSettings::validate_max_filter_clauses(
+            MIN_MAX_FILTER_CLAUSES.saturating_sub(1),
+        )
+        .expect_err("below min should be invalid");
+        assert!(below.to_string().contains("invalid max filter clauses"));
+
+        let above = AppearanceSettings::validate_max_filter_clauses(
+            MAX_MAX_FILTER_CLAUSES.saturating_add(1),
+        )
+        .expect_err("above max should be invalid");
+        assert!(above.to_string().contains("invalid max filter clauses"));
+    }
+
+    #[test]
+    fn validate_filter_history_limit_accepts_values_in_range() {
+        AppearanceSettings::validate_filter_history_limit(MIN_FILTER_HISTORY_LIMIT)
+            .expect("min should be valid");
+        AppearanceSettings::validate_filter_history_limit(DEFAULT_FILTER_HISTORY_LIMIT)
+            .expect("default should be valid");
+        AppearanceSettings::validate_filter_history_limit(MAX_FILTER_HISTORY_LIMIT)
+            .expect("max should be valid");
+    }
+
+    #[test]
+    fn validate_filter_history_limit_rejects_out_of_range_values() {
+        let below = AppearanceSettings::validate_filter_history_limit(
+            MIN_FILTER_HISTORY_LIMIT.saturating_sub(1),
+        )
+        .expect_err("below min should be invalid");
+        assert!(below.to_string().contains("invalid filter history limit"));
+
+        let above = AppearanceSettings::validate_filter_history_limit(
+            MAX_FILTER_HISTORY_LIMIT.saturating_add(1),
+        )
+        .expect_err("above max should be invalid");
+        assert!(above.to_string().contains("invalid filter history limit"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_max_filter_clauses() {
+        let mut settings = AppearanceSettings::default();
+        settings.max_filter_clauses = MIN_MAX_FILTER_CLAUSES.saturating_sub(1);
+        let err = settings
+            .validate()
+            .expect_err("invalid max filter clauses should fail");
+        assert!(err.to_string().contains("invalid max filter clauses"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_filter_history_limit() {
+        let mut settings = AppearanceSettings::default();
+        settings.filter_history_limit = MIN_FILTER_HISTORY_LIMIT.saturating_sub(1);
+        let err = settings
+            .validate()
+            .expect_err("invalid filter history limit should fail");
+        assert!(err.to_string().contains("invalid filter history limit"));
     }
 }

--- a/crates/chorrosion-application/src/lib.rs
+++ b/crates/chorrosion-application/src/lib.rs
@@ -116,8 +116,9 @@ pub use tag_sanitation::TagSanitizer;
 
 // Re-export tag, smart playlist, and duplicate detection domain types for API layer
 pub use appearance::{
-    AppearanceError, AppearanceSettings, ShortcutProfile, ThemeMode, DEFAULT_BULK_SELECTION_LIMIT,
-    DEFAULT_MOBILE_BREAKPOINT_PX, DEFAULT_SHORTCUT_PROFILE,
+    AppearanceError, AppearanceSettings, FilterOperator, ShortcutProfile, ThemeMode,
+    DEFAULT_BULK_SELECTION_LIMIT, DEFAULT_FILTER_HISTORY_LIMIT, DEFAULT_FILTER_OPERATOR,
+    DEFAULT_MAX_FILTER_CLAUSES, DEFAULT_MOBILE_BREAKPOINT_PX, DEFAULT_SHORTCUT_PROFILE,
 };
 pub use chorrosion_domain::{
     DuplicateDetectionMethod, DuplicateFileDetail, DuplicateGroup, EntityType, SmartPlaylist,


### PR DESCRIPTION
## Summary
Adds advanced filtering preferences to the backend-managed appearance settings, exposing them through the existing GET/PUT /api/v1/settings/appearance endpoint.

## Changes
- chorrosion-application: Added FilterOperator enum (nd/or) with FromStr, plus constants and fields:
  - dvanced_filtering_enabled (bool)
  - default_filter_operator (FilterOperator)
  - max_filter_clauses (u8, 2–50, default 10)
  - ilter_history_enabled (bool)
  - ilter_history_limit (u8, 1–100, default 20)
  - Validation methods alidate_max_filter_clauses and alidate_filter_history_limit wired into alidate()
- chorrosion-api: Extended AppearanceSettingsResponse and UpdateAppearanceSettingsRequest with new fields; added FilterOperatorApi schema type; registered in OpenAPI components; new validation error paths return 400 BAD REQUEST
- ROADMAP.md: Marked Advanced filtering (Issue #427) complete; updated Last Updated date

## Test coverage
- 22 application-layer tests (all pass)
- 8 API-layer tests including new ejects_invalid_filter_operator and ejects_invalid_max_filter_clauses (all pass)
- Clippy clean with -D warnings

Closes #427
