### PR TITLE
fix: stabilize dashboard stream status to avoid false reconnecting

### DIFF
--- a/web/src/routes/(app)/dashboard/+page.svelte
+++ b/web/src/routes/(app)/dashboard/+page.svelte
@@ -56,6 +56,8 @@
 		const states = ALL_STREAM_KEYS.map((k) => streamStates[k]);
 		if (states.every((s) => s === 'connected')) return 'connected' as const;
 		if (states.every((s) => s === 'disconnected')) return 'disconnected' as const;
+		if (states.some((s) => s === 'reconnecting')) return 'reconnecting' as const;
+		if (states.some((s) => s === 'connecting')) return 'connecting' as const;
 		return 'reconnecting' as const;
 	});
 
@@ -177,6 +179,11 @@
 				}
 			});
 		}
+
+		es.onopen = () => {
+			reconnectAttempts[key] = 0;
+			setStreamConnectionState(key, 'connected');
+		};
 
 		es.onerror = () => {
 			es.close();
@@ -313,6 +320,7 @@
 			<span
 				class="pill"
 				class:connected={streamState === 'connected'}
+				class:connecting={streamState === 'connecting'}
 				class:reconnecting={streamState === 'reconnecting'}
 				class:disconnected={streamState === 'disconnected'}
 			>
@@ -539,6 +547,12 @@
 		background: rgba(var(--success-rgb), 0.1);
 		border-color: var(--success);
 		color: var(--success);
+	}
+
+	.pill.connecting {
+		background: rgba(var(--accent-rgb), 0.1);
+		border-color: var(--accent);
+		color: var(--accent);
 	}
 
 	.pill.reconnecting {


### PR DESCRIPTION
# fix: stabilize dashboard SSE stream status (false RECONNECTING)

## Problem

The dashboard status pill could show `RECONNECTING` even when SSE streams were
healthy. This happened because:

- aggregate status collapsed any mixed states into `reconnecting`
- connection state depended only on the custom `connected` SSE event

If the custom event was not observed in time, a stream could remain in
`connecting` while still being alive, and the aggregate status incorrectly
rendered as reconnecting.

## Fix

- Set stream state to `connected` on native EventSource `onopen`
- Keep `reconnecting` reserved for actual reconnect attempts
- Distinguish `connecting` from `reconnecting` in aggregate status computation
- Add `connecting` styling for the dashboard status pill

## Validation

- `bun run check` passes (0 errors, 0 warnings)
- Dashboard stream status now reflects real connection lifecycle:
  - `connecting` during initial handshake
  - `connected` when streams are open
  - `reconnecting` only after stream errors and retry scheduling
