### PR TITLE
feat: realtime dashboard UX and activity panels (Phase 11.3, Issue #434)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,13 +1,15 @@
 import type {
 	AppearanceErrorResponse,
 	AppearanceSettings,
+	ActivityListResponse,
 	Artist,
 	Album,
 	Track,
 	FormsLoginResponse,
 	FormsLogoutResponse,
 	GenericListResponse,
-	PaginatedResponse
+	PaginatedResponse,
+	SystemTasksResponse
 } from './types';
 
 const API_BASE = (import.meta.env.VITE_CHORROSION_API_BASE ?? 'http://127.0.0.1:5150').replace(
@@ -111,16 +113,16 @@ export async function updateAppearanceSettings(
 	});
 }
 
-export async function getQueueSnapshot(): Promise<GenericListResponse> {
-	return request<GenericListResponse>('/api/v1/activity/queue');
+export async function getQueueSnapshot(): Promise<ActivityListResponse> {
+	return request<ActivityListResponse>('/api/v1/activity/queue');
 }
 
-export async function getProcessingSnapshot(): Promise<GenericListResponse> {
-	return request<GenericListResponse>('/api/v1/activity/processing');
+export async function getProcessingSnapshot(): Promise<ActivityListResponse> {
+	return request<ActivityListResponse>('/api/v1/activity/processing');
 }
 
-export async function getTasksSnapshot(): Promise<GenericListResponse> {
-	return request<GenericListResponse>('/api/v1/system/tasks');
+export async function getTasksSnapshot(): Promise<SystemTasksResponse> {
+	return request<SystemTasksResponse>('/api/v1/system/tasks');
 }
 
 export async function getArtists(params?: {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,7 +7,6 @@ import type {
 	Track,
 	FormsLoginResponse,
 	FormsLogoutResponse,
-	GenericListResponse,
 	PaginatedResponse,
 	SystemTasksResponse
 } from './types';

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -31,7 +31,7 @@ export interface AppearanceErrorResponse {
 	error: string;
 }
 
-export interface SseMessage<T> {
+export interface SseMessage<T = unknown> {
 	sequence?: number;
 	tick?: number;
 	status?: string;
@@ -45,6 +45,32 @@ export interface GenericListResponse {
 	total: number;
 	limit?: number;
 	offset?: number;
+}
+
+export interface ActivityItem {
+	id: string;
+	name: string;
+	state: string;
+	progress_percent: number;
+}
+
+export interface ActivityListResponse {
+	items: ActivityItem[];
+	total: number;
+}
+
+export interface SystemTask {
+	id: string;
+	name: string;
+	schedule_seconds: number;
+	enabled: boolean;
+	status: string;
+}
+
+export interface SystemTasksResponse {
+	items: SystemTask[];
+	total: number;
+	max_concurrent_jobs: number;
 }
 
 export interface PaginatedResponse<T> {

--- a/web/src/routes/(app)/dashboard/+page.svelte
+++ b/web/src/routes/(app)/dashboard/+page.svelte
@@ -42,6 +42,7 @@
 	type StreamKey = 'events' | 'queue' | 'processing' | 'tasks';
 
 	const ALL_STREAM_KEYS: StreamKey[] = ['events', 'queue', 'processing', 'tasks'];
+	const PULSE_EVENT_NAMES = ['download_progress', 'import_progress', 'job_status'] as const;
 
 	let streamStates = $state<Record<StreamKey, StreamConnectionState>>({
 		events: 'disconnected',
@@ -111,7 +112,7 @@
 				reconnectAttempts[key] = 0;
 				streamStates[key] = 'connected';
 			});
-			for (const evtName of ['download_progress', 'import_progress', 'job_status']) {
+			for (const evtName of PULSE_EVENT_NAMES) {
 				es.addEventListener(evtName, (event) => {
 					const payload = safeParse((event as MessageEvent).data) as {
 						status?: string;

--- a/web/src/routes/(app)/dashboard/+page.svelte
+++ b/web/src/routes/(app)/dashboard/+page.svelte
@@ -37,11 +37,26 @@
 
 	let pulse = $state('idle');
 	let pulseTick = $state(0);
-	let streamState = $state<'connecting' | 'connected' | 'reconnecting' | 'disconnected'>(
-		'disconnected'
-	);
 
+	type StreamConnectionState = 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
 	type StreamKey = 'events' | 'queue' | 'processing' | 'tasks';
+
+	const ALL_STREAM_KEYS: StreamKey[] = ['events', 'queue', 'processing', 'tasks'];
+
+	let streamStates = $state<Record<StreamKey, StreamConnectionState>>({
+		events: 'disconnected',
+		queue: 'disconnected',
+		processing: 'disconnected',
+		tasks: 'disconnected'
+	});
+
+	let streamState = $derived.by(() => {
+		const states = ALL_STREAM_KEYS.map((k) => streamStates[k]);
+		if (states.every((s) => s === 'connected')) return 'connected' as const;
+		if (states.every((s) => s === 'disconnected')) return 'disconnected' as const;
+		return 'reconnecting' as const;
+	});
+
 	let eventStreams = $state<Partial<Record<StreamKey, EventSource>>>({});
 	let reconnectTimers = $state<Partial<Record<StreamKey, ReturnType<typeof setTimeout>>>>({});
 	let reconnectAttempts = $state<Partial<Record<StreamKey, number>>>({});
@@ -76,7 +91,7 @@
 		clearTimeout(reconnectTimers[key]);
 		const delay = backoffMs(key);
 		reconnectAttempts[key] = (reconnectAttempts[key] ?? 0) + 1;
-		streamState = 'reconnecting';
+		streamStates[key] = 'reconnecting';
 		reconnectTimers[key] = setTimeout(() => attachStream(key), delay);
 	}
 
@@ -86,6 +101,7 @@
 
 	function attachStream(key: StreamKey): void {
 		eventStreams[key]?.close();
+		streamStates[key] = 'connecting';
 
 		let es: EventSource;
 
@@ -93,17 +109,23 @@
 			es = openStream('/api/v1/events');
 			es.addEventListener('connected', () => {
 				reconnectAttempts[key] = 0;
-				streamState = 'connected';
+				streamStates[key] = 'connected';
 			});
-			es.onmessage = (event) => {
-				const payload = safeParse(event.data) as { status?: string; tick?: number } | null;
-				if (payload?.status) pulse = payload.status;
-				if (payload?.tick !== undefined) pulseTick = payload.tick;
-			};
+			for (const evtName of ['download_progress', 'import_progress', 'job_status']) {
+				es.addEventListener(evtName, (event) => {
+					const payload = safeParse((event as MessageEvent).data) as {
+						status?: string;
+						tick?: number;
+					} | null;
+					if (payload?.status) pulse = payload.status;
+					if (payload?.tick !== undefined) pulseTick = payload.tick;
+				});
+			}
 		} else if (key === 'queue') {
 			es = openStream('/api/v1/events/download-progress');
 			es.addEventListener('connected', () => {
 				reconnectAttempts[key] = 0;
+				streamStates[key] = 'connected';
 			});
 			es.addEventListener('download_queue_snapshot', (event) => {
 				const payload = safeParse((event as MessageEvent).data) as {
@@ -119,6 +141,7 @@
 			es = openStream('/api/v1/events/import-progress');
 			es.addEventListener('connected', () => {
 				reconnectAttempts[key] = 0;
+				streamStates[key] = 'connected';
 			});
 			es.addEventListener('import_progress_snapshot', (event) => {
 				const payload = safeParse((event as MessageEvent).data) as {
@@ -134,6 +157,7 @@
 			es = openStream('/api/v1/events/job-status');
 			es.addEventListener('connected', () => {
 				reconnectAttempts[key] = 0;
+				streamStates[key] = 'connected';
 			});
 			es.addEventListener('job_status_snapshot', (event) => {
 				const payload = safeParse((event as MessageEvent).data) as {
@@ -158,21 +182,25 @@
 	}
 
 	function attachSse(): void {
-		streamState = 'connecting';
-		for (const key of ['events', 'queue', 'processing', 'tasks'] as StreamKey[]) {
+		for (const key of ALL_STREAM_KEYS) {
 			attachStream(key);
 		}
 	}
 
 	function detachSse(): void {
-		for (const key of ['events', 'queue', 'processing', 'tasks'] as StreamKey[]) {
+		for (const key of ALL_STREAM_KEYS) {
 			clearTimeout(reconnectTimers[key]);
 			eventStreams[key]?.close();
 		}
 		eventStreams = {};
 		reconnectTimers = {};
 		reconnectAttempts = {};
-		streamState = 'disconnected';
+		streamStates = {
+			events: 'disconnected',
+			queue: 'disconnected',
+			processing: 'disconnected',
+			tasks: 'disconnected'
+		};
 	}
 
 	async function hydrateData(): Promise<void> {

--- a/web/src/routes/(app)/dashboard/+page.svelte
+++ b/web/src/routes/(app)/dashboard/+page.svelte
@@ -8,7 +8,13 @@
 		sseUrl,
 		updateAppearanceSettings
 	} from '$lib/api';
-	import type { AppearanceSettings, GenericListResponse } from '$lib/types';
+	import type {
+		ActivityItem,
+		ActivityListResponse,
+		AppearanceSettings,
+		SystemTask,
+		SystemTasksResponse
+	} from '$lib/types';
 
 	const DEFAULT_ERROR = 'Request failed. Please verify API server settings and try again.';
 
@@ -17,15 +23,35 @@
 	let settingsSaved = $state('');
 	let saving = $state(false);
 
-	let queue = $state<GenericListResponse | null>(null);
-	let processing = $state<GenericListResponse | null>(null);
-	let tasks = $state<GenericListResponse | null>(null);
+	let queueItems = $state<ActivityItem[]>([]);
+	let queueTotal = $state(0);
+	let processingItems = $state<ActivityItem[]>([]);
+	let processingTotal = $state(0);
+	let taskItems = $state<SystemTask[]>([]);
+	let taskTotal = $state(0);
+	let maxConcurrentJobs = $state(0);
+
+	let queueUpdated = $state<Date | null>(null);
+	let processingUpdated = $state<Date | null>(null);
+	let tasksUpdated = $state<Date | null>(null);
 
 	let pulse = $state('idle');
 	let pulseTick = $state(0);
-	let streamState = $state('disconnected');
+	let streamState = $state<'connecting' | 'connected' | 'reconnecting' | 'disconnected'>(
+		'disconnected'
+	);
 
-	let eventStreams: EventSource[] = [];
+	type StreamKey = 'events' | 'queue' | 'processing' | 'tasks';
+	let eventStreams = $state<Partial<Record<StreamKey, EventSource>>>({});
+	let reconnectTimers = $state<Partial<Record<StreamKey, ReturnType<typeof setTimeout>>>>({});
+	let reconnectAttempts = $state<Partial<Record<StreamKey, number>>>({});
+
+	const RECONNECT_BASE_MS = 1000;
+	const RECONNECT_MAX_MS = 30_000;
+	const STALE_THRESHOLD_MS = 60_000;
+
+	let now = $state(Date.now());
+	let clockInterval: ReturnType<typeof setInterval> | null = null;
 
 	const safeParse = (input: string): unknown => {
 		try {
@@ -36,13 +62,117 @@
 	};
 
 	function apiErrorMessage(error: unknown): string {
-		if (error instanceof ApiError) {
-			return error.message;
-		}
-		if (error instanceof Error) {
-			return error.message;
-		}
+		if (error instanceof ApiError) return error.message;
+		if (error instanceof Error) return error.message;
 		return DEFAULT_ERROR;
+	}
+
+	function backoffMs(key: StreamKey): number {
+		const attempts = reconnectAttempts[key] ?? 0;
+		return Math.min(RECONNECT_BASE_MS * 2 ** attempts, RECONNECT_MAX_MS);
+	}
+
+	function scheduleReconnect(key: StreamKey): void {
+		clearTimeout(reconnectTimers[key]);
+		const delay = backoffMs(key);
+		reconnectAttempts[key] = (reconnectAttempts[key] ?? 0) + 1;
+		streamState = 'reconnecting';
+		reconnectTimers[key] = setTimeout(() => attachStream(key), delay);
+	}
+
+	function openStream(path: string): EventSource {
+		return new EventSource(sseUrl(path), { withCredentials: true });
+	}
+
+	function attachStream(key: StreamKey): void {
+		eventStreams[key]?.close();
+
+		let es: EventSource;
+
+		if (key === 'events') {
+			es = openStream('/api/v1/events');
+			es.addEventListener('connected', () => {
+				reconnectAttempts[key] = 0;
+				streamState = 'connected';
+			});
+			es.onmessage = (event) => {
+				const payload = safeParse(event.data) as { status?: string; tick?: number } | null;
+				if (payload?.status) pulse = payload.status;
+				if (payload?.tick !== undefined) pulseTick = payload.tick;
+			};
+		} else if (key === 'queue') {
+			es = openStream('/api/v1/events/download-progress');
+			es.addEventListener('connected', () => {
+				reconnectAttempts[key] = 0;
+			});
+			es.addEventListener('download_queue_snapshot', (event) => {
+				const payload = safeParse((event as MessageEvent).data) as {
+					queue?: ActivityListResponse;
+				} | null;
+				if (payload?.queue) {
+					queueItems = payload.queue.items;
+					queueTotal = payload.queue.total;
+					queueUpdated = new Date();
+				}
+			});
+		} else if (key === 'processing') {
+			es = openStream('/api/v1/events/import-progress');
+			es.addEventListener('connected', () => {
+				reconnectAttempts[key] = 0;
+			});
+			es.addEventListener('import_progress_snapshot', (event) => {
+				const payload = safeParse((event as MessageEvent).data) as {
+					processing?: ActivityListResponse;
+				} | null;
+				if (payload?.processing) {
+					processingItems = payload.processing.items;
+					processingTotal = payload.processing.total;
+					processingUpdated = new Date();
+				}
+			});
+		} else {
+			es = openStream('/api/v1/events/job-status');
+			es.addEventListener('connected', () => {
+				reconnectAttempts[key] = 0;
+			});
+			es.addEventListener('job_status_snapshot', (event) => {
+				const payload = safeParse((event as MessageEvent).data) as {
+					tasks?: SystemTasksResponse;
+				} | null;
+				if (payload?.tasks) {
+					taskItems = payload.tasks.items;
+					taskTotal = payload.tasks.total;
+					maxConcurrentJobs = payload.tasks.max_concurrent_jobs;
+					tasksUpdated = new Date();
+				}
+			});
+		}
+
+		es.onerror = () => {
+			es.close();
+			delete eventStreams[key];
+			scheduleReconnect(key);
+		};
+
+		eventStreams[key] = es;
+	}
+
+	function attachSse(): void {
+		streamState = 'connecting';
+		for (const key of ['events', 'queue', 'processing', 'tasks'] as StreamKey[]) {
+			attachStream(key);
+		}
+	}
+
+	function detachSse(): void {
+		for (const key of ['events', 'queue', 'processing', 'tasks'] as StreamKey[]) {
+			clearTimeout(reconnectTimers[key]);
+			eventStreams[key]?.close();
+		}
+		eventStreams = {};
+		reconnectTimers = {};
+		reconnectAttempts = {};
+		streamState = 'disconnected';
 	}
 
 	async function hydrateData(): Promise<void> {
@@ -56,65 +186,19 @@
 				getTasksSnapshot()
 			]);
 			settings = appearance;
-			queue = queueSnapshot;
-			processing = processingSnapshot;
-			tasks = tasksSnapshot;
+			queueItems = queueSnapshot.items;
+			queueTotal = queueSnapshot.total;
+			queueUpdated = new Date();
+			processingItems = processingSnapshot.items;
+			processingTotal = processingSnapshot.total;
+			processingUpdated = new Date();
+			taskItems = tasksSnapshot.items;
+			taskTotal = tasksSnapshot.total;
+			maxConcurrentJobs = tasksSnapshot.max_concurrent_jobs;
+			tasksUpdated = new Date();
 		} catch (error) {
 			settingsError = apiErrorMessage(error);
 		}
-	}
-
-	function attachSse(): void {
-		detachSse();
-		streamState = 'connecting';
-
-		const pulseStream = new EventSource(sseUrl('/api/v1/events'), { withCredentials: true });
-		pulseStream.onmessage = (event) => {
-			const payload = safeParse(event.data) as { status?: string; tick?: number } | null;
-			pulse = payload?.status ?? 'active';
-			pulseTick = payload?.tick ?? pulseTick;
-			streamState = 'connected';
-		};
-
-		const queueStream = new EventSource(sseUrl('/api/v1/events/download-progress'), {
-			withCredentials: true
-		});
-		queueStream.onmessage = (event) => {
-			const payload = safeParse(event.data) as { queue?: GenericListResponse } | null;
-			if (payload?.queue) queue = payload.queue;
-		};
-
-		const processingStream = new EventSource(sseUrl('/api/v1/events/import-progress'), {
-			withCredentials: true
-		});
-		processingStream.onmessage = (event) => {
-			const payload = safeParse(event.data) as { processing?: GenericListResponse } | null;
-			if (payload?.processing) processing = payload.processing;
-		};
-
-		const taskStream = new EventSource(sseUrl('/api/v1/events/job-status'), {
-			withCredentials: true
-		});
-		taskStream.onmessage = (event) => {
-			const payload = safeParse(event.data) as { tasks?: GenericListResponse } | null;
-			if (payload?.tasks) tasks = payload.tasks;
-		};
-
-		for (const stream of [pulseStream, queueStream, processingStream, taskStream]) {
-			stream.onerror = () => {
-				streamState = 'reconnecting';
-			};
-		}
-
-		eventStreams = [pulseStream, queueStream, processingStream, taskStream];
-	}
-
-	function detachSse(): void {
-		for (const stream of eventStreams) {
-			stream.close();
-		}
-		eventStreams = [];
-		streamState = 'disconnected';
 	}
 
 	async function saveSettings(): Promise<void> {
@@ -135,36 +219,177 @@
 	$effect(() => {
 		hydrateData();
 		attachSse();
-		return () => detachSse();
+		clockInterval = setInterval(() => {
+			now = Date.now();
+		}, 5000);
+		return () => {
+			detachSse();
+			if (clockInterval) clearInterval(clockInterval);
+		};
 	});
+
+	function formatAge(date: Date | null): string {
+		if (!date) return 'never';
+		const secs = Math.floor((now - date.getTime()) / 1000);
+		if (secs < 5) return 'just now';
+		if (secs < 60) return `${secs}s ago`;
+		const mins = Math.floor(secs / 60);
+		if (mins < 60) return `${mins}m ago`;
+		return `${Math.floor(mins / 60)}h ago`;
+	}
+
+	function isStale(date: Date | null): boolean {
+		if (!date) return true;
+		return now - date.getTime() > STALE_THRESHOLD_MS;
+	}
+
+	function stateColor(state: string): string {
+		switch (state) {
+			case 'downloading':
+				return 'state-active';
+			case 'queued':
+				return 'state-queued';
+			case 'paused':
+				return 'state-paused';
+			case 'completed':
+				return 'state-done';
+			case 'error':
+				return 'state-error';
+			default:
+				return 'state-unknown';
+		}
+	}
+
+	function scheduleSummary(seconds: number): string {
+		if (seconds < 60) return `Every ${seconds}s`;
+		if (seconds < 3600) return `Every ${Math.round(seconds / 60)}m`;
+		return `Every ${Math.round(seconds / 3600)}h`;
+	}
 </script>
 
 <section class="dashboard-section">
 	<header class="section-header">
 		<h2>Dashboard</h2>
 		<div class="status-bar">
-			<span class="pill" class:connected={streamState === 'connected'} class:reconnecting={streamState === 'reconnecting'}>
+			<span
+				class="pill"
+				class:connected={streamState === 'connected'}
+				class:reconnecting={streamState === 'reconnecting'}
+				class:disconnected={streamState === 'disconnected'}
+			>
 				{streamState}
 			</span>
-			<span class="pulse">Pulse: {pulse} #{pulseTick}</span>
+			<span class="pulse-label">Pulse: {pulse} #{pulseTick}</span>
 		</div>
 	</header>
 
-	<section class="dashboard-grid">
-		<article class="panel stat-panel">
-			<h3>Download Queue</h3>
-			<p class="stat">{queue?.total ?? 0}</p>
-			<p class="meta">Live from /events/download-progress</p>
+	{#if streamState === 'disconnected'}
+		<div class="degraded-banner">
+			Realtime feed disconnected — data may be out of date.
+		</div>
+	{/if}
+
+	<section class="activity-grid">
+		<!-- Download Queue -->
+		<article class="panel activity-panel" class:stale={isStale(queueUpdated)}>
+			<div class="panel-header">
+				<h3>Download Queue</h3>
+				<span class="count-badge">{queueTotal}</span>
+			</div>
+			{#if queueUpdated}
+				<p class="updated-at" class:stale-text={isStale(queueUpdated)}>
+					Updated {formatAge(queueUpdated)}
+				</p>
+			{/if}
+			{#if queueItems.length === 0}
+				<p class="empty-state">No active downloads</p>
+			{:else}
+				<ul class="item-list">
+					{#each queueItems as item (item.id)}
+						<li class="activity-item">
+							<div class="item-top">
+								<span class="item-name" title={item.name}>{item.name}</span>
+								<span class="state-badge {stateColor(item.state)}">{item.state}</span>
+							</div>
+							{#if item.state === 'downloading'}
+								<div class="progress-bar" role="progressbar" aria-valuenow={item.progress_percent} aria-valuemin={0} aria-valuemax={100}>
+									<div class="progress-fill" style="width: {item.progress_percent}%"></div>
+								</div>
+								<span class="progress-pct">{item.progress_percent}%</span>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
 		</article>
-		<article class="panel stat-panel">
-			<h3>Import Processing</h3>
-			<p class="stat">{processing?.total ?? 0}</p>
-			<p class="meta">Live from /events/import-progress</p>
+
+		<!-- Import Processing -->
+		<article class="panel activity-panel" class:stale={isStale(processingUpdated)}>
+			<div class="panel-header">
+				<h3>Import Processing</h3>
+				<span class="count-badge">{processingTotal}</span>
+			</div>
+			{#if processingUpdated}
+				<p class="updated-at" class:stale-text={isStale(processingUpdated)}>
+					Updated {formatAge(processingUpdated)}
+				</p>
+			{/if}
+			{#if processingItems.length === 0}
+				<p class="empty-state">No active imports</p>
+			{:else}
+				<ul class="item-list">
+					{#each processingItems as item (item.id)}
+						<li class="activity-item">
+							<div class="item-top">
+								<span class="item-name" title={item.name}>{item.name}</span>
+								<span class="state-badge {stateColor(item.state)}">{item.state}</span>
+							</div>
+							{#if item.progress_percent > 0}
+								<div class="progress-bar" role="progressbar" aria-valuenow={item.progress_percent} aria-valuemin={0} aria-valuemax={100}>
+									<div class="progress-fill" style="width: {item.progress_percent}%"></div>
+								</div>
+								<span class="progress-pct">{item.progress_percent}%</span>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
 		</article>
-		<article class="panel stat-panel">
-			<h3>Scheduled Tasks</h3>
-			<p class="stat">{tasks?.total ?? 0}</p>
-			<p class="meta">Live from /events/job-status</p>
+
+		<!-- Scheduled Tasks -->
+		<article class="panel activity-panel" class:stale={isStale(tasksUpdated)}>
+			<div class="panel-header">
+				<h3>Scheduled Tasks</h3>
+				<span class="count-badge">{taskTotal}</span>
+				{#if maxConcurrentJobs > 0}
+					<span class="concurrency-label">max {maxConcurrentJobs} concurrent</span>
+				{/if}
+			</div>
+			{#if tasksUpdated}
+				<p class="updated-at" class:stale-text={isStale(tasksUpdated)}>
+					Updated {formatAge(tasksUpdated)}
+				</p>
+			{/if}
+			{#if taskItems.length === 0}
+				<p class="empty-state">No scheduled tasks</p>
+			{:else}
+				<ul class="task-list">
+					{#each taskItems as task (task.id)}
+						<li class="task-item">
+							<div class="task-info">
+								<span class="task-name">{task.name}</span>
+								<span class="task-schedule">{scheduleSummary(task.schedule_seconds)}</span>
+							</div>
+							<div class="task-meta">
+								<span class="state-badge {task.enabled ? 'state-active' : 'state-paused'}">
+									{task.enabled ? 'enabled' : 'disabled'}
+								</span>
+								<span class="state-badge {stateColor(task.status)}">{task.status}</span>
+							</div>
+						</li>
+					{/each}
+				</ul>
+			{/if}
 		</article>
 	</section>
 
@@ -242,7 +467,8 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		gap: 1rem;
+		flex-wrap: wrap;
+		gap: 0.75rem;
 	}
 
 	.section-header h2 {
@@ -251,9 +477,10 @@
 
 	.status-bar {
 		display: flex;
-		gap: 1rem;
+		gap: 0.75rem;
 		align-items: center;
 		font-size: 0.875rem;
+		flex-wrap: wrap;
 	}
 
 	.pill {
@@ -281,46 +508,245 @@
 		color: var(--warning);
 	}
 
-	.pulse {
-		color: var(--text-secondary);
+	.pill.disconnected {
+		background: rgba(var(--error-rgb), 0.1);
+		border-color: var(--error);
+		color: var(--error);
 	}
 
-	.dashboard-grid {
+	.pulse-label {
+		color: var(--text-secondary);
+		font-size: 0.8rem;
+	}
+
+	.degraded-banner {
+		padding: 0.75rem 1rem;
+		background: rgba(var(--error-rgb), 0.08);
+		border: 1px solid var(--error);
+		border-radius: 0.375rem;
+		color: var(--error);
+		font-size: 0.875rem;
+		font-weight: 500;
+	}
+
+	/* Activity grid — 3 columns on wide, stack on mobile */
+	.activity-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 		gap: 1.5rem;
 	}
 
-	.stat-panel {
+	.activity-panel {
 		display: flex;
 		flex-direction: column;
-		justify-content: center;
-		align-items: center;
-		padding: 2rem;
-		text-align: center;
+		gap: 0.75rem;
+		min-width: 0; /* prevent overflow on mobile */
 	}
 
-	.stat-panel h3 {
-		margin: 0 0 1rem 0;
+	.activity-panel.stale {
+		opacity: 0.7;
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.panel-header h3 {
+		margin: 0;
 		font-size: 0.875rem;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		color: var(--text-secondary);
+		flex: 1;
 	}
 
-	.stat {
-		margin: 0 0 0.5rem 0;
-		font-size: 3rem;
-		font-weight: 700;
-		line-height: 1;
-	}
-
-	.meta {
-		margin: 0;
+	.count-badge {
+		display: inline-block;
+		padding: 0.15rem 0.5rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-color);
+		border-radius: 0.75rem;
 		font-size: 0.75rem;
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+
+	.concurrency-label {
+		font-size: 0.7rem;
 		color: var(--text-secondary);
 	}
 
+	.updated-at {
+		margin: 0;
+		font-size: 0.7rem;
+		color: var(--text-secondary);
+	}
+
+	.updated-at.stale-text {
+		color: var(--warning);
+	}
+
+	.empty-state {
+		margin: 0.5rem 0;
+		padding: 1.5rem;
+		text-align: center;
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		border: 1px dashed var(--border-color);
+		border-radius: 0.375rem;
+	}
+
+	/* Item list (queue / processing) */
+	.item-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.activity-item {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		padding: 0.5rem 0.75rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-color);
+		border-radius: 0.375rem;
+	}
+
+	.item-top {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+
+	.item-name {
+		flex: 1;
+		font-size: 0.8rem;
+		font-weight: 500;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.progress-bar {
+		height: 4px;
+		background: var(--border-color);
+		border-radius: 2px;
+		overflow: hidden;
+	}
+
+	.progress-fill {
+		height: 100%;
+		background: var(--accent);
+		border-radius: 2px;
+		transition: width 0.3s ease;
+	}
+
+	.progress-pct {
+		font-size: 0.7rem;
+		color: var(--text-secondary);
+		text-align: right;
+	}
+
+	/* Task list */
+	.task-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.task-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-color);
+		border-radius: 0.375rem;
+		flex-wrap: wrap;
+	}
+
+	.task-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.task-name {
+		font-size: 0.8rem;
+		font-weight: 500;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.task-schedule {
+		font-size: 0.7rem;
+		color: var(--text-secondary);
+	}
+
+	.task-meta {
+		display: flex;
+		gap: 0.25rem;
+		flex-shrink: 0;
+	}
+
+	/* State badges */
+	.state-badge {
+		display: inline-block;
+		padding: 0.15rem 0.45rem;
+		border-radius: 0.25rem;
+		font-size: 0.65rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+		white-space: nowrap;
+	}
+
+	.state-active {
+		background: rgba(var(--success-rgb), 0.15);
+		color: var(--success);
+	}
+
+	.state-queued {
+		background: rgba(var(--accent-rgb), 0.15);
+		color: var(--accent);
+	}
+
+	.state-paused {
+		background: rgba(var(--warning-rgb), 0.15);
+		color: var(--warning);
+	}
+
+	.state-done {
+		background: rgba(var(--success-rgb), 0.08);
+		color: var(--text-secondary);
+	}
+
+	.state-error {
+		background: rgba(var(--error-rgb), 0.15);
+		color: var(--error);
+	}
+
+	.state-unknown {
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+	}
+
+	/* Settings panel */
 	.settings-panel {
 		background: var(--bg-secondary);
 		border: 1px solid var(--border-color);


### PR DESCRIPTION
## Phase 11.3 — Realtime Dashboard UX (Issue #434)

Rewrites the dashboard page to expose live SSE activity streams with per-panel auto-reconnect, typed data, item-level detail, and stale detection.

### Changes

**`web/src/lib/types.ts`**
- Added `ActivityItem`, `ActivityListResponse`, `SystemTask`, `SystemTasksResponse` interfaces matching backend API response shapes
- Updated `SseMessage<T>` to `SseMessage<T = unknown>` (default generic)

**`web/src/lib/api.ts`**
- `getQueueSnapshot()`, `getProcessingSnapshot()` now return `ActivityListResponse`
- `getTasksSnapshot()` now returns `SystemTasksResponse`

**`web/src/routes/(app)/dashboard/+page.svelte`** — full rewrite
- Per-stream `EventSource` lifecycle with independent reconnect timers
- Exponential backoff on reconnect: 1 s → 2 s → 4 s … capped at 30 s
- Per-panel last-updated timestamps with live age labels (e.g. "5s ago", "2m ago") updated every 5 s
- Stale detection: panels dim and show a warning after 60 s without an update
- Disconnected state banner when all SSE streams are down
- Item-level activity panels:
  - **Download Queue** — name, state badge, progress bar for `downloading` state
  - **Import Processing** — name, state badge, progress indicator
  - **Scheduled Tasks** — name, schedule interval, enabled + status badges
- Proper empty states with dashed-border placeholders
- Mobile-safe layout: `min-width: 0` on panels, flex-wrap headers

### Validation

```
bun run check  →  svelte-check found 0 errors and 0 warnings ✓
bun run build  →  ✔ built in 2.11s  /  ✔ done (adapter-static) ✓
```

Closes #434
Builds on #437
