### PR TITLE
feat(web): connection-health UX and manual reconnect controls

### DIFF
--- a/web/src/lib/dashboard.test.ts
+++ b/web/src/lib/dashboard.test.ts
@@ -4,7 +4,10 @@ import {
 	aggregateStreamState,
 	backoffMs,
 	formatAge,
-	isStale
+	isStale,
+	needsReconnect,
+	STREAM_LABELS,
+	streamHealthClass
 } from '$lib/dashboard';
 import type { StreamConnectionState, StreamKey } from '$lib/dashboard';
 
@@ -125,5 +128,49 @@ describe('formatAge', () => {
 
 	it('returns hours label', () => {
 		expect(formatAge(new Date(now - 3_600_000 * 2), now)).toBe('2h ago');
+	});
+});
+
+describe('streamHealthClass', () => {
+	it('returns the state string unchanged for each state', () => {
+		const states: StreamConnectionState[] = ['connected', 'connecting', 'reconnecting', 'disconnected'];
+		for (const s of states) {
+			expect(streamHealthClass(s)).toBe(s);
+		}
+	});
+});
+
+describe('needsReconnect', () => {
+	it('returns false when all streams are connected', () => {
+		expect(needsReconnect(allStates('connected'))).toBe(false);
+	});
+
+	it('returns false when all streams are connecting', () => {
+		expect(needsReconnect(allStates('connecting'))).toBe(false);
+	});
+
+	it('returns true when any stream is reconnecting', () => {
+		const states = allStates('connected');
+		states.queue = 'reconnecting';
+		expect(needsReconnect(states)).toBe(true);
+	});
+
+	it('returns true when any stream is disconnected', () => {
+		const states = allStates('connected');
+		states.events = 'disconnected';
+		expect(needsReconnect(states)).toBe(true);
+	});
+
+	it('returns true when all streams are disconnected', () => {
+		expect(needsReconnect(allStates('disconnected'))).toBe(true);
+	});
+});
+
+describe('STREAM_LABELS', () => {
+	it('has a label for every stream key', () => {
+		for (const key of ALL_STREAM_KEYS) {
+			expect(typeof STREAM_LABELS[key]).toBe('string');
+			expect(STREAM_LABELS[key].length).toBeGreaterThan(0);
+		}
 	});
 });

--- a/web/src/lib/dashboard.ts
+++ b/web/src/lib/dashboard.ts
@@ -48,3 +48,26 @@ export function formatAge(date: Date | null, now: number): string {
 	if (mins < 60) return `${mins}m ago`;
 	return `${Math.floor(mins / 60)}h ago`;
 }
+
+/** CSS class suffix for a stream connection state (matches `.pill.<class>` selectors). */
+export function streamHealthClass(state: StreamConnectionState): string {
+	return state; // 'connected' | 'connecting' | 'reconnecting' | 'disconnected'
+}
+
+/**
+ * Returns true when any stream is not in a healthy/progressing state and the
+ * operator may benefit from a manual reconnect option.
+ */
+export function needsReconnect(states: Record<StreamKey, StreamConnectionState>): boolean {
+	return ALL_STREAM_KEYS.some(
+		(k) => states[k] === 'reconnecting' || states[k] === 'disconnected'
+	);
+}
+
+/** Human-readable label per stream key for use in health indicators. */
+export const STREAM_LABELS: Record<StreamKey, string> = {
+	events: 'Events',
+	queue: 'Download Queue',
+	processing: 'Import',
+	tasks: 'Tasks'
+};

--- a/web/src/routes/(app)/dashboard/+page.svelte
+++ b/web/src/routes/(app)/dashboard/+page.svelte
@@ -351,7 +351,7 @@
 
 	<!-- Per-stream health row (shown when any stream is unhealthy) -->
 	{#if streamSick}
-		<div class="stream-health-row" aria-label="Stream health">
+		<div class="stream-health-row" role="group" aria-label="Stream health">
 			{#each ALL_STREAM_KEYS as key (key)}
 				<div class="stream-health-item">
 					<span

--- a/web/src/routes/(app)/dashboard/+page.svelte
+++ b/web/src/routes/(app)/dashboard/+page.svelte
@@ -14,7 +14,10 @@
 		aggregateStreamState,
 		backoffMs as calcBackoffMs,
 		formatAge as formatAgeHelper,
-		isStale as isStaleHelper
+		isStale as isStaleHelper,
+		needsReconnect,
+		STREAM_LABELS,
+		streamHealthClass
 	} from '$lib/dashboard';
 	import type { StreamConnectionState, StreamKey } from '$lib/dashboard';
 	import type {
@@ -59,6 +62,7 @@
 	});
 
 	let streamState = $derived(aggregateStreamState(streamStates));
+	let streamSick = $derived(needsReconnect(streamStates));
 
 	let eventStreams: Partial<Record<StreamKey, EventSource>> = {};
 	let reconnectTimers: Partial<Record<StreamKey, ReturnType<typeof setTimeout>>> = {};
@@ -194,6 +198,19 @@
 		}
 	}
 
+	function reconnectStream(key: StreamKey): void {
+		clearTimeout(reconnectTimers[key]);
+		delete reconnectTimers[key];
+		reconnectAttempts[key] = 0;
+		attachStream(key);
+	}
+
+	function reconnectAll(): void {
+		for (const key of ALL_STREAM_KEYS) {
+			reconnectStream(key);
+		}
+	}
+
 	function detachSse(resetState = true): void {
 		for (const key of ALL_STREAM_KEYS) {
 			clearTimeout(reconnectTimers[key]);
@@ -321,8 +338,39 @@
 	</header>
 
 	{#if streamState === 'disconnected'}
-		<div class="degraded-banner">
-			Realtime feed disconnected — data may be out of date.
+		<div class="degraded-banner" role="alert">
+			<span>Realtime feed disconnected — data may be out of date.</span>
+			<button class="reconnect-btn" onclick={reconnectAll}>Reconnect</button>
+		</div>
+	{:else if streamSick}
+		<div class="degraded-banner degraded-banner--warning" role="status">
+			<span>One or more streams are reconnecting…</span>
+			<button class="reconnect-btn" onclick={reconnectAll}>Reconnect All</button>
+		</div>
+	{/if}
+
+	<!-- Per-stream health row (shown when any stream is unhealthy) -->
+	{#if streamSick}
+		<div class="stream-health-row" aria-label="Stream health">
+			{#each ALL_STREAM_KEYS as key (key)}
+				<div class="stream-health-item">
+					<span
+						class="pill pill--sm {streamHealthClass(streamStates[key])}"
+						title="Stream: {STREAM_LABELS[key]} — {streamStates[key]}"
+					>
+						{STREAM_LABELS[key]}
+					</span>
+					{#if streamStates[key] === 'reconnecting' || streamStates[key] === 'disconnected'}
+						<button
+							class="reconnect-btn reconnect-btn--sm"
+							onclick={() => reconnectStream(key)}
+							aria-label="Reconnect {STREAM_LABELS[key]} stream"
+						>
+							↺
+						</button>
+					{/if}
+				</div>
+			{/each}
 		</div>
 	{/if}
 
@@ -339,6 +387,12 @@
 			<div class="panel-header">
 				<h3>Download Queue</h3>
 				<span class="count-badge">{queueTotal}</span>
+				{#if streamStates.queue !== 'connected'}
+					<span
+						class="pill pill--sm {streamHealthClass(streamStates.queue)}"
+						title="Stream: {streamStates.queue}"
+					>{streamStates.queue}</span>
+				{/if}
 			</div>
 			{#if queueUpdated}
 				<p class="updated-at" class:stale-text={isStale(queueUpdated)}>
@@ -376,6 +430,12 @@
 			<div class="panel-header">
 				<h3>Import Processing</h3>
 				<span class="count-badge">{processingTotal}</span>
+				{#if streamStates.processing !== 'connected'}
+					<span
+						class="pill pill--sm {streamHealthClass(streamStates.processing)}"
+						title="Stream: {streamStates.processing}"
+					>{streamStates.processing}</span>
+				{/if}
 			</div>
 			{#if processingUpdated}
 				<p class="updated-at" class:stale-text={isStale(processingUpdated)}>
@@ -413,6 +473,12 @@
 			<div class="panel-header">
 				<h3>Scheduled Tasks</h3>
 				<span class="count-badge">{taskTotal}</span>
+				{#if streamStates.tasks !== 'connected'}
+					<span
+						class="pill pill--sm {streamHealthClass(streamStates.tasks)}"
+						title="Stream: {streamStates.tasks}"
+					>{streamStates.tasks}</span>
+				{/if}
 				{#if maxConcurrentJobs > 0}
 					<span class="concurrency-label">max {maxConcurrentJobs} concurrent</span>
 				{/if}
@@ -591,6 +657,57 @@
 		color: var(--error);
 		font-size: 0.875rem;
 		font-weight: 500;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.degraded-banner--warning {
+		background: rgba(var(--warning-rgb), 0.08);
+		border-color: var(--warning);
+		color: var(--warning);
+	}
+
+	.stream-health-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.stream-health-item {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.pill--sm {
+		padding: 0.15rem 0.5rem;
+		font-size: 0.65rem;
+	}
+
+	.reconnect-btn {
+		padding: 0.35rem 0.85rem;
+		border: 1px solid currentColor;
+		border-radius: 6px;
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+		font-size: 0.825rem;
+		white-space: nowrap;
+		transition: opacity 0.12s;
+	}
+
+	.reconnect-btn:hover {
+		opacity: 0.75;
+	}
+
+	.reconnect-btn--sm {
+		padding: 0.1rem 0.4rem;
+		font-size: 0.75rem;
+		border-radius: 4px;
 	}
 
 	.error-banner {


### PR DESCRIPTION
## Summary

Implements connection-health UX and manual reconnect controls for the realtime dashboard, closing #447.

## Changes

### `web/src/lib/dashboard.ts`
- `needsReconnect(states)` — returns `true` when any stream is `reconnecting` or `disconnected`
- `streamHealthClass(state)` — maps a `StreamConnectionState` to its CSS class suffix
- `STREAM_LABELS` — human-readable labels per stream key for health indicators

### `web/src/routes/(app)/dashboard/+page.svelte`
- **Degraded banner** now includes a **Reconnect** button (was plain text); shows warning-styled variant when streams are reconnecting (not just fully disconnected)
- **Per-stream health row** appears below the banner when any stream is unhealthy, showing a pill for each stream and a targeted `↺` reconnect button for streams that are `reconnecting` or `disconnected`
- **Per-panel health pill** in each activity panel header shows stream state when not `connected`
- `reconnectStream(key)` — resets backoff counter and immediately reattaches a single stream without a page reload
- `reconnectAll()` — calls `reconnectStream` for all four stream keys
- `streamSick` derived state drives conditional rendering of health UI

### `web/src/lib/dashboard.test.ts`
- 7 new unit tests covering `streamHealthClass`, `needsReconnect`, and `STREAM_LABELS`
- Total: 43 tests, all passing

## Acceptance Criteria

- [x] Stream health visible at a glance (per-panel pills + health row)
- [x] Manual reconnect does not require full page reload
- [x] No excessive reconnect loops — `reconnectStream` resets backoff to zero for intentional manual reconnects only; automatic reconnects still use exponential backoff

## Test Results

```
Tests  43 passed (43)
svelte-check found 0 errors and 0 warnings
Build succeeded
```

Closes #447
