### PR TITLE
feat(e2e): Playwright E2E smoke tests (#446)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -49,3 +49,9 @@ jobs:
 
       - name: Production build
         run: bun run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: E2E smoke tests (Playwright)
+        run: bun run test:e2e

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -50,8 +50,23 @@ jobs:
       - name: Production build
         run: bun run build
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browsers (Linux)
+        if: matrix.os == 'ubuntu-latest'
         run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright browsers (Windows)
+        if: matrix.os == 'windows-latest'
+        run: npx playwright install chromium
 
       - name: E2E smoke tests (Playwright)
         run: bun run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.os }}
+          path: |
+            web/playwright-report/
+            web/test-results/
+          retention-days: 7

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "web",
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@sveltejs/adapter-static": "^3.0.0",
         "@sveltejs/kit": "^2.57.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
@@ -116,6 +117,8 @@
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -429,6 +432,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
@@ -534,6 +541,8 @@
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { injectAuth, mockApiRoutes, MOCK_USER } from './helpers';
+
+test.describe('Authentication', () => {
+	test('shows the login form at the root path', async ({ page }) => {
+		await page.goto('/');
+		await expect(page.getByRole('heading', { name: 'Chorrosion Control Deck' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Sign In' })).toBeVisible();
+		await expect(page.getByLabel('Username')).toBeVisible();
+		await expect(page.getByLabel('Password')).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+	});
+
+	test('shows an error message on failed login', async ({ page }) => {
+		// Override the default stub to return 401
+		await page.route('http://127.0.0.1:5150/api/v1/auth/forms/login', (route) =>
+			route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ error: 'Invalid credentials' })
+			})
+		);
+
+		await page.goto('/');
+		await page.getByLabel('Username').fill('baduser');
+		await page.getByLabel('Password').fill('wrongpass');
+		await page.getByRole('button', { name: 'Sign In' }).click();
+
+		await expect(page.getByText('Invalid credentials')).toBeVisible();
+		// Should remain on the login page
+		await expect(page).toHaveURL('/');
+	});
+
+	test('redirects to /dashboard after successful login', async ({ page }) => {
+		await mockApiRoutes(page);
+
+		await page.goto('/');
+		await page.getByLabel('Username').fill('testuser');
+		await page.getByLabel('Password').fill('testpass');
+		await page.getByRole('button', { name: 'Sign In' }).click();
+
+		await expect(page).toHaveURL('/dashboard');
+		await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+	});
+
+	test('logs out and returns to the login page', async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectAuth(page);
+
+		await page.goto('/dashboard');
+		await expect(
+			page.getByRole('button', { name: /Log Out/i })
+		).toBeVisible();
+
+		await page.getByRole('button', { name: /Log Out/i }).click();
+
+		await expect(page).toHaveURL('/');
+		await expect(page.getByRole('heading', { name: 'Sign In' })).toBeVisible();
+	});
+
+	test('displays logged-in username in the header', async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectAuth(page);
+
+		await page.goto('/dashboard');
+		// Username is rendered in a <span> with aria-label
+		await expect(
+			page.locator(`[aria-label="Logged in as ${MOCK_USER.username}"]`)
+		).toBeVisible();
+	});
+});

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { injectAuth, mockApiRoutes, MOCK_USER } from './helpers';
+import { injectAuth, mockApiRoutes, MOCK_USER, API_BASE } from './helpers';
 
 test.describe('Authentication', () => {
 	test('shows the login form at the root path', async ({ page }) => {
@@ -13,7 +13,7 @@ test.describe('Authentication', () => {
 
 	test('shows an error message on failed login', async ({ page }) => {
 		// Override the default stub to return 401
-		await page.route('http://127.0.0.1:5150/api/v1/auth/forms/login', (route) =>
+		await page.route(`${API_BASE}/api/v1/auth/forms/login`, (route) =>
 			route.fulfill({
 				status: 401,
 				contentType: 'application/json',

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -9,7 +9,7 @@ test.describe('Dashboard — realtime stream status', () => {
 		await page.goto('/dashboard');
 		const pill = page.locator('.section-header .pill').first();
 		await expect(pill).toBeVisible();
-		await expect(pill).toHaveText(/connecting|connected|reconnecting|disconnected/i);
+		await expect(pill).toHaveText('connecting');
 	});
 
 	test('stream pill shows "connected" after SSE fires connected event', async ({ page }) => {

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { injectAuth, injectConnectedEventSource, injectFailingEventSource, mockApiRoutes } from './helpers';
+
+test.describe('Dashboard — realtime stream status', () => {
+	test('shows a stream status pill in the header', async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectAuth(page);
+		// No EventSource mock → streams start in 'connecting' state (no real backend)
+		await page.goto('/dashboard');
+		const pill = page.locator('.section-header .pill').first();
+		await expect(pill).toBeVisible();
+		await expect(pill).toHaveText(/connecting|connected|reconnecting|disconnected/i);
+	});
+
+	test('stream pill shows "connected" after SSE fires connected event', async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectConnectedEventSource(page); // mock EventSource fires onopen then connected event
+		await injectAuth(page);
+
+		await page.goto('/dashboard');
+		await expect(page.locator('.section-header .pill').first()).toHaveText('connected', {
+			timeout: 8_000
+		});
+	});
+
+	test('shows degraded banner when all SSE streams report errors', async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectFailingEventSource(page); // mock EventSource fires onerror immediately
+		await injectAuth(page);
+
+		await page.goto('/dashboard');
+
+		// After onerror, scheduleReconnect sets state to 'reconnecting' → degraded banner appears
+		await expect(page.locator('.degraded-banner')).toBeVisible({ timeout: 10_000 });
+	});
+
+	test('renders activity panel headings', async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectAuth(page);
+
+		await page.goto('/dashboard');
+		await expect(page.getByRole('heading', { name: 'Download Queue' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Import Processing' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Scheduled Tasks' })).toBeVisible();
+	});
+
+	test('renders empty-state messages for idle panels', async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectAuth(page);
+
+		await page.goto('/dashboard');
+		await expect(page.getByText('Download queue is idle')).toBeVisible({ timeout: 8_000 });
+	});
+});

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { injectAuth, injectConnectedEventSource, injectFailingEventSource, mockApiRoutes } from './helpers';
+import { injectAuth, injectConnectedEventSource, injectFailingEventSource, injectPendingEventSource, mockApiRoutes } from './helpers';
 
 test.describe('Dashboard — realtime stream status', () => {
 	test('shows a stream status pill in the header', async ({ page }) => {
 		await mockApiRoutes(page);
+		await injectPendingEventSource(page); // never fires → streams stay in 'connecting' state
 		await injectAuth(page);
-		// No EventSource mock → streams start in 'connecting' state (no real backend)
 		await page.goto('/dashboard');
 		const pill = page.locator('.section-header .pill').first();
 		await expect(pill).toBeVisible();

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 
 /** The mock API base — matches the default VITE_CHORROSION_API_BASE. */
-const API_BASE = 'http://127.0.0.1:5150';
+export const API_BASE = 'http://127.0.0.1:5150';
 
 export const MOCK_USER = {
 	isAuthenticated: true,

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -1,0 +1,176 @@
+import type { Page } from '@playwright/test';
+
+/** The mock API base — matches the default VITE_CHORROSION_API_BASE. */
+const API_BASE = 'http://127.0.0.1:5150';
+
+export const MOCK_USER = {
+	isAuthenticated: true,
+	username: 'testuser',
+	token: 'mock-e2e-token'
+};
+
+/**
+ * Inject auth state into sessionStorage before the page loads so tests can
+ * skip the login form and start on an authenticated page.
+ * Must be called before `page.goto()`.
+ */
+export async function injectAuth(page: Page): Promise<void> {
+	await page.addInitScript((auth) => {
+		sessionStorage.setItem('auth_state', JSON.stringify(auth));
+	}, MOCK_USER);
+}
+
+/**
+ * Inject a mock EventSource into the page that immediately fires `onopen`
+ * and a `connected` event, then stays open forever (no onerror).
+ * This simulates a healthy SSE connection without needing a real server.
+ * Must be called before `page.goto()`.
+ */
+export async function injectConnectedEventSource(page: Page): Promise<void> {
+	await page.addInitScript(() => {
+		class MockEventSource extends EventTarget {
+			static CONNECTING = 0;
+			static OPEN = 1;
+			static CLOSED = 2;
+			readyState = MockEventSource.CONNECTING;
+			onopen: ((ev: Event) => void) | null = null;
+			onerror: ((ev: Event) => void) | null = null;
+
+			constructor(_url: string, _opts?: EventSourceInit) {
+				super();
+				setTimeout(() => {
+					if (this.readyState === MockEventSource.CLOSED) return;
+					this.readyState = MockEventSource.OPEN;
+					const openEvent = new Event('open');
+					if (this.onopen) this.onopen(openEvent);
+					this.dispatchEvent(new MessageEvent('connected', { data: '{}' }));
+				}, 30);
+			}
+
+			close() {
+				this.readyState = MockEventSource.CLOSED;
+			}
+		}
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(window as any).EventSource = MockEventSource;
+	});
+}
+
+/**
+ * Inject a mock EventSource that immediately fires `onerror`, simulating a
+ * backend that is unreachable. Must be called before `page.goto()`.
+ */
+export async function injectFailingEventSource(page: Page): Promise<void> {
+	await page.addInitScript(() => {
+		class FailingEventSource extends EventTarget {
+			static CONNECTING = 0;
+			static OPEN = 1;
+			static CLOSED = 2;
+			readyState = FailingEventSource.CONNECTING;
+			onopen: ((ev: Event) => void) | null = null;
+			onerror: ((ev: Event) => void) | null = null;
+
+			constructor(_url: string, _opts?: EventSourceInit) {
+				super();
+				setTimeout(() => {
+					if (this.readyState === FailingEventSource.CLOSED) return;
+					const errEvent = new Event('error');
+					if (this.onerror) this.onerror(errEvent);
+				}, 30);
+			}
+
+			close() {
+				this.readyState = FailingEventSource.CLOSED;
+			}
+		}
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(window as any).EventSource = FailingEventSource;
+	});
+}
+
+export async function mockApiRoutes(page: Page): Promise<void> {
+	await page.route(`${API_BASE}/api/v1/auth/forms/login`, (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				authenticated: true,
+				username: 'testuser',
+				permission_level: 'admin'
+			})
+		})
+	);
+
+	await page.route(`${API_BASE}/api/v1/auth/forms/logout`, (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ logged_out: true })
+		})
+	);
+
+	// Appearance settings
+	await page.route(`${API_BASE}/api/v1/settings/appearance`, (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				theme_mode: 'system',
+				mobile_breakpoint_px: 768,
+				mobile_compact_layout: false,
+				touch_targets_optimized: false,
+				keyboard_shortcuts_enabled: true,
+				shortcut_profile: 'standard',
+				bulk_operations_enabled: true,
+				bulk_selection_limit: 250,
+				bulk_action_confirmation: true,
+				advanced_filtering_enabled: false,
+				default_filter_operator: 'and',
+				max_filter_clauses: 10,
+				filter_history_enabled: true,
+				filter_history_limit: 20
+			})
+		})
+	);
+
+	// Activity snapshots
+	const emptyList = { items: [], total: 0 };
+	await page.route(`${API_BASE}/api/v1/activity/queue`, (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(emptyList)
+		})
+	);
+	await page.route(`${API_BASE}/api/v1/activity/processing`, (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(emptyList)
+		})
+	);
+	await page.route(`${API_BASE}/api/v1/system/tasks`, (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ items: [], total: 0, max_concurrent_jobs: 4 })
+		})
+	);
+
+	// Catalog endpoints
+	const emptyPage = { items: [], total: 0, limit: 25, offset: 0 };
+	await page.route(`${API_BASE}/api/v1/artists**`, (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(emptyPage)
+		})
+	);
+	await page.route(`${API_BASE}/api/v1/albums**`, (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(emptyPage)
+		})
+	);
+}

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -57,6 +57,37 @@ export async function injectConnectedEventSource(page: Page): Promise<void> {
 }
 
 /**
+ * Inject a mock EventSource that never fires any events (no `onopen`, no
+ * `onerror`), keeping all streams permanently in the `connecting` state.
+ * Use this when you need to assert that the dashboard renders the initial
+ * `connecting` pill without the real EventSource racing to `reconnecting`.
+ * Must be called before `page.goto()`.
+ */
+export async function injectPendingEventSource(page: Page): Promise<void> {
+	await page.addInitScript(() => {
+		class PendingEventSource extends EventTarget {
+			static CONNECTING = 0;
+			static OPEN = 1;
+			static CLOSED = 2;
+			readyState = PendingEventSource.CONNECTING;
+			onopen: ((ev: Event) => void) | null = null;
+			onerror: ((ev: Event) => void) | null = null;
+
+			constructor(_url: string, _opts?: EventSourceInit) {
+				super();
+				// Intentionally fire nothing — stays in CONNECTING forever.
+			}
+
+			close() {
+				this.readyState = PendingEventSource.CLOSED;
+			}
+		}
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(window as any).EventSource = PendingEventSource;
+	});
+}
+
+/**
  * Inject a mock EventSource that immediately fires `onerror`, simulating a
  * backend that is unreachable. Must be called before `page.goto()`.
  */

--- a/web/e2e/navigation.spec.ts
+++ b/web/e2e/navigation.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { injectAuth, mockApiRoutes } from './helpers';
+
+test.describe('Navigation', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectAuth(page);
+	});
+
+	test('renders all four nav links in the header', async ({ page }) => {
+		await page.goto('/dashboard');
+		const nav = page.getByRole('navigation', { name: 'Main navigation' });
+		await expect(nav.getByRole('link', { name: 'Dashboard' })).toBeVisible();
+		await expect(nav.getByRole('link', { name: 'Artists' })).toBeVisible();
+		await expect(nav.getByRole('link', { name: 'Albums' })).toBeVisible();
+		await expect(nav.getByRole('link', { name: 'Appearance' })).toBeVisible();
+	});
+
+	test('active nav link has aria-current="page"', async ({ page }) => {
+		await page.goto('/dashboard');
+		const link = page.getByRole('navigation', { name: 'Main navigation' }).getByRole('link', { name: 'Dashboard' });
+		await expect(link).toHaveAttribute('aria-current', 'page');
+	});
+
+	test('non-active nav links do not have aria-current', async ({ page }) => {
+		await page.goto('/dashboard');
+		const nav = page.getByRole('navigation', { name: 'Main navigation' });
+		for (const name of ['Artists', 'Albums', 'Appearance']) {
+			await expect(nav.getByRole('link', { name })).not.toHaveAttribute('aria-current');
+		}
+	});
+
+	test('clicking Artists navigates to /artists', async ({ page }) => {
+		await page.goto('/dashboard');
+		await page.getByRole('navigation', { name: 'Main navigation' }).getByRole('link', { name: 'Artists' }).click();
+		await expect(page).toHaveURL('/artists');
+		await expect(page.getByRole('heading', { name: 'Artists' })).toBeVisible();
+	});
+
+	test('clicking Albums navigates to /albums', async ({ page }) => {
+		await page.goto('/dashboard');
+		await page.getByRole('navigation', { name: 'Main navigation' }).getByRole('link', { name: 'Albums' }).click();
+		await expect(page).toHaveURL('/albums');
+		await expect(page.getByRole('heading', { name: 'Albums' })).toBeVisible();
+	});
+
+	test('clicking Appearance navigates to /appearance', async ({ page }) => {
+		await page.goto('/dashboard');
+		await page.getByRole('navigation', { name: 'Main navigation' }).getByRole('link', { name: 'Appearance' }).click();
+		await expect(page).toHaveURL('/appearance');
+	});
+
+	test('nav link aria-current tracks the active page', async ({ page }) => {
+		await page.goto('/artists');
+		const nav = page.getByRole('navigation', { name: 'Main navigation' });
+		await expect(nav.getByRole('link', { name: 'Artists' })).toHaveAttribute('aria-current', 'page');
+		await expect(nav.getByRole('link', { name: 'Dashboard' })).not.toHaveAttribute('aria-current');
+	});
+
+	test('skip link is present and points to main content', async ({ page }) => {
+		await page.goto('/dashboard');
+		const skipLink = page.getByRole('link', { name: 'Skip to main content' });
+		// Visually hidden until focused (off-screen via CSS) but present in DOM
+		await expect(skipLink).toBeAttached();
+		await expect(skipLink).toHaveAttribute('href', '#main-content');
+	});
+});

--- a/web/package.json
+++ b/web/package.json
@@ -13,9 +13,12 @@
 		"lint": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"test:coverage": "vitest run --coverage"
+		"test:coverage": "vitest run --coverage",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.59.1",
 		"@sveltejs/adapter-static": "^3.0.0",
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: './e2e',
+	timeout: 30_000,
+	expect: { timeout: 5_000 },
+	fullyParallel: true,
+	retries: process.env.CI ? 2 : 0,
+	reporter: [['html', { open: 'never' }], ['list']],
+	use: {
+		baseURL: 'http://localhost:4173',
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure'
+	},
+	projects: [
+		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }
+	],
+	webServer: {
+		command: 'bun run preview',
+		url: 'http://localhost:4173',
+		reuseExistingServer: !process.env.CI,
+		timeout: 30_000
+	}
+});


### PR DESCRIPTION
## Summary

Adds Playwright 1.59 E2E smoke tests for the SvelteKit web UI, satisfying issue #446 (Phase 12 — UI Production Readiness).

## Changes

### New files
- `web/playwright.config.ts` — Chromium-only config, `baseURL: http://localhost:4173`, `webServer: bun run preview`, retries in CI
- `web/e2e/helpers.ts` — shared test utilities:
  - `injectAuth(page)` — injects sessionStorage auth state via `addInitScript`
  - `injectConnectedEventSource(page)` — overrides `window.EventSource` with a mock that fires `onopen` + `connected` event after 30 ms, keeping all streams permanently connected
  - `injectFailingEventSource(page)` — overrides `window.EventSource` with a mock that fires `onerror` after 30 ms
  - `mockApiRoutes(page)` — stubs all REST endpoints (login, logout, settings, activity, tasks, artists) so tests run without a live backend
- `web/e2e/auth.spec.ts` — 5 tests: login form render, successful login redirect, failed login error, logout, username display
- `web/e2e/navigation.spec.ts` — 7 tests: nav links present, `aria-current="page"` tracking, Artists/Albums/Appearance navigation, skip link
- `web/e2e/dashboard.spec.ts` — 5 tests: stream pill visible, pill shows `connected` via mock EventSource, degraded banner on stream errors, activity panel headings, empty-state messages

### Modified files
- `web/package.json` — adds `test:e2e` and `test:e2e:ui` scripts
- `.github/workflows/frontend-ci.yml` — adds Playwright browser install + E2E smoke test step after production build

## Test results

```
18 passed (8.2s)
```

All 48 Vitest unit tests continue to pass; `svelte-check` reports 0 errors and 0 warnings.

## Closes

Closes #446
