### PR TITLE
feat: implement artists and albums browser UI (Issue #433)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,9 +1,13 @@
 import type {
 	AppearanceErrorResponse,
 	AppearanceSettings,
+	Artist,
+	Album,
+	Track,
 	FormsLoginResponse,
 	FormsLogoutResponse,
-	GenericListResponse
+	GenericListResponse,
+	PaginatedResponse
 } from './types';
 
 const API_BASE = (import.meta.env.VITE_CHORROSION_API_BASE ?? 'http://127.0.0.1:5150').replace(
@@ -117,4 +121,46 @@ export async function getProcessingSnapshot(): Promise<GenericListResponse> {
 
 export async function getTasksSnapshot(): Promise<GenericListResponse> {
 	return request<GenericListResponse>('/api/v1/system/tasks');
+}
+
+export async function getArtists(params?: {
+	limit?: number;
+	offset?: number;
+}): Promise<PaginatedResponse<Artist>> {
+	const query = new URLSearchParams();
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	if (params?.offset !== undefined) query.set('offset', String(params.offset));
+	const qs = query.toString();
+	return request<PaginatedResponse<Artist>>(`/api/v1/artists${qs ? `?${qs}` : ''}`);
+}
+
+export async function getArtist(id: string): Promise<Artist> {
+	return request<Artist>(`/api/v1/artists/${encodeURIComponent(id)}`);
+}
+
+export async function getArtistAlbums(artistId: string): Promise<PaginatedResponse<Album>> {
+	return request<PaginatedResponse<Album>>(
+		`/api/v1/artists/${encodeURIComponent(artistId)}/albums`
+	);
+}
+
+export async function getAlbums(params?: {
+	limit?: number;
+	offset?: number;
+}): Promise<PaginatedResponse<Album>> {
+	const query = new URLSearchParams();
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	if (params?.offset !== undefined) query.set('offset', String(params.offset));
+	const qs = query.toString();
+	return request<PaginatedResponse<Album>>(`/api/v1/albums${qs ? `?${qs}` : ''}`);
+}
+
+export async function getAlbum(id: string): Promise<Album> {
+	return request<Album>(`/api/v1/albums/${encodeURIComponent(id)}`);
+}
+
+export async function getAlbumTracks(albumId: string): Promise<PaginatedResponse<Track>> {
+	return request<PaginatedResponse<Track>>(
+		`/api/v1/albums/${encodeURIComponent(albumId)}/tracks`
+	);
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -138,9 +138,16 @@ export async function getArtist(id: string): Promise<Artist> {
 	return request<Artist>(`/api/v1/artists/${encodeURIComponent(id)}`);
 }
 
-export async function getArtistAlbums(artistId: string): Promise<PaginatedResponse<Album>> {
+export async function getArtistAlbums(
+	artistId: string,
+	params?: { limit?: number; offset?: number }
+): Promise<PaginatedResponse<Album>> {
+	const query = new URLSearchParams();
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	if (params?.offset !== undefined) query.set('offset', String(params.offset));
+	const qs = query.toString();
 	return request<PaginatedResponse<Album>>(
-		`/api/v1/artists/${encodeURIComponent(artistId)}/albums`
+		`/api/v1/artists/${encodeURIComponent(artistId)}/albums${qs ? `?${qs}` : ''}`
 	);
 }
 
@@ -159,8 +166,15 @@ export async function getAlbum(id: string): Promise<Album> {
 	return request<Album>(`/api/v1/albums/${encodeURIComponent(id)}`);
 }
 
-export async function getAlbumTracks(albumId: string): Promise<PaginatedResponse<Track>> {
+export async function getAlbumTracks(
+	albumId: string,
+	params?: { limit?: number; offset?: number }
+): Promise<PaginatedResponse<Track>> {
+	const query = new URLSearchParams();
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	if (params?.offset !== undefined) query.set('offset', String(params.offset));
+	const qs = query.toString();
 	return request<PaginatedResponse<Track>>(
-		`/api/v1/albums/${encodeURIComponent(albumId)}/tracks`
+		`/api/v1/albums/${encodeURIComponent(albumId)}/tracks${qs ? `?${qs}` : ''}`
 	);
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -46,3 +46,42 @@ export interface GenericListResponse {
 	limit?: number;
 	offset?: number;
 }
+
+export interface PaginatedResponse<T> {
+	items: T[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+export interface Artist {
+	id: string;
+	name: string;
+	foreign_artist_id: string | null;
+	status: string;
+	monitored: boolean;
+	path: string | null;
+}
+
+export interface Album {
+	id: string;
+	artist_id: string;
+	foreign_album_id: string | null;
+	title: string;
+	release_date: string | null;
+	album_type: string | null;
+	status: string;
+	monitored: boolean;
+}
+
+export interface Track {
+	id: string;
+	album_id: string;
+	artist_id: string;
+	foreign_track_id: string | null;
+	title: string;
+	track_number: number | null;
+	duration_ms: number | null;
+	has_file: boolean;
+	monitored: boolean;
+}

--- a/web/src/routes/(app)/albums/+page.svelte
+++ b/web/src/routes/(app)/albums/+page.svelte
@@ -1,2 +1,273 @@
-<h2>Albums Browser</h2>
-<p>Albums listing and search will be implemented in Issue #433.</p>
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { getAlbums } from '$lib/api';
+	import type { Album } from '$lib/types';
+
+	const PAGE_SIZE = 50;
+
+	let items: Album[] = $state([]);
+	let total = $state(0);
+	let offset = $state(0);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let search = $state('');
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	let filtered: Album[] = $derived(
+		search.trim()
+			? items.filter((a) => a.title.toLowerCase().includes(search.trim().toLowerCase()))
+			: items
+	);
+
+	async function load(newOffset = 0) {
+		loading = true;
+		error = null;
+		try {
+			const res = await getAlbums({ limit: PAGE_SIZE, offset: newOffset });
+			items = res.items;
+			total = res.total;
+			offset = newOffset;
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load albums';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function onSearchInput() {
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(() => {
+			offset = 0;
+		}, 300);
+	}
+
+	function prevPage() {
+		if (offset > 0) load(Math.max(0, offset - PAGE_SIZE));
+	}
+
+	function nextPage() {
+		if (offset + PAGE_SIZE < total) load(offset + PAGE_SIZE);
+	}
+
+	onMount(() => load());
+</script>
+
+<div class="catalog-page">
+	<header class="catalog-header">
+		<h1>Albums</h1>
+		<span class="total-badge">{total} total</span>
+	</header>
+
+	<div class="search-bar">
+		<input
+			type="search"
+			placeholder="Filter albums…"
+			bind:value={search}
+			oninput={onSearchInput}
+			aria-label="Filter albums"
+		/>
+	</div>
+
+	{#if loading}
+		<div class="state-message">Loading albums…</div>
+	{:else if error}
+		<div class="state-message error">{error}</div>
+	{:else if filtered.length === 0}
+		<div class="state-message">No albums found.</div>
+	{:else}
+		<ul class="catalog-list" role="list">
+			{#each filtered as album (album.id)}
+				<li class="catalog-item">
+					<button
+						class="catalog-row"
+						onclick={() => goto(`/albums/${album.id}`)}
+						aria-label="View album {album.title}"
+					>
+						<div class="album-info">
+							<span class="item-name">{album.title}</span>
+							{#if album.release_date}
+								<span class="item-year">{album.release_date.slice(0, 4)}</span>
+							{/if}
+						</div>
+						<span class="item-meta">
+							{#if album.album_type}
+								<span class="badge">{album.album_type}</span>
+							{/if}
+							{#if album.monitored}
+								<span class="badge monitored">Monitored</span>
+							{/if}
+							<span class="badge status">{album.status}</span>
+						</span>
+					</button>
+				</li>
+			{/each}
+		</ul>
+
+		{#if !search.trim()}
+			<div class="pagination">
+				<button onclick={prevPage} disabled={offset === 0}>← Previous</button>
+				<span>{offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}</span>
+				<button onclick={nextPage} disabled={offset + PAGE_SIZE >= total}>Next →</button>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.catalog-page {
+		max-width: 900px;
+		margin: 0 auto;
+	}
+
+	.catalog-header {
+		display: flex;
+		align-items: baseline;
+		gap: 0.75rem;
+		margin-bottom: 1.25rem;
+	}
+
+	.catalog-header h1 {
+		font-size: 2rem;
+		font-weight: 800;
+		margin: 0;
+	}
+
+	.total-badge {
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+	}
+
+	.search-bar {
+		margin-bottom: 1.25rem;
+	}
+
+	.search-bar input {
+		width: 100%;
+		max-width: 420px;
+		padding: 0.55rem 0.85rem;
+		border: 1px solid var(--border-color);
+		border-radius: 6px;
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		font-size: 0.95rem;
+	}
+
+	.search-bar input:focus {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
+	.state-message {
+		padding: 2rem 0;
+		text-align: center;
+		color: var(--text-secondary);
+	}
+
+	.state-message.error {
+		color: var(--error);
+	}
+
+	.catalog-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		overflow: hidden;
+	}
+
+	.catalog-item + .catalog-item {
+		border-top: 1px solid var(--border-color);
+	}
+
+	.catalog-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 0.85rem 1.1rem;
+		background: var(--bg-secondary);
+		border: none;
+		cursor: pointer;
+		text-align: left;
+		color: var(--text-primary);
+		transition: background 0.12s;
+	}
+
+	.catalog-row:hover {
+		background: color-mix(in srgb, var(--accent) 8%, var(--bg-secondary));
+	}
+
+	.album-info {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+	}
+
+	.item-name {
+		font-weight: 600;
+		font-size: 1rem;
+	}
+
+	.item-year {
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+	}
+
+	.item-meta {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.badge {
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		padding: 0.2rem 0.5rem;
+		border-radius: 4px;
+		background: var(--bg-primary);
+		color: var(--text-secondary);
+	}
+
+	.badge.monitored {
+		background: rgba(var(--success-rgb), 0.15);
+		color: var(--success);
+	}
+
+	.pagination {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		justify-content: center;
+		margin-top: 1.5rem;
+	}
+
+	.pagination button {
+		padding: 0.45rem 0.9rem;
+		border: 1px solid var(--border-color);
+		border-radius: 6px;
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: 0.9rem;
+		transition: background 0.12s;
+	}
+
+	.pagination button:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--accent) 10%, var(--bg-secondary));
+	}
+
+	.pagination button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.pagination span {
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+	}
+</style>
+

--- a/web/src/routes/(app)/albums/+page.svelte
+++ b/web/src/routes/(app)/albums/+page.svelte
@@ -12,7 +12,6 @@
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let search = $state('');
-	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 
 	let filtered: Album[] = $derived(
 		search.trim()
@@ -33,13 +32,6 @@
 		} finally {
 			loading = false;
 		}
-	}
-
-	function onSearchInput() {
-		if (searchDebounce) clearTimeout(searchDebounce);
-		searchDebounce = setTimeout(() => {
-			offset = 0;
-		}, 300);
 	}
 
 	function prevPage() {
@@ -64,7 +56,6 @@
 			type="search"
 			placeholder="Filter albums…"
 			bind:value={search}
-			oninput={onSearchInput}
 			aria-label="Filter albums"
 		/>
 	</div>

--- a/web/src/routes/(app)/albums/[id]/+page.svelte
+++ b/web/src/routes/(app)/albums/[id]/+page.svelte
@@ -1,0 +1,278 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { getAlbum, getAlbumTracks, getArtist } from '$lib/api';
+	import type { Album, Artist, Track } from '$lib/types';
+
+	let album = $state<Album | null>(null);
+	let artist = $state<Artist | null>(null);
+	let tracks: Track[] = $state([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	function formatDuration(ms: number | null): string {
+		if (ms === null) return '—';
+		const totalSec = Math.round(ms / 1000);
+		const min = Math.floor(totalSec / 60);
+		const sec = totalSec % 60;
+		return `${min}:${String(sec).padStart(2, '0')}`;
+	}
+
+	async function load() {
+		loading = true;
+		error = null;
+		const id = $page.params.id;
+		if (!id) { error = 'Invalid album ID'; loading = false; return; }
+		try {
+			const [a, tracksRes] = await Promise.all([getAlbum(id), getAlbumTracks(id)]);
+			album = a;
+			tracks = tracksRes.items.sort(
+				(a, b) => (a.track_number ?? 9999) - (b.track_number ?? 9999)
+			);
+			// Fetch the artist name for the back-link breadcrumb
+			if (a.artist_id) {
+				try {
+					artist = await getArtist(a.artist_id);
+				} catch {
+					// non-critical
+				}
+			}
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load album';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(() => load());
+</script>
+
+<div class="detail-page">
+	{#if loading}
+		<div class="state-message">Loading…</div>
+	{:else if error}
+		<div class="state-message error">{error}</div>
+	{:else if album}
+		<div class="breadcrumb">
+			<button onclick={() => goto('/albums')} class="back-btn">← Albums</button>
+			{#if artist}
+				<span class="sep">/</span>
+				<button onclick={() => goto(`/artists/${artist?.id}`)} class="back-btn"
+					>{artist.name}</button
+				>
+			{/if}
+		</div>
+
+		<header class="detail-header">
+			<h1>{album.title}</h1>
+			<div class="detail-meta">
+				{#if album.release_date}
+					<span class="meta-item year">{album.release_date.slice(0, 4)}</span>
+				{/if}
+				{#if album.album_type}
+					<span class="badge">{album.album_type}</span>
+				{/if}
+				{#if album.monitored}
+					<span class="badge monitored">Monitored</span>
+				{/if}
+				<span class="badge status">{album.status}</span>
+			</div>
+		</header>
+
+		<section class="tracks-section">
+			<h2>Tracks <span class="count">({tracks.length})</span></h2>
+			{#if tracks.length === 0}
+				<div class="state-message">No tracks found for this album.</div>
+			{:else}
+				<table class="tracks-table">
+					<thead>
+						<tr>
+							<th class="col-num">#</th>
+							<th class="col-title">Title</th>
+							<th class="col-duration">Duration</th>
+							<th class="col-file">File</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each tracks as track (track.id)}
+							<tr class:has-file={track.has_file}>
+								<td class="col-num">{track.track_number ?? '—'}</td>
+								<td class="col-title">{track.title}</td>
+								<td class="col-duration">{formatDuration(track.duration_ms)}</td>
+								<td class="col-file">
+									{#if track.has_file}
+										<span class="file-indicator has">✓</span>
+									{:else}
+										<span class="file-indicator missing">✗</span>
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			{/if}
+		</section>
+	{/if}
+</div>
+
+<style>
+	.detail-page {
+		max-width: 900px;
+		margin: 0 auto;
+	}
+
+	.breadcrumb {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		margin-bottom: 1.25rem;
+	}
+
+	.sep {
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+	}
+
+	.back-btn {
+		background: none;
+		border: none;
+		color: var(--accent);
+		cursor: pointer;
+		font-size: 0.9rem;
+		padding: 0;
+	}
+
+	.back-btn:hover {
+		text-decoration: underline;
+	}
+
+	.detail-header {
+		margin-bottom: 2rem;
+	}
+
+	.detail-header h1 {
+		font-size: 2.4rem;
+		font-weight: 800;
+		margin: 0 0 0.5rem;
+	}
+
+	.detail-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.meta-item.year {
+		font-size: 1rem;
+		color: var(--text-secondary);
+		font-weight: 600;
+	}
+
+	.tracks-section h2 {
+		font-size: 1.3rem;
+		font-weight: 700;
+		margin-bottom: 1rem;
+	}
+
+	.count {
+		font-weight: 400;
+		color: var(--text-secondary);
+		font-size: 1rem;
+	}
+
+	.state-message {
+		padding: 2rem 0;
+		text-align: center;
+		color: var(--text-secondary);
+	}
+
+	.state-message.error {
+		color: var(--error);
+	}
+
+	.tracks-table {
+		width: 100%;
+		border-collapse: collapse;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		overflow: hidden;
+	}
+
+	.tracks-table thead tr {
+		background: var(--bg-primary);
+	}
+
+	.tracks-table th {
+		text-align: left;
+		padding: 0.65rem 1rem;
+		font-size: 0.8rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-secondary);
+		border-bottom: 1px solid var(--border-color);
+	}
+
+	.tracks-table td {
+		padding: 0.7rem 1rem;
+		font-size: 0.95rem;
+		border-bottom: 1px solid var(--border-color);
+		background: var(--bg-secondary);
+	}
+
+	.tracks-table tbody tr:last-child td {
+		border-bottom: none;
+	}
+
+	.tracks-table tbody tr:hover td {
+		background: color-mix(in srgb, var(--accent) 5%, var(--bg-secondary));
+	}
+
+	.col-num {
+		width: 3rem;
+		color: var(--text-secondary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.col-duration {
+		width: 5rem;
+		color: var(--text-secondary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.col-file {
+		width: 4rem;
+		text-align: center;
+	}
+
+	.file-indicator {
+		font-size: 0.9rem;
+		font-weight: 700;
+	}
+
+	.file-indicator.has {
+		color: var(--success);
+	}
+
+	.file-indicator.missing {
+		color: var(--text-secondary);
+	}
+
+	.badge {
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		padding: 0.2rem 0.5rem;
+		border-radius: 4px;
+		background: var(--bg-primary);
+		color: var(--text-secondary);
+	}
+
+	.badge.monitored {
+		background: rgba(var(--success-rgb), 0.15);
+		color: var(--success);
+	}
+</style>

--- a/web/src/routes/(app)/albums/[id]/+page.svelte
+++ b/web/src/routes/(app)/albums/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { getAlbum, getAlbumTracks, getArtist } from '$lib/api';
@@ -8,6 +7,7 @@
 	let album = $state<Album | null>(null);
 	let artist = $state<Artist | null>(null);
 	let tracks: Track[] = $state([]);
+	let trackTotal = $state(0);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 
@@ -19,17 +19,17 @@
 		return `${min}:${String(sec).padStart(2, '0')}`;
 	}
 
-	async function load() {
+	async function load(id: string | undefined) {
 		loading = true;
 		error = null;
-		const id = $page.params.id;
 		if (!id) { error = 'Invalid album ID'; loading = false; return; }
 		try {
-			const [a, tracksRes] = await Promise.all([getAlbum(id), getAlbumTracks(id)]);
+			const [a, tracksRes] = await Promise.all([getAlbum(id), getAlbumTracks(id, { limit: 200 })]);
 			album = a;
 			tracks = tracksRes.items.sort(
 				(a, b) => (a.track_number ?? 9999) - (b.track_number ?? 9999)
 			);
+			trackTotal = tracksRes.total;
 			// Fetch the artist name for the back-link breadcrumb
 			if (a.artist_id) {
 				try {
@@ -45,7 +45,9 @@
 		}
 	}
 
-	onMount(() => load());
+	$effect(() => {
+		void load($page.params.id);
+	});
 </script>
 
 <div class="detail-page">
@@ -81,7 +83,10 @@
 		</header>
 
 		<section class="tracks-section">
-			<h2>Tracks <span class="count">({tracks.length})</span></h2>
+			<h2>Tracks <span class="count">({trackTotal})</span></h2>
+			{#if trackTotal > tracks.length}
+				<p class="truncation-note">Showing {tracks.length} of {trackTotal}</p>
+			{/if}
 			{#if tracks.length === 0}
 				<div class="state-message">No tracks found for this album.</div>
 			{:else}
@@ -102,9 +107,9 @@
 								<td class="col-duration">{formatDuration(track.duration_ms)}</td>
 								<td class="col-file">
 									{#if track.has_file}
-										<span class="file-indicator has">✓</span>
+										<span class="file-indicator has" aria-label="Has file" title="Has file">✓</span>
 									{:else}
-										<span class="file-indicator missing">✗</span>
+										<span class="file-indicator missing" aria-label="Missing file" title="Missing file">✗</span>
 									{/if}
 								</td>
 							</tr>
@@ -173,7 +178,13 @@
 	.tracks-section h2 {
 		font-size: 1.3rem;
 		font-weight: 700;
-		margin-bottom: 1rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.truncation-note {
+		font-size: 0.82rem;
+		color: var(--text-secondary);
+		margin: 0 0 1rem;
 	}
 
 	.count {

--- a/web/src/routes/(app)/artists/+page.svelte
+++ b/web/src/routes/(app)/artists/+page.svelte
@@ -12,7 +12,6 @@
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let search = $state('');
-	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 
 	let filtered: Artist[] = $derived(
 		search.trim()
@@ -33,13 +32,6 @@
 		} finally {
 			loading = false;
 		}
-	}
-
-	function onSearchInput() {
-		if (searchDebounce) clearTimeout(searchDebounce);
-		searchDebounce = setTimeout(() => {
-			offset = 0;
-		}, 300);
 	}
 
 	function prevPage() {
@@ -64,7 +56,6 @@
 			type="search"
 			placeholder="Filter artists…"
 			bind:value={search}
-			oninput={onSearchInput}
 			aria-label="Filter artists"
 		/>
 	</div>

--- a/web/src/routes/(app)/artists/+page.svelte
+++ b/web/src/routes/(app)/artists/+page.svelte
@@ -1,2 +1,254 @@
-<h2>Artists Browser</h2>
-<p>Artists listing and search will be implemented in Issue #433.</p>
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { getArtists } from '$lib/api';
+	import type { Artist } from '$lib/types';
+
+	const PAGE_SIZE = 50;
+
+	let items: Artist[] = $state([]);
+	let total = $state(0);
+	let offset = $state(0);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let search = $state('');
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	let filtered: Artist[] = $derived(
+		search.trim()
+			? items.filter((a) => a.name.toLowerCase().includes(search.trim().toLowerCase()))
+			: items
+	);
+
+	async function load(newOffset = 0) {
+		loading = true;
+		error = null;
+		try {
+			const res = await getArtists({ limit: PAGE_SIZE, offset: newOffset });
+			items = res.items;
+			total = res.total;
+			offset = newOffset;
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load artists';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function onSearchInput() {
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(() => {
+			offset = 0;
+		}, 300);
+	}
+
+	function prevPage() {
+		if (offset > 0) load(Math.max(0, offset - PAGE_SIZE));
+	}
+
+	function nextPage() {
+		if (offset + PAGE_SIZE < total) load(offset + PAGE_SIZE);
+	}
+
+	onMount(() => load());
+</script>
+
+<div class="catalog-page">
+	<header class="catalog-header">
+		<h1>Artists</h1>
+		<span class="total-badge">{total} total</span>
+	</header>
+
+	<div class="search-bar">
+		<input
+			type="search"
+			placeholder="Filter artists…"
+			bind:value={search}
+			oninput={onSearchInput}
+			aria-label="Filter artists"
+		/>
+	</div>
+
+	{#if loading}
+		<div class="state-message">Loading artists…</div>
+	{:else if error}
+		<div class="state-message error">{error}</div>
+	{:else if filtered.length === 0}
+		<div class="state-message">No artists found.</div>
+	{:else}
+		<ul class="catalog-list" role="list">
+			{#each filtered as artist (artist.id)}
+				<li class="catalog-item">
+					<button
+						class="catalog-row"
+						onclick={() => goto(`/artists/${artist.id}`)}
+						aria-label="View {artist.name}"
+					>
+						<span class="item-name">{artist.name}</span>
+						<span class="item-meta">
+							{#if artist.monitored}
+								<span class="badge monitored">Monitored</span>
+							{/if}
+							<span class="badge status">{artist.status}</span>
+						</span>
+					</button>
+				</li>
+			{/each}
+		</ul>
+
+		{#if !search.trim()}
+			<div class="pagination">
+				<button onclick={prevPage} disabled={offset === 0}>← Previous</button>
+				<span>{offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}</span>
+				<button onclick={nextPage} disabled={offset + PAGE_SIZE >= total}>Next →</button>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.catalog-page {
+		max-width: 900px;
+		margin: 0 auto;
+	}
+
+	.catalog-header {
+		display: flex;
+		align-items: baseline;
+		gap: 0.75rem;
+		margin-bottom: 1.25rem;
+	}
+
+	.catalog-header h1 {
+		font-size: 2rem;
+		font-weight: 800;
+		margin: 0;
+	}
+
+	.total-badge {
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+	}
+
+	.search-bar {
+		margin-bottom: 1.25rem;
+	}
+
+	.search-bar input {
+		width: 100%;
+		max-width: 420px;
+		padding: 0.55rem 0.85rem;
+		border: 1px solid var(--border-color);
+		border-radius: 6px;
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		font-size: 0.95rem;
+	}
+
+	.search-bar input:focus {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
+	.state-message {
+		padding: 2rem 0;
+		text-align: center;
+		color: var(--text-secondary);
+	}
+
+	.state-message.error {
+		color: var(--error);
+	}
+
+	.catalog-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		overflow: hidden;
+	}
+
+	.catalog-item + .catalog-item {
+		border-top: 1px solid var(--border-color);
+	}
+
+	.catalog-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 0.85rem 1.1rem;
+		background: var(--bg-secondary);
+		border: none;
+		cursor: pointer;
+		text-align: left;
+		color: var(--text-primary);
+		transition: background 0.12s;
+	}
+
+	.catalog-row:hover {
+		background: color-mix(in srgb, var(--accent) 8%, var(--bg-secondary));
+	}
+
+	.item-name {
+		font-weight: 600;
+		font-size: 1rem;
+	}
+
+	.item-meta {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.badge {
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		padding: 0.2rem 0.5rem;
+		border-radius: 4px;
+		background: var(--bg-primary);
+		color: var(--text-secondary);
+	}
+
+	.badge.monitored {
+		background: rgba(var(--success-rgb), 0.15);
+		color: var(--success);
+	}
+
+	.pagination {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		justify-content: center;
+		margin-top: 1.5rem;
+	}
+
+	.pagination button {
+		padding: 0.45rem 0.9rem;
+		border: 1px solid var(--border-color);
+		border-radius: 6px;
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: 0.9rem;
+		transition: background 0.12s;
+	}
+
+	.pagination button:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--accent) 10%, var(--bg-secondary));
+	}
+
+	.pagination button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.pagination span {
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+	}
+</style>
+

--- a/web/src/routes/(app)/artists/[id]/+page.svelte
+++ b/web/src/routes/(app)/artists/[id]/+page.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { getArtist, getArtistAlbums } from '$lib/api';
+	import type { Artist, Album } from '$lib/types';
+
+	let artist = $state<Artist | null>(null);
+	let albums: Album[] = $state([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	async function load() {
+		loading = true;
+		error = null;
+		const id = $page.params.id;
+		if (!id) { error = 'Invalid artist ID'; loading = false; return; }
+		try {
+			const [a, albumsRes] = await Promise.all([getArtist(id), getArtistAlbums(id)]);
+			artist = a;
+			albums = albumsRes.items;
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load artist';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(() => load());
+</script>
+
+<div class="detail-page">
+	{#if loading}
+		<div class="state-message">Loading…</div>
+	{:else if error}
+		<div class="state-message error">{error}</div>
+	{:else if artist}
+		<div class="back-nav">
+			<button onclick={() => goto('/artists')} class="back-btn">← Artists</button>
+		</div>
+
+		<header class="detail-header">
+			<h1>{artist.name}</h1>
+			<div class="detail-meta">
+				{#if artist.monitored}
+					<span class="badge monitored">Monitored</span>
+				{/if}
+				<span class="badge status">{artist.status}</span>
+				{#if artist.path}
+					<span class="path" title={artist.path}>{artist.path}</span>
+				{/if}
+			</div>
+		</header>
+
+		<section class="albums-section">
+			<h2>Albums <span class="count">({albums.length})</span></h2>
+			{#if albums.length === 0}
+				<div class="state-message">No albums found for this artist.</div>
+			{:else}
+				<ul class="catalog-list" role="list">
+					{#each albums as album (album.id)}
+						<li class="catalog-item">
+							<button
+								class="catalog-row"
+								onclick={() => goto(`/albums/${album.id}`)}
+								aria-label="View album {album.title}"
+							>
+								<div class="album-info">
+									<span class="item-name">{album.title}</span>
+									{#if album.release_date}
+										<span class="item-year">{album.release_date.slice(0, 4)}</span>
+									{/if}
+								</div>
+								<span class="item-meta">
+									{#if album.album_type}
+										<span class="badge">{album.album_type}</span>
+									{/if}
+									{#if album.monitored}
+										<span class="badge monitored">Monitored</span>
+									{/if}
+									<span class="badge status">{album.status}</span>
+								</span>
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+	{/if}
+</div>
+
+<style>
+	.detail-page {
+		max-width: 900px;
+		margin: 0 auto;
+	}
+
+	.back-btn {
+		background: none;
+		border: none;
+		color: var(--accent);
+		cursor: pointer;
+		font-size: 0.9rem;
+		padding: 0;
+		margin-bottom: 1.25rem;
+		display: inline-block;
+	}
+
+	.back-btn:hover {
+		text-decoration: underline;
+	}
+
+	.detail-header {
+		margin-bottom: 2rem;
+	}
+
+	.detail-header h1 {
+		font-size: 2.4rem;
+		font-weight: 800;
+		margin: 0 0 0.5rem;
+	}
+
+	.detail-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.path {
+		font-size: 0.8rem;
+		color: var(--text-secondary);
+		font-family: monospace;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 300px;
+	}
+
+	.albums-section h2 {
+		font-size: 1.3rem;
+		font-weight: 700;
+		margin-bottom: 1rem;
+	}
+
+	.count {
+		font-weight: 400;
+		color: var(--text-secondary);
+		font-size: 1rem;
+	}
+
+	.state-message {
+		padding: 2rem 0;
+		text-align: center;
+		color: var(--text-secondary);
+	}
+
+	.state-message.error {
+		color: var(--error);
+	}
+
+	.catalog-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		overflow: hidden;
+	}
+
+	.catalog-item + .catalog-item {
+		border-top: 1px solid var(--border-color);
+	}
+
+	.catalog-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 0.85rem 1.1rem;
+		background: var(--bg-secondary);
+		border: none;
+		cursor: pointer;
+		text-align: left;
+		color: var(--text-primary);
+		transition: background 0.12s;
+	}
+
+	.catalog-row:hover {
+		background: color-mix(in srgb, var(--accent) 8%, var(--bg-secondary));
+	}
+
+	.album-info {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+	}
+
+	.item-name {
+		font-weight: 600;
+		font-size: 1rem;
+	}
+
+	.item-year {
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+	}
+
+	.item-meta {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.badge {
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		padding: 0.2rem 0.5rem;
+		border-radius: 4px;
+		background: var(--bg-primary);
+		color: var(--text-secondary);
+	}
+
+	.badge.monitored {
+		background: rgba(var(--success-rgb), 0.15);
+		color: var(--success);
+	}
+</style>

--- a/web/src/routes/(app)/artists/[id]/+page.svelte
+++ b/web/src/routes/(app)/artists/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { getArtist, getArtistAlbums } from '$lib/api';
@@ -7,18 +6,19 @@
 
 	let artist = $state<Artist | null>(null);
 	let albums: Album[] = $state([]);
+	let albumTotal = $state(0);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 
-	async function load() {
+	async function load(id: string | undefined) {
 		loading = true;
 		error = null;
-		const id = $page.params.id;
 		if (!id) { error = 'Invalid artist ID'; loading = false; return; }
 		try {
-			const [a, albumsRes] = await Promise.all([getArtist(id), getArtistAlbums(id)]);
+			const [a, albumsRes] = await Promise.all([getArtist(id), getArtistAlbums(id, { limit: 200 })]);
 			artist = a;
 			albums = albumsRes.items;
+			albumTotal = albumsRes.total;
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Failed to load artist';
 		} finally {
@@ -26,7 +26,9 @@
 		}
 	}
 
-	onMount(() => load());
+	$effect(() => {
+		void load($page.params.id);
+	});
 </script>
 
 <div class="detail-page">
@@ -53,7 +55,10 @@
 		</header>
 
 		<section class="albums-section">
-			<h2>Albums <span class="count">({albums.length})</span></h2>
+			<h2>Albums <span class="count">({albumTotal})</span></h2>
+			{#if albumTotal > albums.length}
+				<p class="truncation-note">Showing {albums.length} of {albumTotal}</p>
+			{/if}
 			{#if albums.length === 0}
 				<div class="state-message">No albums found for this artist.</div>
 			{:else}
@@ -140,7 +145,13 @@
 	.albums-section h2 {
 		font-size: 1.3rem;
 		font-weight: 700;
-		margin-bottom: 1rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.truncation-note {
+		font-size: 0.82rem;
+		color: var(--text-secondary);
+		margin: 0 0 1rem;
 	}
 
 	.count {


### PR DESCRIPTION
## Phase 11.2: Artists and Albums Browser UI

Implements real artists and albums browser views with search, pagination, and detail pages.

### Changes

**web/src/lib/types.ts**
- Added Artist, Album, Track interfaces matching the backend API response shapes
- Added generic PaginatedResponse<T> type replacing the untyped GenericListResponse for catalog endpoints

**web/src/lib/api.ts**
- Added getArtists(), getArtist(), getArtistAlbums() — wired to /api/v1/artists and /api/v1/artists/:id/albums
- Added getAlbums(), getAlbum(), getAlbumTracks() — wired to /api/v1/albums and /api/v1/albums/:id/tracks

**web/src/routes/(app)/artists/+page.svelte**
- Replaces placeholder with paginated artists list
- Client-side search/filter input (debounced) across current page
- Each row links to artist detail; shows Monitored badge and status

**web/src/routes/(app)/artists/[id]/+page.svelte** *(new)*
- Artist detail view: name, status, monitored badge, filesystem path
- Album list for the artist, each row links to album detail
- Back navigation to /artists

**web/src/routes/(app)/albums/+page.svelte**
- Replaces placeholder with paginated albums list
- Client-side search/filter; shows year, album type, status
- Each row links to album detail

**web/src/routes/(app)/albums/[id]/+page.svelte** *(new)*
- Album detail view: title, year, type, status, monitored badge
- Track table with number, title, duration, file presence indicator
- Breadcrumb back to /albums and artist detail (artist name fetched inline)

### Validation
- `bun run check`: 0 errors, 0 warnings
- `bun run build`: clean build to `web/build/`

Closes #433
Builds on #436