### PR TITLE
feat: Settings IA, shell navigation, and shared primitives (#457)

### DIFF
--- a/web/e2e/navigation.spec.ts
+++ b/web/e2e/navigation.spec.ts
@@ -13,7 +13,7 @@ test.describe('Navigation', () => {
 		await expect(nav.getByRole('link', { name: 'Dashboard' })).toBeVisible();
 		await expect(nav.getByRole('link', { name: 'Artists' })).toBeVisible();
 		await expect(nav.getByRole('link', { name: 'Albums' })).toBeVisible();
-		await expect(nav.getByRole('link', { name: 'Appearance' })).toBeVisible();
+		await expect(nav.getByRole('link', { name: 'Settings' })).toBeVisible();
 	});
 
 	test('active nav link has aria-current="page"', async ({ page }) => {
@@ -25,7 +25,7 @@ test.describe('Navigation', () => {
 	test('non-active nav links do not have aria-current', async ({ page }) => {
 		await page.goto('/dashboard');
 		const nav = page.getByRole('navigation', { name: 'Main navigation' });
-		for (const name of ['Artists', 'Albums', 'Appearance']) {
+		for (const name of ['Artists', 'Albums', 'Settings']) {
 			await expect(nav.getByRole('link', { name })).not.toHaveAttribute('aria-current');
 		}
 	});
@@ -44,10 +44,10 @@ test.describe('Navigation', () => {
 		await expect(page.getByRole('heading', { name: 'Albums' })).toBeVisible();
 	});
 
-	test('clicking Appearance navigates to /appearance', async ({ page }) => {
+	test('clicking Settings navigates to /settings', async ({ page }) => {
 		await page.goto('/dashboard');
-		await page.getByRole('navigation', { name: 'Main navigation' }).getByRole('link', { name: 'Appearance' }).click();
-		await expect(page).toHaveURL('/appearance');
+		await page.getByRole('navigation', { name: 'Main navigation' }).getByRole('link', { name: 'Settings' }).click();
+		await expect(page).toHaveURL(/\/settings/);
 	});
 
 	test('nav link aria-current tracks the active page', async ({ page }) => {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "web",
 			"version": "0.0.1",
 			"devDependencies": {
+				"@playwright/test": "^1.59.1",
 				"@sveltejs/adapter-static": "^3.0.0",
 				"@sveltejs/kit": "^2.57.0",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
@@ -720,6 +721,22 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -2907,6 +2924,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -5,10 +5,13 @@
 	--paper: #fffdf7;
 	--ink: #0f1a1f;
 	--accent: #0f7b6c;
+	--accent-rgb: 15, 123, 108;
 	--accent-2: #cf5a2f;
 	--soft: #d4c9b1;
 	--error: #b6422e;
+	--error-rgb: 182, 66, 46;
 	--success: #116a3f;
+	--success-rgb: 17, 106, 63;
 }
 
 * {

--- a/web/src/lib/components/settings/ConfirmDialog.svelte
+++ b/web/src/lib/components/settings/ConfirmDialog.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	interface Props {
+		open: boolean;
+		title?: string;
+		message: string;
+		confirmLabel?: string;
+		cancelLabel?: string;
+		destructive?: boolean;
+		onconfirm: () => void;
+		oncancel: () => void;
+	}
+
+	let {
+		open,
+		title = 'Confirm',
+		message,
+		confirmLabel = 'Confirm',
+		cancelLabel = 'Cancel',
+		destructive = false,
+		onconfirm,
+		oncancel
+	}: Props = $props();
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			oncancel();
+		}
+	}
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+	<div
+		class="dialog-backdrop"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="dialog-title"
+		tabindex="-1"
+		onkeydown={handleKeydown}
+	>
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<div class="dialog-scrim" role="presentation" onclick={oncancel}></div>
+		<div class="dialog-panel">
+			<h3 class="dialog-title" id="dialog-title">{title}</h3>
+			<p class="dialog-message">{message}</p>
+			<div class="dialog-actions">
+				<button class="btn-cancel" onclick={oncancel}>{cancelLabel}</button>
+				<button
+					class="btn-confirm"
+					class:destructive
+					onclick={onconfirm}
+				>
+					{confirmLabel}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.dialog-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.dialog-scrim {
+		position: absolute;
+		inset: 0;
+		background: rgba(15, 26, 31, 0.45);
+		backdrop-filter: blur(2px);
+	}
+
+	.dialog-panel {
+		position: relative;
+		z-index: 1;
+		background: var(--paper, #fffdf7);
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.15));
+		border-radius: 12px;
+		padding: 1.75rem 2rem;
+		max-width: 420px;
+		width: calc(100% - 2rem);
+		box-shadow: 0 16px 48px rgba(15, 26, 31, 0.18);
+		animation: pop-in 0.15s ease-out;
+	}
+
+	.dialog-title {
+		margin: 0 0 0.75rem 0;
+		font-size: 1.1rem;
+		font-weight: 700;
+	}
+
+	.dialog-message {
+		margin: 0 0 1.5rem 0;
+		color: var(--text-secondary, #555);
+		font-size: 0.9rem;
+		line-height: 1.5;
+	}
+
+	.dialog-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.75rem;
+	}
+
+	.btn-cancel {
+		padding: 0.55rem 1.1rem;
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
+		border-radius: 6px;
+		background: transparent;
+		cursor: pointer;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--text-primary, #0f1a1f);
+		transition: background 0.12s;
+	}
+
+	.btn-cancel:hover {
+		background: rgba(0, 0, 0, 0.04);
+	}
+
+	.btn-confirm {
+		padding: 0.55rem 1.1rem;
+		border: none;
+		border-radius: 6px;
+		background: var(--accent, #0f7b6c);
+		color: #fff;
+		cursor: pointer;
+		font-size: 0.875rem;
+		font-weight: 600;
+		transition: opacity 0.12s;
+	}
+
+	.btn-confirm:hover {
+		opacity: 0.88;
+	}
+
+	.btn-confirm.destructive {
+		background: var(--error, #b6422e);
+	}
+
+	@keyframes pop-in {
+		from { opacity: 0; transform: scale(0.95); }
+		to { opacity: 1; transform: scale(1); }
+	}
+</style>

--- a/web/src/lib/components/settings/ConfirmDialog.svelte
+++ b/web/src/lib/components/settings/ConfirmDialog.svelte
@@ -21,6 +21,8 @@
 		oncancel
 	}: Props = $props();
 
+	const dialogTitleId = `dialog-title-${crypto.randomUUID()}`;
+
 	function handleKeydown(event: KeyboardEvent) {
 		if (event.key === 'Escape') {
 			oncancel();
@@ -34,18 +36,19 @@
 		class="dialog-backdrop"
 		role="dialog"
 		aria-modal="true"
-		aria-labelledby="dialog-title"
+		aria-labelledby={dialogTitleId}
 		tabindex="-1"
 		onkeydown={handleKeydown}
 	>
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<div class="dialog-scrim" role="presentation" onclick={oncancel}></div>
 		<div class="dialog-panel">
-			<h3 class="dialog-title" id="dialog-title">{title}</h3>
+			<h3 class="dialog-title" id={dialogTitleId}>{title}</h3>
 			<p class="dialog-message">{message}</p>
 			<div class="dialog-actions">
-				<button class="btn-cancel" onclick={oncancel}>{cancelLabel}</button>
+				<button type="button" class="btn-cancel" onclick={oncancel}>{cancelLabel}</button>
 				<button
+					type="button"
 					class="btn-confirm"
 					class:destructive
 					onclick={onconfirm}

--- a/web/src/lib/components/settings/EmptyState.svelte
+++ b/web/src/lib/components/settings/EmptyState.svelte
@@ -11,7 +11,7 @@
 <div class="empty-state" role="status">
 	<p class="message">{message}</p>
 	{#if actionLabel && onaction}
-		<button class="action-btn" onclick={onaction}>{actionLabel}</button>
+		<button type="button" class="action-btn" onclick={onaction}>{actionLabel}</button>
 	{/if}
 </div>
 

--- a/web/src/lib/components/settings/EmptyState.svelte
+++ b/web/src/lib/components/settings/EmptyState.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	interface Props {
+		message: string;
+		actionLabel?: string;
+		onaction?: () => void;
+	}
+
+	let { message, actionLabel, onaction }: Props = $props();
+</script>
+
+<div class="empty-state" role="status">
+	<p class="message">{message}</p>
+	{#if actionLabel && onaction}
+		<button class="action-btn" onclick={onaction}>{actionLabel}</button>
+	{/if}
+</div>
+
+<style>
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+		padding: 3rem 1rem;
+		text-align: center;
+		color: var(--text-secondary, #777);
+		border: 1px dashed var(--border-color, rgba(15, 26, 31, 0.15));
+		border-radius: 8px;
+	}
+
+	.message {
+		margin: 0;
+		font-size: 0.95rem;
+	}
+
+	.action-btn {
+		padding: 0.55rem 1.25rem;
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
+		border-radius: 6px;
+		background: transparent;
+		cursor: pointer;
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--accent, #0f7b6c);
+		border-color: var(--accent, #0f7b6c);
+		transition: background 0.12s;
+	}
+
+	.action-btn:hover {
+		background: rgba(15, 123, 108, 0.06);
+	}
+</style>

--- a/web/src/lib/components/settings/ErrorMessage.svelte
+++ b/web/src/lib/components/settings/ErrorMessage.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	interface Props {
+		message: string;
+		onretry?: () => void;
+	}
+
+	let { message, onretry }: Props = $props();
+</script>
+
+<div class="error-message" role="alert" aria-live="assertive">
+	<span class="icon" aria-hidden="true">⚠</span>
+	<p class="text">{message}</p>
+	{#if onretry}
+		<button class="retry-btn" onclick={onretry}>Try again</button>
+	{/if}
+</div>
+
+<style>
+	.error-message {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 1rem 1.25rem;
+		background: rgba(182, 66, 46, 0.07);
+		border: 1px solid rgba(182, 66, 46, 0.25);
+		border-radius: 8px;
+		color: var(--error, #b6422e);
+	}
+
+	.icon {
+		font-size: 1.1rem;
+		flex-shrink: 0;
+	}
+
+	.text {
+		margin: 0;
+		font-size: 0.9rem;
+		flex: 1;
+	}
+
+	.retry-btn {
+		padding: 0.35rem 0.85rem;
+		border: 1px solid rgba(182, 66, 46, 0.35);
+		border-radius: 6px;
+		background: transparent;
+		color: var(--error, #b6422e);
+		cursor: pointer;
+		font-size: 0.8rem;
+		font-weight: 600;
+		white-space: nowrap;
+		transition: background 0.12s;
+	}
+
+	.retry-btn:hover {
+		background: rgba(182, 66, 46, 0.1);
+	}
+</style>

--- a/web/src/lib/components/settings/ErrorMessage.svelte
+++ b/web/src/lib/components/settings/ErrorMessage.svelte
@@ -11,7 +11,7 @@
 	<span class="icon" aria-hidden="true">⚠</span>
 	<p class="text">{message}</p>
 	{#if onretry}
-		<button class="retry-btn" onclick={onretry}>Try again</button>
+		<button type="button" class="retry-btn" onclick={onretry}>Try again</button>
 	{/if}
 </div>
 

--- a/web/src/lib/components/settings/LoadingSpinner.svelte
+++ b/web/src/lib/components/settings/LoadingSpinner.svelte
@@ -32,8 +32,8 @@
 		display: inline-block;
 		width: 1.5rem;
 		height: 1.5rem;
-		border: 2px solid rgba(15, 123, 108, 0.2);
-		border-top-color: var(--accent, #0f7b6c);
+		border: 2px solid rgba(var(--accent-rgb), 0.2);
+		border-top-color: var(--accent);
 		border-radius: 50%;
 		animation: spin 0.6s linear infinite;
 	}

--- a/web/src/lib/components/settings/LoadingSpinner.svelte
+++ b/web/src/lib/components/settings/LoadingSpinner.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	interface Props {
+		label?: string;
+		size?: 'sm' | 'md' | 'lg';
+	}
+
+	let { label = 'Loading…', size = 'md' }: Props = $props();
+</script>
+
+<div class="spinner-wrapper" class:sm={size === 'sm'} class:lg={size === 'lg'} role="status" aria-label={label}>
+	<span class="spinner" aria-hidden="true"></span>
+	<span class="sr-only">{label}</span>
+</div>
+
+<style>
+	.spinner-wrapper {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem;
+	}
+
+	.spinner-wrapper.sm {
+		padding: 0.5rem;
+	}
+
+	.spinner-wrapper.lg {
+		padding: 4rem;
+	}
+
+	.spinner {
+		display: inline-block;
+		width: 1.5rem;
+		height: 1.5rem;
+		border: 2px solid rgba(15, 123, 108, 0.2);
+		border-top-color: var(--accent, #0f7b6c);
+		border-radius: 50%;
+		animation: spin 0.6s linear infinite;
+	}
+
+	.sm .spinner {
+		width: 1rem;
+		height: 1rem;
+	}
+
+	.lg .spinner {
+		width: 2.5rem;
+		height: 2.5rem;
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/web/src/lib/components/settings/SaveStatusBanner.svelte
+++ b/web/src/lib/components/settings/SaveStatusBanner.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+	interface Props {
+		status: SaveStatus;
+		errorMessage?: string;
+	}
+
+	let { status, errorMessage }: Props = $props();
+</script>
+
+{#if status !== 'idle'}
+	<div
+		class="save-banner"
+		class:saving={status === 'saving'}
+		class:saved={status === 'saved'}
+		class:error={status === 'error'}
+		role={status === 'error' ? 'alert' : 'status'}
+		aria-live="polite"
+	>
+		{#if status === 'saving'}
+			<span class="spinner" aria-hidden="true"></span>
+			Saving…
+		{:else if status === 'saved'}
+			<span class="icon" aria-hidden="true">✓</span>
+			Saved
+		{:else if status === 'error'}
+			<span class="icon" aria-hidden="true">✕</span>
+			{errorMessage || 'Save failed. Please try again.'}
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.save-banner {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.6rem 1rem;
+		border-radius: 6px;
+		font-size: 0.875rem;
+		font-weight: 500;
+		animation: slide-in 0.15s ease-out;
+	}
+
+	.saving {
+		background: rgba(15, 123, 108, 0.08);
+		color: var(--accent);
+		border: 1px solid rgba(15, 123, 108, 0.2);
+	}
+
+	.saved {
+		background: rgba(17, 106, 63, 0.08);
+		color: var(--success);
+		border: 1px solid rgba(17, 106, 63, 0.2);
+	}
+
+	.error {
+		background: rgba(182, 66, 46, 0.08);
+		color: var(--error);
+		border: 1px solid rgba(182, 66, 46, 0.2);
+	}
+
+	.spinner {
+		display: inline-block;
+		width: 0.875rem;
+		height: 0.875rem;
+		border: 2px solid currentColor;
+		border-top-color: transparent;
+		border-radius: 50%;
+		animation: spin 0.6s linear infinite;
+	}
+
+	.icon {
+		font-size: 0.875rem;
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+
+	@keyframes slide-in {
+		from { opacity: 0; transform: translateY(-4px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+</style>

--- a/web/src/lib/components/settings/SaveStatusBanner.svelte
+++ b/web/src/lib/components/settings/SaveStatusBanner.svelte
@@ -44,21 +44,21 @@
 	}
 
 	.saving {
-		background: rgba(15, 123, 108, 0.08);
+		background: rgba(var(--accent-rgb), 0.08);
 		color: var(--accent);
-		border: 1px solid rgba(15, 123, 108, 0.2);
+		border: 1px solid rgba(var(--accent-rgb), 0.2);
 	}
 
 	.saved {
-		background: rgba(17, 106, 63, 0.08);
+		background: rgba(var(--success-rgb), 0.08);
 		color: var(--success);
-		border: 1px solid rgba(17, 106, 63, 0.2);
+		border: 1px solid rgba(var(--success-rgb), 0.2);
 	}
 
 	.error {
-		background: rgba(182, 66, 46, 0.08);
+		background: rgba(var(--error-rgb), 0.08);
 		color: var(--error);
-		border: 1px solid rgba(182, 66, 46, 0.2);
+		border: 1px solid rgba(var(--error-rgb), 0.2);
 	}
 
 	.spinner {

--- a/web/src/lib/components/settings/SettingsSection.svelte
+++ b/web/src/lib/components/settings/SettingsSection.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	interface Props {
+		title: string;
+		description?: string;
+		children: import('svelte').Snippet;
+		actions?: import('svelte').Snippet;
+	}
+
+	let { title, description, children, actions }: Props = $props();
+</script>
+
+<section class="settings-section">
+	<header class="section-header">
+		<div class="section-meta">
+			<h2 class="section-title">{title}</h2>
+			{#if description}
+				<p class="section-description">{description}</p>
+			{/if}
+		</div>
+		{#if actions}
+			<div class="section-actions">
+				{@render actions()}
+			</div>
+		{/if}
+	</header>
+
+	<div class="section-body">
+		{@render children()}
+	</div>
+</section>
+
+<style>
+	.settings-section {
+		display: grid;
+		gap: 1.5rem;
+	}
+
+	.section-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.section-meta {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.section-title {
+		font-size: 1.5rem;
+		font-weight: 700;
+		margin: 0 0 0.25rem 0;
+		line-height: 1.2;
+	}
+
+	.section-description {
+		margin: 0;
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+		line-height: 1.5;
+	}
+
+	.section-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-shrink: 0;
+	}
+</style>

--- a/web/src/lib/stores/unsavedGuard.ts
+++ b/web/src/lib/stores/unsavedGuard.ts
@@ -1,0 +1,66 @@
+/**
+ * Unsaved guard store.
+ *
+ * Usage:
+ *   import { createUnsavedGuard } from '$lib/stores/unsavedGuard';
+ *
+ *   // In a settings page component:
+ *   const guard = createUnsavedGuard();
+ *
+ *   // Mark dirty when a field changes:
+ *   guard.markDirty();
+ *
+ *   // Clear after successful save:
+ *   guard.markClean();
+ *
+ *   // Check before navigating:
+ *   if (guard.isDirty) { ... show confirm dialog ... }
+ *
+ *   // Wire into SvelteKit beforeNavigate:
+ *   guard.beforeNavigate(navigate);  // cancels navigation if dirty and dialog is pending
+ */
+
+import { beforeNavigate } from '$app/navigation';
+
+export interface UnsavedGuard {
+	readonly isDirty: boolean;
+	markDirty: () => void;
+	markClean: () => void;
+	/** Returns true if navigation should proceed (not dirty or user confirmed). */
+	confirmNavigation: () => boolean;
+}
+
+/**
+ * Create a per-component unsaved guard.
+ * Call this once at component initialisation (not inside a reactive block).
+ *
+ * @param onNavigateBlocked - optional callback invoked when navigation is blocked;
+ *   use this to open your ConfirmDialog. Resolve by calling markClean() + goto().
+ */
+export function createUnsavedGuard(onNavigateBlocked?: () => void): UnsavedGuard {
+	let dirty = $state(false);
+
+	beforeNavigate(({ cancel }) => {
+		if (dirty) {
+			cancel();
+			if (onNavigateBlocked) {
+				onNavigateBlocked();
+			}
+		}
+	});
+
+	return {
+		get isDirty() {
+			return dirty;
+		},
+		markDirty() {
+			dirty = true;
+		},
+		markClean() {
+			dirty = false;
+		},
+		confirmNavigation() {
+			return !dirty;
+		}
+	};
+}

--- a/web/src/lib/stores/unsavedGuard.ts
+++ b/web/src/lib/stores/unsavedGuard.ts
@@ -5,7 +5,7 @@
  *   import { createUnsavedGuard } from '$lib/stores/unsavedGuard';
  *
  *   // In a settings page component:
- *   const guard = createUnsavedGuard();
+ *   const guard = createUnsavedGuard(() => { showConfirmDialog = true; });
  *
  *   // Mark dirty when a field changes:
  *   guard.markDirty();
@@ -13,11 +13,11 @@
  *   // Clear after successful save:
  *   guard.markClean();
  *
- *   // Check before navigating:
- *   if (guard.isDirty) { ... show confirm dialog ... }
+ *   // Check state imperatively (e.g. to disable a Save button):
+ *   if (guard.isDirty) { ... }
  *
- *   // Wire into SvelteKit beforeNavigate:
- *   guard.beforeNavigate(navigate);  // cancels navigation if dirty and dialog is pending
+ *   // Navigation is blocked automatically via beforeNavigate; the optional
+ *   // onNavigateBlocked callback lets you open a confirm dialog in response.
  */
 
 import { beforeNavigate } from '$app/navigation';
@@ -38,7 +38,7 @@ export interface UnsavedGuard {
  *   use this to open your ConfirmDialog. Resolve by calling markClean() + goto().
  */
 export function createUnsavedGuard(onNavigateBlocked?: () => void): UnsavedGuard {
-	let dirty = $state(false);
+	let dirty = false;
 
 	beforeNavigate(({ cancel }) => {
 		if (dirty) {

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -26,7 +26,7 @@
 		{ label: 'Dashboard', href: '/dashboard' },
 		{ label: 'Artists', href: '/artists' },
 		{ label: 'Albums', href: '/albums' },
-		{ label: 'Appearance', href: '/appearance' }
+		{ label: 'Settings', href: '/settings' }
 	];
 
 	function isActive(href: string): boolean {

--- a/web/src/routes/(app)/settings/+layout.svelte
+++ b/web/src/routes/(app)/settings/+layout.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+
+	let { children } = $props();
+
+	const subNavItems = [
+		{ label: 'Download Clients', href: '/settings/download-clients' },
+		{ label: 'Indexers', href: '/settings/indexers' },
+		{ label: 'Quality Profiles', href: '/settings/quality-profiles' },
+		{ label: 'Metadata Profiles', href: '/settings/metadata-profiles' },
+		{ label: 'Appearance', href: '/settings/appearance' }
+	];
+
+	function isActive(href: string): boolean {
+		return $page.url.pathname === href || $page.url.pathname.startsWith(href + '/');
+	}
+</script>
+
+<div class="settings-shell">
+	<aside class="settings-sidebar" aria-label="Settings navigation">
+		<h2 class="settings-title">Settings</h2>
+		<nav>
+			<ul class="settings-nav" role="list">
+				{#each subNavItems as item}
+					<li>
+						<a
+							href={item.href}
+							class="settings-nav-link"
+							class:active={isActive(item.href)}
+							aria-current={isActive(item.href) ? 'page' : undefined}
+						>
+							{item.label}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</nav>
+	</aside>
+
+	<div class="settings-content">
+		{@render children()}
+	</div>
+</div>
+
+<style>
+	.settings-shell {
+		display: grid;
+		grid-template-columns: 220px 1fr;
+		gap: 0;
+		max-width: 1200px;
+		margin: 0 auto;
+		min-height: calc(100vh - 8rem);
+	}
+
+	.settings-sidebar {
+		border-right: 1px solid var(--border-color);
+		padding: 1.5rem 0;
+	}
+
+	.settings-title {
+		font-size: 0.75rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--text-secondary);
+		margin: 0 0 0.75rem 0;
+		padding: 0 1.25rem;
+	}
+
+	.settings-nav {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.settings-nav-link {
+		display: block;
+		padding: 0.6rem 1.25rem;
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: 0.9rem;
+		font-weight: 500;
+		border-left: 2px solid transparent;
+		transition: all 0.15s;
+	}
+
+	.settings-nav-link:hover {
+		color: var(--text-primary);
+		background: rgba(0, 0, 0, 0.03);
+	}
+
+	.settings-nav-link.active {
+		color: var(--accent);
+		border-left-color: var(--accent);
+		background: rgba(15, 123, 108, 0.06);
+	}
+
+	.settings-content {
+		padding: 2rem 2.5rem;
+		min-width: 0;
+	}
+
+	@media (max-width: 700px) {
+		.settings-shell {
+			grid-template-columns: 1fr;
+		}
+
+		.settings-sidebar {
+			border-right: none;
+			border-bottom: 1px solid var(--border-color);
+			padding: 1rem 0 0;
+		}
+
+		.settings-nav {
+			display: flex;
+			overflow-x: auto;
+			gap: 0;
+		}
+
+		.settings-nav-link {
+			border-left: none;
+			border-bottom: 2px solid transparent;
+			white-space: nowrap;
+		}
+
+		.settings-nav-link.active {
+			border-left-color: transparent;
+			border-bottom-color: var(--accent);
+		}
+
+		.settings-content {
+			padding: 1.5rem 1rem;
+		}
+	}
+</style>

--- a/web/src/routes/(app)/settings/+layout.svelte
+++ b/web/src/routes/(app)/settings/+layout.svelte
@@ -86,13 +86,13 @@
 
 	.settings-nav-link:hover {
 		color: var(--text-primary);
-		background: rgba(0, 0, 0, 0.03);
+		background: rgba(var(--accent-rgb), 0.03);
 	}
 
 	.settings-nav-link.active {
 		color: var(--accent);
 		border-left-color: var(--accent);
-		background: rgba(15, 123, 108, 0.06);
+		background: rgba(var(--accent-rgb), 0.06);
 	}
 
 	.settings-content {

--- a/web/src/routes/(app)/settings/+page.ts
+++ b/web/src/routes/(app)/settings/+page.ts
@@ -2,5 +2,5 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = () => {
-	redirect(307, '/settings/download-clients');
+	throw redirect(307, '/settings/download-clients');
 };

--- a/web/src/routes/(app)/settings/+page.ts
+++ b/web/src/routes/(app)/settings/+page.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = () => {
+	redirect(307, '/settings/download-clients');
+};

--- a/web/src/routes/(app)/settings/appearance/+page.svelte
+++ b/web/src/routes/(app)/settings/appearance/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
+	import EmptyState from '$lib/components/settings/EmptyState.svelte';
+</script>
+
+<SettingsSection
+	title="Appearance"
+	description="Customize the look and feel of the Chorrosion Control Deck."
+>
+	<EmptyState message="Appearance settings will be implemented in Issue #434." />
+</SettingsSection>

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
+	import EmptyState from '$lib/components/settings/EmptyState.svelte';
+</script>
+
+<SettingsSection
+	title="Download Clients"
+	description="Configure download clients (NZBGet, SABnzbd, qBittorrent, etc.) used to fetch releases."
+>
+	<EmptyState message="Download Clients management will be implemented in Issue #459." />
+</SettingsSection>

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
+	import EmptyState from '$lib/components/settings/EmptyState.svelte';
+</script>
+
+<SettingsSection
+	title="Indexers"
+	description="Configure Torznab, Newznab, and Gazelle indexers used to search for releases."
+>
+	<EmptyState message="Indexers management will be implemented in Issue #460." />
+</SettingsSection>

--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
+	import EmptyState from '$lib/components/settings/EmptyState.svelte';
+</script>
+
+<SettingsSection
+	title="Metadata Profiles"
+	description="Control which metadata sources and fields are used when tagging music files."
+>
+	<EmptyState message="Metadata Profiles management will be implemented in Issue #462." />
+</SettingsSection>

--- a/web/src/routes/(app)/settings/quality-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/quality-profiles/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
+	import EmptyState from '$lib/components/settings/EmptyState.svelte';
+</script>
+
+<SettingsSection
+	title="Quality Profiles"
+	description="Define which audio formats and bitrates are acceptable for automated downloading."
+>
+	<EmptyState message="Quality Profiles management will be implemented in Issue #461." />
+</SettingsSection>


### PR DESCRIPTION
## feat: Settings IA, shell navigation, and shared primitives

Closes #457

Implements the settings information architecture foundation:

### Changes

**Navigation**
- Replaced `Appearance` with `Settings` in the top-level nav (routes to `/settings`)
- `/settings` redirects to `/settings/download-clients`

**Settings shell layout** (`web/src/routes/(app)/settings/+layout.svelte`)
- Sidebar sub-nav with 5 sections: Download Clients, Indexers, Quality Profiles, Metadata Profiles, Appearance
- Active-state highlighting, responsive collapse at 700 px

**Placeholder domain pages** (each imports shared primitives)
- `download-clients/+page.svelte`
- `indexers/+page.svelte`
- `quality-profiles/+page.svelte`
- `metadata-profiles/+page.svelte`
- `appearance/+page.svelte`

**Shared primitives** (`web/src/lib/components/settings/`)
- `SettingsSection.svelte` — title/description/actions/body wrapper
- `EmptyState.svelte` — empty list placeholder with optional action button
- `SaveStatusBanner.svelte` — idle/saving/saved/error status
- `ConfirmDialog.svelte` — reusable destructive-action modal
- `LoadingSpinner.svelte` — sm/md/lg spinner
- `ErrorMessage.svelte` — error display with optional retry callback

**Unsaved guard** (`web/src/lib/stores/unsavedGuard.ts`)
- `createUnsavedGuard()` — Svelte 5 `$state`-based dirty tracking with `beforeNavigate` integration

### QA
- `npm run check`: 0 errors, 0 warnings

Builds on #468 (parent tracking issue).
