### PR TITLE
docs: update roadmap for #446 and ignore Playwright artifacts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -494,7 +494,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ### 12.3 UI Reliability Testing
 
-- [ ] Playwright smoke E2E for auth, navigation, and realtime dashboard (Issue #446)
+- [x] Playwright smoke E2E for auth, navigation, and realtime dashboard (Issue #446) ✓
 
 ### 12.4 UI-State Maintainability
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -7,6 +7,8 @@ node_modules
 .wrangler
 /.svelte-kit
 /build
+/playwright-report
+/test-results
 
 # OS
 .DS_Store


### PR DESCRIPTION
## Summary
- mark the Phase 12.3 roadmap item for Issue #446 as complete
- ignore generated Playwright artifacts in web workspace output paths

## Why
The Playwright E2E work was merged, but the roadmap checkbox remained unchecked and generated report files appeared as local noise after test runs.

## Validation
- git status shows only intended tracked changes before commit
- no diagnostics for updated files

Follow-up to #446
