### PR TITLE
feat: frontend settings API/type coverage (#458)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4,11 +4,29 @@ import type {
 	ActivityListResponse,
 	Artist,
 	Album,
+	CreateDownloadClientRequest,
+	CreateIndexerRequest,
+	CreateMetadataProfileRequest,
+	CreateQualityProfileRequest,
+	DownloadClient,
+	Indexer,
+	ListDownloadClientsResponse,
+	ListIndexersResponse,
+	ListMetadataProfilesResponse,
+	ListQualityProfilesResponse,
+	MetadataProfile,
 	Track,
 	FormsLoginResponse,
 	FormsLogoutResponse,
 	PaginatedResponse,
-	SystemTasksResponse
+	QualityProfile,
+	SystemTasksResponse,
+	TestIndexerRequest,
+	TestIndexerResponse,
+	UpdateDownloadClientRequest,
+	UpdateIndexerRequest,
+	UpdateMetadataProfileRequest,
+	UpdateQualityProfileRequest
 } from './types';
 
 const API_BASE = (import.meta.env.VITE_CHORROSION_API_BASE ?? 'http://127.0.0.1:5150').replace(
@@ -109,6 +127,177 @@ export async function updateAppearanceSettings(
 	return request<AppearanceSettings>('/api/v1/settings/appearance', {
 		method: 'PUT',
 		body: JSON.stringify(settings)
+	});
+}
+
+export async function getDownloadClients(params?: {
+	limit?: number;
+	offset?: number;
+}): Promise<ListDownloadClientsResponse> {
+	const query = new URLSearchParams();
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	if (params?.offset !== undefined) query.set('offset', String(params.offset));
+	const qs = query.toString();
+	return request<ListDownloadClientsResponse>(
+		`/api/v1/settings/download-clients${qs ? `?${qs}` : ''}`
+	);
+}
+
+export async function getDownloadClient(id: string): Promise<DownloadClient> {
+	return request<DownloadClient>(`/api/v1/settings/download-clients/${encodeURIComponent(id)}`);
+}
+
+export async function createDownloadClient(
+	payload: CreateDownloadClientRequest
+): Promise<DownloadClient> {
+	return request<DownloadClient>('/api/v1/settings/download-clients', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function updateDownloadClient(
+	id: string,
+	payload: UpdateDownloadClientRequest
+): Promise<DownloadClient> {
+	return request<DownloadClient>(`/api/v1/settings/download-clients/${encodeURIComponent(id)}`, {
+		method: 'PUT',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function deleteDownloadClient(id: string): Promise<void> {
+	await request<unknown>(`/api/v1/settings/download-clients/${encodeURIComponent(id)}`, {
+		method: 'DELETE'
+	});
+}
+
+export async function getIndexers(params?: {
+	limit?: number;
+	offset?: number;
+}): Promise<ListIndexersResponse> {
+	const query = new URLSearchParams();
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	if (params?.offset !== undefined) query.set('offset', String(params.offset));
+	const qs = query.toString();
+	return request<ListIndexersResponse>(`/api/v1/settings/indexers${qs ? `?${qs}` : ''}`);
+}
+
+export async function getIndexer(id: string): Promise<Indexer> {
+	return request<Indexer>(`/api/v1/settings/indexers/${encodeURIComponent(id)}`);
+}
+
+export async function createIndexer(payload: CreateIndexerRequest): Promise<Indexer> {
+	return request<Indexer>('/api/v1/settings/indexers', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function updateIndexer(
+	id: string,
+	payload: UpdateIndexerRequest
+): Promise<Indexer> {
+	return request<Indexer>(`/api/v1/settings/indexers/${encodeURIComponent(id)}`, {
+		method: 'PUT',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function deleteIndexer(id: string): Promise<void> {
+	await request<unknown>(`/api/v1/settings/indexers/${encodeURIComponent(id)}`, {
+		method: 'DELETE'
+	});
+}
+
+export async function testIndexer(payload: TestIndexerRequest): Promise<TestIndexerResponse> {
+	return request<TestIndexerResponse>('/api/v1/indexers/test', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function getQualityProfiles(params?: {
+	limit?: number;
+	offset?: number;
+}): Promise<ListQualityProfilesResponse> {
+	const query = new URLSearchParams();
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	if (params?.offset !== undefined) query.set('offset', String(params.offset));
+	const qs = query.toString();
+	return request<ListQualityProfilesResponse>(
+		`/api/v1/settings/quality-profiles${qs ? `?${qs}` : ''}`
+	);
+}
+
+export async function getQualityProfile(id: string): Promise<QualityProfile> {
+	return request<QualityProfile>(`/api/v1/settings/quality-profiles/${encodeURIComponent(id)}`);
+}
+
+export async function createQualityProfile(
+	payload: CreateQualityProfileRequest
+): Promise<QualityProfile> {
+	return request<QualityProfile>('/api/v1/settings/quality-profiles', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function updateQualityProfile(
+	id: string,
+	payload: UpdateQualityProfileRequest
+): Promise<QualityProfile> {
+	return request<QualityProfile>(`/api/v1/settings/quality-profiles/${encodeURIComponent(id)}`, {
+		method: 'PUT',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function deleteQualityProfile(id: string): Promise<void> {
+	await request<unknown>(`/api/v1/settings/quality-profiles/${encodeURIComponent(id)}`, {
+		method: 'DELETE'
+	});
+}
+
+export async function getMetadataProfiles(params?: {
+	limit?: number;
+	offset?: number;
+}): Promise<ListMetadataProfilesResponse> {
+	const query = new URLSearchParams();
+	if (params?.limit !== undefined) query.set('limit', String(params.limit));
+	if (params?.offset !== undefined) query.set('offset', String(params.offset));
+	const qs = query.toString();
+	return request<ListMetadataProfilesResponse>(
+		`/api/v1/settings/metadata-profiles${qs ? `?${qs}` : ''}`
+	);
+}
+
+export async function getMetadataProfile(id: string): Promise<MetadataProfile> {
+	return request<MetadataProfile>(`/api/v1/settings/metadata-profiles/${encodeURIComponent(id)}`);
+}
+
+export async function createMetadataProfile(
+	payload: CreateMetadataProfileRequest
+): Promise<MetadataProfile> {
+	return request<MetadataProfile>('/api/v1/settings/metadata-profiles', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function updateMetadataProfile(
+	id: string,
+	payload: UpdateMetadataProfileRequest
+): Promise<MetadataProfile> {
+	return request<MetadataProfile>(`/api/v1/settings/metadata-profiles/${encodeURIComponent(id)}`, {
+		method: 'PUT',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function deleteMetadataProfile(id: string): Promise<void> {
+	await request<unknown>(`/api/v1/settings/metadata-profiles/${encodeURIComponent(id)}`, {
+		method: 'DELETE'
 	});
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type {
-	AppearanceErrorResponse,
+	ApiErrorResponse,
 	AppearanceSettings,
 	ActivityListResponse,
 	Artist,
@@ -45,6 +45,14 @@ export class ApiError extends Error {
 	}
 }
 
+/** Extracts the error message from an API response body, falling back to `fallback`. */
+export function parseApiError(body: unknown, fallback: string): string {
+	if (typeof body === 'object' && body !== null && 'error' in body) {
+		return String((body as ApiErrorResponse).error);
+	}
+	return fallback;
+}
+
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
 	const response = await fetch(`${API_BASE}${path}`, {
 		...init,
@@ -67,11 +75,7 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
 
 	if (!response.ok) {
 		const fallbackMessage = `Request failed with status ${response.status}`;
-		const apiMessage =
-			typeof body === 'object' && body !== null && 'error' in body
-				? String((body as AppearanceErrorResponse).error)
-				: fallbackMessage;
-		throw new ApiError(apiMessage, response.status, body);
+		throw new ApiError(parseApiError(body, fallbackMessage), response.status, body);
 	}
 
 	return (body ?? {}) as T;
@@ -103,10 +107,7 @@ export async function login(username: string, password: string): Promise<FormsLo
 	}
 
 	if (!response.ok) {
-		const errorMessage =
-			typeof body === 'object' && body !== null && 'error' in body
-				? String((body as { error: unknown }).error)
-				: `Login failed (${response.status})`;
+		const errorMessage = parseApiError(body, `Login failed (${response.status})`);
 		throw new ApiError(errorMessage, response.status, body);
 	}
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -10,6 +10,30 @@ export interface FormsLogoutResponse {
 	logged_out: boolean;
 }
 
+/** Shared paginated response wrapper used for all list endpoints. */
+export interface PaginatedResponse<T> {
+	items: T[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+/** Shared API error response shape returned by all endpoints on failure. */
+export interface ApiErrorResponse {
+	error: string;
+}
+
+/** Field-level validation error detail (included in 400/422 responses). */
+export interface ApiValidationFieldError {
+	field: string;
+	message: string;
+}
+
+/** Extended error shape for validation failures that include per-field errors. */
+export interface ApiValidationError extends ApiErrorResponse {
+	fields?: ApiValidationFieldError[];
+}
+
 export interface AppearanceSettings {
 	theme_mode: 'system' | 'dark' | 'light';
 	mobile_breakpoint_px: number;
@@ -27,9 +51,7 @@ export interface AppearanceSettings {
 	filter_history_limit: number;
 }
 
-export interface AppearanceErrorResponse {
-	error: string;
-}
+export type AppearanceErrorResponse = ApiErrorResponse;
 
 export interface DownloadClient {
 	id: string;
@@ -42,12 +64,7 @@ export interface DownloadClient {
 	has_password: boolean;
 }
 
-export interface ListDownloadClientsResponse {
-	items: DownloadClient[];
-	total: number;
-	limit: number;
-	offset: number;
-}
+export type ListDownloadClientsResponse = PaginatedResponse<DownloadClient>;
 
 export interface CreateDownloadClientRequest {
 	name: string;
@@ -63,15 +80,13 @@ export interface UpdateDownloadClientRequest {
 	name?: string;
 	client_type?: string;
 	base_url?: string;
-	username?: string | null;
-	password?: string | null;
-	category?: string | null;
+	username?: string;
+	password?: string;
+	category?: string;
 	enabled?: boolean;
 }
 
-export interface DownloadClientErrorResponse {
-	error: string;
-}
+export type DownloadClientErrorResponse = ApiErrorResponse;
 
 export interface Indexer {
 	id: string;
@@ -82,12 +97,7 @@ export interface Indexer {
 	has_api_key: boolean;
 }
 
-export interface ListIndexersResponse {
-	items: Indexer[];
-	total: number;
-	limit: number;
-	offset: number;
-}
+export type ListIndexersResponse = PaginatedResponse<Indexer>;
 
 export interface CreateIndexerRequest {
 	name: string;
@@ -101,13 +111,11 @@ export interface UpdateIndexerRequest {
 	name?: string;
 	base_url?: string;
 	protocol?: string;
-	api_key?: string | null;
+	api_key?: string;
 	enabled?: boolean;
 }
 
-export interface IndexerErrorResponse {
-	error: string;
-}
+export type IndexerErrorResponse = ApiErrorResponse;
 
 export interface TestIndexerRequest {
 	name: string;
@@ -131,9 +139,7 @@ export interface TestIndexerResponse {
 	capabilities: IndexerCapabilities;
 }
 
-export interface IndexerTestErrorResponse {
-	error: string;
-}
+export type IndexerTestErrorResponse = ApiErrorResponse;
 
 export interface QualityProfile {
 	id: string;
@@ -143,12 +149,7 @@ export interface QualityProfile {
 	cutoff_quality: string | null;
 }
 
-export interface ListQualityProfilesResponse {
-	items: QualityProfile[];
-	total: number;
-	limit: number;
-	offset: number;
-}
+export type ListQualityProfilesResponse = PaginatedResponse<QualityProfile>;
 
 export interface CreateQualityProfileRequest {
 	name: string;
@@ -161,12 +162,10 @@ export interface UpdateQualityProfileRequest {
 	name?: string;
 	allowed_qualities?: string[];
 	upgrade_allowed?: boolean;
-	cutoff_quality?: string | null;
+	cutoff_quality?: string;
 }
 
-export interface QualityProfileErrorResponse {
-	error: string;
-}
+export type QualityProfileErrorResponse = ApiErrorResponse;
 
 export interface MetadataProfile {
 	id: string;
@@ -176,12 +175,7 @@ export interface MetadataProfile {
 	release_statuses: string[];
 }
 
-export interface ListMetadataProfilesResponse {
-	items: MetadataProfile[];
-	total: number;
-	limit: number;
-	offset: number;
-}
+export type ListMetadataProfilesResponse = PaginatedResponse<MetadataProfile>;
 
 export interface CreateMetadataProfileRequest {
 	name: string;
@@ -197,9 +191,7 @@ export interface UpdateMetadataProfileRequest {
 	release_statuses?: string[];
 }
 
-export interface MetadataProfileErrorResponse {
-	error: string;
-}
+export type MetadataProfileErrorResponse = ApiErrorResponse;
 
 export interface SseMessage<T = unknown> {
 	sequence?: number;
@@ -241,13 +233,6 @@ export interface SystemTasksResponse {
 	items: SystemTask[];
 	total: number;
 	max_concurrent_jobs: number;
-}
-
-export interface PaginatedResponse<T> {
-	items: T[];
-	total: number;
-	limit: number;
-	offset: number;
 }
 
 export interface Artist {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -31,6 +31,176 @@ export interface AppearanceErrorResponse {
 	error: string;
 }
 
+export interface DownloadClient {
+	id: string;
+	name: string;
+	client_type: string;
+	base_url: string;
+	username: string | null;
+	category: string | null;
+	enabled: boolean;
+	has_password: boolean;
+}
+
+export interface ListDownloadClientsResponse {
+	items: DownloadClient[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+export interface CreateDownloadClientRequest {
+	name: string;
+	client_type: string;
+	base_url: string;
+	username?: string | null;
+	password?: string | null;
+	category?: string | null;
+	enabled?: boolean;
+}
+
+export interface UpdateDownloadClientRequest {
+	name?: string;
+	client_type?: string;
+	base_url?: string;
+	username?: string | null;
+	password?: string | null;
+	category?: string | null;
+	enabled?: boolean;
+}
+
+export interface DownloadClientErrorResponse {
+	error: string;
+}
+
+export interface Indexer {
+	id: string;
+	name: string;
+	base_url: string;
+	protocol: string;
+	enabled: boolean;
+	has_api_key: boolean;
+}
+
+export interface ListIndexersResponse {
+	items: Indexer[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+export interface CreateIndexerRequest {
+	name: string;
+	base_url: string;
+	protocol: string;
+	api_key?: string | null;
+	enabled?: boolean;
+}
+
+export interface UpdateIndexerRequest {
+	name?: string;
+	base_url?: string;
+	protocol?: string;
+	api_key?: string | null;
+	enabled?: boolean;
+}
+
+export interface IndexerErrorResponse {
+	error: string;
+}
+
+export interface TestIndexerRequest {
+	name: string;
+	base_url: string;
+	protocol: string;
+	api_key?: string | null;
+}
+
+export interface IndexerCapabilities {
+	supports_search: boolean;
+	supports_rss: boolean;
+	supports_capabilities_detection: boolean;
+	supports_categories: boolean;
+	supported_categories: string[];
+}
+
+export interface TestIndexerResponse {
+	success: boolean;
+	message: string;
+	protocol: string;
+	capabilities: IndexerCapabilities;
+}
+
+export interface IndexerTestErrorResponse {
+	error: string;
+}
+
+export interface QualityProfile {
+	id: string;
+	name: string;
+	allowed_qualities: string[];
+	upgrade_allowed: boolean;
+	cutoff_quality: string | null;
+}
+
+export interface ListQualityProfilesResponse {
+	items: QualityProfile[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+export interface CreateQualityProfileRequest {
+	name: string;
+	allowed_qualities: string[];
+	upgrade_allowed?: boolean;
+	cutoff_quality?: string | null;
+}
+
+export interface UpdateQualityProfileRequest {
+	name?: string;
+	allowed_qualities?: string[];
+	upgrade_allowed?: boolean;
+	cutoff_quality?: string | null;
+}
+
+export interface QualityProfileErrorResponse {
+	error: string;
+}
+
+export interface MetadataProfile {
+	id: string;
+	name: string;
+	primary_album_types: string[];
+	secondary_album_types: string[];
+	release_statuses: string[];
+}
+
+export interface ListMetadataProfilesResponse {
+	items: MetadataProfile[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+export interface CreateMetadataProfileRequest {
+	name: string;
+	primary_album_types?: string[];
+	secondary_album_types?: string[];
+	release_statuses?: string[];
+}
+
+export interface UpdateMetadataProfileRequest {
+	name?: string;
+	primary_album_types?: string[];
+	secondary_album_types?: string[];
+	release_statuses?: string[];
+}
+
+export interface MetadataProfileErrorResponse {
+	error: string;
+}
+
 export interface SseMessage<T = unknown> {
 	sequence?: number;
 	tick?: number;


### PR DESCRIPTION
## feat: frontend settings API/type coverage for four domains

Closes #458
Builds on #469

Adds complete frontend DTO and API method coverage for settings domains so the upcoming UI pages can use typed contracts end-to-end.

### Included

- Added TypeScript DTOs in `web/src/lib/types.ts` for:
  - Download Clients: list/item/create/update/error
  - Indexers: list/item/create/update/error
  - Indexer test endpoint contracts (`/api/v1/indexers/test`)
  - Quality Profiles: list/item/create/update/error
  - Metadata Profiles: list/item/create/update/error

- Added typed API functions in `web/src/lib/api.ts` for:
  - Download Clients CRUD
  - Indexers CRUD + `testIndexer`
  - Quality Profiles CRUD
  - Metadata Profiles CRUD

### Notes

- Backend currently exposes indexer test endpoint at `/api/v1/indexers/test`.
- No dedicated download-client test endpoint exists yet in current backend routes.

### Validation

- `npm run check` passed with 0 errors and 0 warnings.
