### PR TITLE
fix: dashboard navigation regression — replace \ with onMount lifecycle

### DIFF
--- a/web/src/routes/(app)/dashboard/+page.svelte
+++ b/web/src/routes/(app)/dashboard/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import {
 		ApiError,
 		getAppearanceSettings,
@@ -58,9 +59,9 @@
 		return 'reconnecting' as const;
 	});
 
-	let eventStreams = $state<Partial<Record<StreamKey, EventSource>>>({});
-	let reconnectTimers = $state<Partial<Record<StreamKey, ReturnType<typeof setTimeout>>>>({});
-	let reconnectAttempts = $state<Partial<Record<StreamKey, number>>>({});
+	let eventStreams: Partial<Record<StreamKey, EventSource>> = {};
+	let reconnectTimers: Partial<Record<StreamKey, ReturnType<typeof setTimeout>>> = {};
+	let reconnectAttempts: Partial<Record<StreamKey, number>> = {};
 
 	const RECONNECT_BASE_MS = 1000;
 	const RECONNECT_MAX_MS = 30_000;
@@ -88,11 +89,15 @@
 		return Math.min(RECONNECT_BASE_MS * 2 ** attempts, RECONNECT_MAX_MS);
 	}
 
+	function setStreamConnectionState(key: StreamKey, value: StreamConnectionState): void {
+		streamStates = { ...streamStates, [key]: value };
+	}
+
 	function scheduleReconnect(key: StreamKey): void {
 		clearTimeout(reconnectTimers[key]);
 		const delay = backoffMs(key);
 		reconnectAttempts[key] = (reconnectAttempts[key] ?? 0) + 1;
-		streamStates[key] = 'reconnecting';
+		setStreamConnectionState(key, 'reconnecting');
 		reconnectTimers[key] = setTimeout(() => attachStream(key), delay);
 	}
 
@@ -102,7 +107,7 @@
 
 	function attachStream(key: StreamKey): void {
 		eventStreams[key]?.close();
-		streamStates[key] = 'connecting';
+		setStreamConnectionState(key, 'connecting');
 
 		let es: EventSource;
 
@@ -110,7 +115,7 @@
 			es = openStream('/api/v1/events');
 			es.addEventListener('connected', () => {
 				reconnectAttempts[key] = 0;
-				streamStates[key] = 'connected';
+				setStreamConnectionState(key, 'connected');
 			});
 			for (const evtName of PULSE_EVENT_NAMES) {
 				es.addEventListener(evtName, (event) => {
@@ -126,7 +131,7 @@
 			es = openStream('/api/v1/events/download-progress');
 			es.addEventListener('connected', () => {
 				reconnectAttempts[key] = 0;
-				streamStates[key] = 'connected';
+				setStreamConnectionState(key, 'connected');
 			});
 			es.addEventListener('download_queue_snapshot', (event) => {
 				const payload = safeParse((event as MessageEvent).data) as {
@@ -142,7 +147,7 @@
 			es = openStream('/api/v1/events/import-progress');
 			es.addEventListener('connected', () => {
 				reconnectAttempts[key] = 0;
-				streamStates[key] = 'connected';
+				setStreamConnectionState(key, 'connected');
 			});
 			es.addEventListener('import_progress_snapshot', (event) => {
 				const payload = safeParse((event as MessageEvent).data) as {
@@ -158,7 +163,7 @@
 			es = openStream('/api/v1/events/job-status');
 			es.addEventListener('connected', () => {
 				reconnectAttempts[key] = 0;
-				streamStates[key] = 'connected';
+				setStreamConnectionState(key, 'connected');
 			});
 			es.addEventListener('job_status_snapshot', (event) => {
 				const payload = safeParse((event as MessageEvent).data) as {
@@ -188,20 +193,23 @@
 		}
 	}
 
-	function detachSse(): void {
+	function detachSse(resetState = true): void {
 		for (const key of ALL_STREAM_KEYS) {
 			clearTimeout(reconnectTimers[key]);
 			eventStreams[key]?.close();
 		}
-		eventStreams = {};
-		reconnectTimers = {};
-		reconnectAttempts = {};
-		streamStates = {
-			events: 'disconnected',
-			queue: 'disconnected',
-			processing: 'disconnected',
-			tasks: 'disconnected'
-		};
+
+		if (resetState) {
+			eventStreams = {};
+			reconnectTimers = {};
+			reconnectAttempts = {};
+			streamStates = {
+				events: 'disconnected',
+				queue: 'disconnected',
+				processing: 'disconnected',
+				tasks: 'disconnected'
+			};
+		}
 	}
 
 	async function hydrateData(): Promise<void> {
@@ -245,14 +253,16 @@
 		}
 	}
 
-	$effect(() => {
-		hydrateData();
+	onMount(() => {
+		void hydrateData();
 		attachSse();
 		clockInterval = setInterval(() => {
 			now = Date.now();
 		}, 5000);
+
 		return () => {
-			detachSse();
+			// During teardown, only close network resources; avoid state writes.
+			detachSse(false);
 			if (clockInterval) clearInterval(clockInterval);
 		};
 	});


### PR DESCRIPTION
# fix: dashboard navigation regression — replace `$effect` with `onMount`

## Problem

After Phase 11.3 (#438), clicking nav links (Artists, Albums, Appearance) from
the dashboard appeared to do nothing — the view only changed after a full page
refresh.

**Root cause:** The dashboard used `$effect` for SSE stream lifecycle
(setup + cleanup). In Svelte 5, the cleanup function of a `$effect` runs
synchronously during the reactive teardown phase when navigating away. Writing
to `$state` variables inside that cleanup (`eventStreams = {}`,
`reconnectTimers = {}`, `streamStates = { ... }`) triggered a Svelte 5 runtime
`"updated at"` error mid-transition, aborting the route change entirely.

## Fix

- Replaced `$effect` lifecycle with `onMount` so setup/teardown happens outside
  the reactive render phase (safe to call during route transitions)
- Converted `eventStreams`, `reconnectTimers`, `reconnectAttempts` from `$state`
  to plain non-reactive local variables — they drive no UI directly so they do
  not need reactivity
- Added `setStreamConnectionState(key, value)` helper to update the reactive
  `streamStates` immutably via object spread
- Added `resetState` parameter to `detachSse()` — the `onMount` cleanup passes
  `false` so no `$state` writes happen during teardown; only safe resource
  cleanup (EventSource `close()` / `clearTimeout`) runs

## Testing

- Navigating to Artists / Albums / Appearance and back to Dashboard all work
  without a page refresh
- `bun run check` → 0 errors
- `bun run build` → clean

## Related

- Regression introduced by Phase 11.3: Closes #434
- Phase 11.3 PR: #438
