### PR TITLE
feat(web): harden settings UX (#463)

### DIFF
--- a/web/src/lib/settingsValidation.test.ts
+++ b/web/src/lib/settingsValidation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '$lib/api';
+import { classifyFormError } from '$lib/settingsValidation';
+
+describe('classifyFormError', () => {
+	it('returns structured field errors from API response bodies', () => {
+		const error = new ApiError('Validation failed', 400, {
+			fields: [{ field: 'name', message: 'Name is required.' }]
+		});
+
+		const result = classifyFormError(error, []);
+
+		expect(result.fieldErrors).toEqual({ name: 'Name is required.' });
+		expect(result.bannerMessage).toBe('');
+	});
+
+	it('returns banner error when no field errors are found', () => {
+		const error = new ApiError('', 409, { error: 'Download client already exists' });
+
+		const result = classifyFormError(error, []);
+
+		expect(result.fieldErrors).toEqual({});
+		expect(result.bannerMessage).toBe('Download client already exists');
+	});
+
+	it('matches field errors using message rules', () => {
+		const error = new ApiError('Indexer name already exists', 409, {});
+
+		const result = classifyFormError(error, [
+			{ field: 'name', messages: ['already exists'] }
+		]);
+
+		expect(result.fieldErrors).toEqual({ name: 'Indexer name already exists' });
+		expect(result.bannerMessage).toBe('');
+	});
+
+	it('handles non-ApiError values as banner-only failures', () => {
+		const result = classifyFormError(new Error('Network failed'), [
+			{ field: 'name', messages: ['already exists'] }
+		]);
+
+		expect(result.fieldErrors).toEqual({});
+		expect(result.bannerMessage).toBe('Network failed');
+	});
+});

--- a/web/src/lib/settingsValidation.ts
+++ b/web/src/lib/settingsValidation.ts
@@ -1,0 +1,65 @@
+import { ApiError } from '$lib/api';
+import type { ApiValidationError } from '$lib/types';
+
+export interface FieldValidationRule {
+	field: string;
+	messages: string[];
+}
+
+export interface ClassifiedFormError {
+	fieldErrors: Record<string, string>;
+	bannerMessage: string;
+}
+
+function getBodyMessage(body: unknown): string {
+	if (typeof body === 'object' && body !== null && 'error' in body) {
+		return String((body as { error?: unknown }).error ?? '');
+	}
+	return '';
+}
+
+function extractStructuredFieldErrors(body: unknown): Record<string, string> {
+	const fieldErrors: Record<string, string> = {};
+	if (
+		typeof body === 'object' &&
+		body !== null &&
+		'fields' in body &&
+		Array.isArray((body as ApiValidationError).fields)
+	) {
+		for (const fieldError of (body as ApiValidationError).fields ?? []) {
+			if (fieldError.field && fieldError.message) {
+				fieldErrors[fieldError.field] = fieldError.message;
+			}
+		}
+	}
+	return fieldErrors;
+}
+
+export function classifyFormError(error: unknown, rules: FieldValidationRule[]): ClassifiedFormError {
+	const fieldErrors: Record<string, string> = {};
+
+	if (error instanceof ApiError) {
+		Object.assign(fieldErrors, extractStructuredFieldErrors(error.body));
+
+		const message = error.message.trim();
+		const bodyMessage = getBodyMessage(error.body).trim();
+		const combined = [message, bodyMessage].filter(Boolean).join(' ');
+
+		for (const rule of rules) {
+			if (fieldErrors[rule.field]) continue;
+			if (rule.messages.some((candidate) => combined.includes(candidate))) {
+				fieldErrors[rule.field] = message || bodyMessage || 'Invalid value';
+			}
+		}
+
+		return {
+			fieldErrors,
+			bannerMessage: Object.keys(fieldErrors).length > 0 ? '' : message || bodyMessage
+		};
+	}
+
+	return {
+		fieldErrors,
+		bannerMessage: error instanceof Error ? error.message : 'Save failed.'
+	};
+}

--- a/web/src/lib/stores/unsavedGuard.test.ts
+++ b/web/src/lib/stores/unsavedGuard.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type BeforeNavigateHandler = (args: {
+	cancel: () => void;
+	to?: { url: URL } | null;
+}) => void;
+
+const { mockGoto, navigationState } = vi.hoisted(() => ({
+	mockGoto: vi.fn(async (_href: string) => {}),
+	navigationState: {
+		handler: null as BeforeNavigateHandler | null
+	}
+}));
+
+vi.mock('$app/navigation', () => ({
+	beforeNavigate: (handler: BeforeNavigateHandler) => {
+		navigationState.handler = handler;
+	},
+	goto: mockGoto
+}));
+
+import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
+
+describe('useUnsavedGuard', () => {
+	beforeEach(() => {
+		navigationState.handler = null;
+		mockGoto.mockClear();
+	});
+
+	it('blocks navigation and stores pending href when dirty', () => {
+		const onBlocked = vi.fn();
+		const guard = useUnsavedGuard(onBlocked);
+		guard.markDirty();
+		const cancel = vi.fn();
+
+		navigationState.handler?.({
+			cancel,
+			to: { url: new URL('http://localhost/settings/indexers') }
+		});
+
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(onBlocked).toHaveBeenCalledOnce();
+		expect(guard.hasPendingNavigation).toBe(true);
+	});
+
+	it('confirmNavigation resumes pending navigation', async () => {
+		const guard = useUnsavedGuard();
+		guard.markDirty();
+
+		navigationState.handler?.({
+			cancel: vi.fn(),
+			to: { url: new URL('http://localhost/settings/quality-profiles') }
+		});
+
+		await guard.confirmNavigation();
+
+		expect(mockGoto).toHaveBeenCalledWith('http://localhost/settings/quality-profiles');
+		expect(guard.hasPendingNavigation).toBe(false);
+		expect(guard.isDirty).toBe(false);
+	});
+
+	it('discardNavigation clears pending navigation without navigating', () => {
+		const guard = useUnsavedGuard();
+		guard.markDirty();
+
+		navigationState.handler?.({
+			cancel: vi.fn(),
+			to: { url: new URL('http://localhost/settings/download-clients') }
+		});
+
+		guard.discardNavigation();
+
+		expect(guard.hasPendingNavigation).toBe(false);
+		expect(mockGoto).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/lib/stores/unsavedGuard.ts
+++ b/web/src/lib/stores/unsavedGuard.ts
@@ -2,10 +2,10 @@
  * Unsaved guard store.
  *
  * Usage:
- *   import { createUnsavedGuard } from '$lib/stores/unsavedGuard';
+ *   import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
  *
  *   // In a settings page component:
- *   const guard = createUnsavedGuard(() => { showConfirmDialog = true; });
+ *   const guard = useUnsavedGuard(() => { showConfirmDialog = true; });
  *
  *   // Mark dirty when a field changes:
  *   guard.markDirty();
@@ -18,16 +18,19 @@
  *
  *   // Navigation is blocked automatically via beforeNavigate; the optional
  *   // onNavigateBlocked callback lets you open a confirm dialog in response.
+ *   // Call guard.confirmNavigation() after the user confirms to continue.
  */
 
-import { beforeNavigate } from '$app/navigation';
+import { beforeNavigate, goto } from '$app/navigation';
 
 export interface UnsavedGuard {
 	readonly isDirty: boolean;
+	readonly hasPendingNavigation: boolean;
 	markDirty: () => void;
 	markClean: () => void;
-	/** Returns true if navigation should proceed (not dirty or user confirmed). */
-	confirmNavigation: () => boolean;
+	/** Continue the blocked navigation if one is pending. */
+	confirmNavigation: () => Promise<boolean>;
+	discardNavigation: () => void;
 }
 
 /**
@@ -35,14 +38,16 @@ export interface UnsavedGuard {
  * Call this once at component initialisation (not inside a reactive block).
  *
  * @param onNavigateBlocked - optional callback invoked when navigation is blocked;
- *   use this to open your ConfirmDialog. Resolve by calling markClean() + goto().
+ *   use this to open your ConfirmDialog. Resolve by calling confirmNavigation().
  */
-export function createUnsavedGuard(onNavigateBlocked?: () => void): UnsavedGuard {
+export function useUnsavedGuard(onNavigateBlocked?: () => void): UnsavedGuard {
 	let dirty = false;
+	let pendingHref: string | null = null;
 
-	beforeNavigate(({ cancel }) => {
+	beforeNavigate(({ cancel, to }) => {
 		if (dirty) {
 			cancel();
+			pendingHref = to?.url.href ?? null;
 			if (onNavigateBlocked) {
 				onNavigateBlocked();
 			}
@@ -53,14 +58,30 @@ export function createUnsavedGuard(onNavigateBlocked?: () => void): UnsavedGuard
 		get isDirty() {
 			return dirty;
 		},
+		get hasPendingNavigation() {
+			return pendingHref !== null;
+		},
 		markDirty() {
 			dirty = true;
 		},
 		markClean() {
 			dirty = false;
 		},
-		confirmNavigation() {
-			return !dirty;
+		async confirmNavigation() {
+			dirty = false;
+			if (pendingHref) {
+				const href = pendingHref;
+				pendingHref = null;
+				await goto(href);
+			}
+			return true;
+		},
+		discardNavigation() {
+			pendingHref = null;
 		}
 	};
+}
+
+export function createUnsavedGuard(onNavigateBlocked?: () => void): UnsavedGuard {
+	return useUnsavedGuard(onNavigateBlocked);
 }

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -14,6 +14,8 @@
 		deleteDownloadClient,
 		ApiError
 	} from '$lib/api';
+	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
+	import { classifyFormError } from '$lib/settingsValidation';
 	import type {
 		DownloadClient,
 		CreateDownloadClientRequest,
@@ -26,6 +28,9 @@
 	let loadError = $state('');
 	let saveStatus = $state<SaveStatus>('idle');
 	let saveError = $state('');
+	let formDirty = $state(false);
+	let leaveDialogOpen = $state(false);
+	let initialFormSnapshot = '';
 
 	// modal state
 	let modalOpen = $state(false);
@@ -49,6 +54,37 @@
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
+	const unsavedGuard = useUnsavedGuard(() => {
+		leaveDialogOpen = true;
+	});
+
+	function getFormSnapshot(): string {
+		return JSON.stringify({
+			name: formName.trim(),
+			clientType: formClientType,
+			baseUrl: formBaseUrl.trim(),
+			username: formUsername.trim(),
+			password: formPassword,
+			category: formCategory.trim(),
+			enabled: formEnabled
+		});
+	}
+
+	function syncDirtyState() {
+		formDirty = getFormSnapshot() !== initialFormSnapshot;
+		if (formDirty) {
+			unsavedGuard.markDirty();
+		} else {
+			unsavedGuard.markClean();
+		}
+	}
+
+	function clearFieldError(field: string) {
+		if (formErrors[field]) {
+			const { [field]: _removed, ...rest } = formErrors;
+			formErrors = rest;
+		}
+	}
 
 	function scheduleBannerClear() {
 		if (saveStatusTimer !== null) clearTimeout(saveStatusTimer);
@@ -98,7 +134,10 @@
 		formCategory = '';
 		formEnabled = true;
 		formErrors = {};
+		leaveDialogOpen = false;
 		modalOpen = true;
+		initialFormSnapshot = getFormSnapshot();
+		syncDirtyState();
 	}
 
 	function openEdit(client: DownloadClient) {
@@ -111,10 +150,18 @@
 		formCategory = client.category ?? '';
 		formEnabled = client.enabled;
 		formErrors = {};
+		leaveDialogOpen = false;
 		modalOpen = true;
+		initialFormSnapshot = getFormSnapshot();
+		syncDirtyState();
 	}
 
 	function closeModal() {
+		if (formDirty) {
+			leaveDialogOpen = true;
+			return;
+		}
+		unsavedGuard.discardNavigation();
 		modalOpen = false;
 		editingClient = null;
 	}
@@ -170,11 +217,28 @@
 				clients = [...clients, created];
 			}
 			closeModal();
+			unsavedGuard.markClean();
+			formDirty = false;
+			initialFormSnapshot = getFormSnapshot();
 			saveStatus = 'saved';
 			scheduleBannerClear();
 		} catch (err) {
-			saveError = err instanceof ApiError ? err.message : 'Save failed.';
-			saveStatus = 'error';
+			const classified = classifyFormError(err, [
+				{ field: 'name', messages: ['name cannot be empty', 'already exists'] },
+				{
+					field: 'base_url',
+					messages: ['base_url must be a valid http or https URL with a host']
+				},
+				{ field: 'client_type', messages: ['unsupported client_type'] }
+			]);
+			if (Object.keys(classified.fieldErrors).length > 0) {
+				formErrors = { ...formErrors, ...classified.fieldErrors };
+				saveStatus = 'idle';
+				saveError = '';
+			} else {
+				saveError = classified.bannerMessage || 'Save failed.';
+				saveStatus = 'error';
+			}
 		} finally {
 			formSaving = false;
 		}
@@ -222,6 +286,16 @@
 
 	function clientTypeLabel(type: string): string {
 		return CLIENT_TYPES.find((t) => t.value === type)?.label ?? type;
+	}
+
+	function confirmLeave() {
+		leaveDialogOpen = false;
+		void unsavedGuard.confirmNavigation();
+	}
+
+	function cancelLeave() {
+		leaveDialogOpen = false;
+		unsavedGuard.discardNavigation();
 	}
 </script>
 
@@ -302,13 +376,29 @@
 			>
 				<div class="field" class:has-error={!!formErrors.name}>
 					<label for="dc-name">Name <span aria-hidden="true">*</span></label>
-					<input id="dc-name" type="text" bind:value={formName} placeholder="My qBittorrent" />
+					<input
+						id="dc-name"
+						type="text"
+						bind:value={formName}
+						placeholder="My qBittorrent"
+						oninput={() => {
+							clearFieldError('name');
+							syncDirtyState();
+						}}
+					/>
 					{#if formErrors.name}<span class="field-error">{formErrors.name}</span>{/if}
 				</div>
 
 				<div class="field">
 					<label for="dc-type">Client Type</label>
-					<select id="dc-type" bind:value={formClientType}>
+					<select
+						id="dc-type"
+						bind:value={formClientType}
+						onchange={() => {
+							clearFieldError('client_type');
+							syncDirtyState();
+						}}
+					>
 						{#each CLIENT_TYPES as type}
 							<option value={type.value}>{type.label}</option>
 						{/each}
@@ -322,13 +412,26 @@
 						type="url"
 						bind:value={formBaseUrl}
 						placeholder="http://localhost:8080"
+						oninput={() => {
+							clearFieldError('base_url');
+							syncDirtyState();
+						}}
 					/>
 					{#if formErrors.base_url}<span class="field-error">{formErrors.base_url}</span>{/if}
 				</div>
 
 				<div class="field">
 					<label for="dc-username">Username</label>
-					<input id="dc-username" type="text" bind:value={formUsername} autocomplete="username" />
+					<input
+						id="dc-username"
+						type="text"
+						bind:value={formUsername}
+						autocomplete="username"
+						oninput={() => {
+							clearFieldError('username');
+							syncDirtyState();
+						}}
+					/>
 				</div>
 
 				<div class="field">
@@ -343,22 +446,43 @@
 						type="password"
 						bind:value={formPassword}
 						autocomplete="current-password"
+						oninput={() => {
+							clearFieldError('password');
+							syncDirtyState();
+						}}
 					/>
 				</div>
 
 				<div class="field">
 					<label for="dc-category">Category</label>
-					<input id="dc-category" type="text" bind:value={formCategory} placeholder="chorrosion" />
+					<input
+						id="dc-category"
+						type="text"
+						bind:value={formCategory}
+						placeholder="chorrosion"
+						oninput={() => {
+							clearFieldError('category');
+							syncDirtyState();
+						}}
+					/>
 				</div>
 
 				<div class="field field-inline">
 					<label for="dc-enabled">Enabled</label>
-					<input id="dc-enabled" type="checkbox" bind:checked={formEnabled} />
+					<input
+						id="dc-enabled"
+						type="checkbox"
+						bind:checked={formEnabled}
+						onchange={() => {
+							clearFieldError('enabled');
+							syncDirtyState();
+						}}
+					/>
 				</div>
 
 				<div class="modal-actions">
 					<button type="button" class="btn-cancel" onclick={closeModal}>Cancel</button>
-					<button type="submit" class="btn-primary" disabled={formSaving}>
+					<button type="submit" class="btn-primary" disabled={formSaving || !formDirty}>
 						{formSaving ? 'Saving…' : editingClient ? 'Save Changes' : 'Add Client'}
 					</button>
 				</div>
@@ -366,6 +490,16 @@
 		</div>
 	</div>
 {/if}
+
+<ConfirmDialog
+	open={leaveDialogOpen}
+	title="Leave with unsaved changes?"
+	message="You have unsaved changes. Leave anyway?"
+	confirmLabel="Leave"
+	destructive
+	onconfirm={confirmLeave}
+	oncancel={cancelLeave}
+/>
 
 <!-- ── Delete confirmation ──────────────────────────────────────────────── -->
 <ConfirmDialog

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -216,10 +216,10 @@
 				const created = await createDownloadClient(payload);
 				clients = [...clients, created];
 			}
-			closeModal();
 			unsavedGuard.markClean();
 			formDirty = false;
 			initialFormSnapshot = getFormSnapshot();
+			closeModal();
 			saveStatus = 'saved';
 			scheduleBannerClear();
 		} catch (err) {
@@ -290,6 +290,8 @@
 
 	function confirmLeave() {
 		leaveDialogOpen = false;
+		modalOpen = false;
+		editingClient = null;
 		void unsavedGuard.confirmNavigation();
 	}
 
@@ -389,7 +391,7 @@
 					{#if formErrors.name}<span class="field-error">{formErrors.name}</span>{/if}
 				</div>
 
-				<div class="field">
+				<div class="field" class:has-error={!!formErrors.client_type}>
 					<label for="dc-type">Client Type</label>
 					<select
 						id="dc-type"
@@ -403,6 +405,7 @@
 							<option value={type.value}>{type.label}</option>
 						{/each}
 					</select>
+					{#if formErrors.client_type}<span class="field-error">{formErrors.client_type}</span>{/if}
 				</div>
 
 				<div class="field" class:has-error={!!formErrors.base_url}>

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -15,6 +15,8 @@
 		testIndexer,
 		ApiError
 	} from '$lib/api';
+	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
+	import { classifyFormError } from '$lib/settingsValidation';
 	import type {
 		Indexer,
 		CreateIndexerRequest,
@@ -28,6 +30,9 @@
 	let loadError = $state('');
 	let saveStatus = $state<SaveStatus>('idle');
 	let saveError = $state('');
+	let formDirty = $state(false);
+	let leaveDialogOpen = $state(false);
+	let initialFormSnapshot = '';
 
 	// modal state
 	let modalOpen = $state(false);
@@ -54,6 +59,35 @@
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
+	const unsavedGuard = useUnsavedGuard(() => {
+		leaveDialogOpen = true;
+	});
+
+	function getFormSnapshot(): string {
+		return JSON.stringify({
+			name: formName.trim(),
+			protocol: formProtocol,
+			baseUrl: formBaseUrl.trim(),
+			apiKey: formApiKey,
+			enabled: formEnabled
+		});
+	}
+
+	function syncDirtyState() {
+		formDirty = getFormSnapshot() !== initialFormSnapshot;
+		if (formDirty) {
+			unsavedGuard.markDirty();
+		} else {
+			unsavedGuard.markClean();
+		}
+	}
+
+	function clearFieldError(field: string) {
+		if (formErrors[field]) {
+			const { [field]: _removed, ...rest } = formErrors;
+			formErrors = rest;
+		}
+	}
 
 	function scheduleBannerClear() {
 		if (saveStatusTimer !== null) clearTimeout(saveStatusTimer);
@@ -102,7 +136,10 @@
 		testStatus = 'idle';
 		testResult = null;
 		testError = '';
+		leaveDialogOpen = false;
 		modalOpen = true;
+		initialFormSnapshot = getFormSnapshot();
+		syncDirtyState();
 	}
 
 	function openEdit(indexer: Indexer) {
@@ -116,10 +153,18 @@
 		testStatus = 'idle';
 		testResult = null;
 		testError = '';
+		leaveDialogOpen = false;
 		modalOpen = true;
+		initialFormSnapshot = getFormSnapshot();
+		syncDirtyState();
 	}
 
 	function closeModal() {
+		if (formDirty) {
+			leaveDialogOpen = true;
+			return;
+		}
+		unsavedGuard.discardNavigation();
 		modalOpen = false;
 		editingIndexer = null;
 	}
@@ -175,11 +220,31 @@
 				indexers = [...indexers, created];
 			}
 			closeModal();
+			unsavedGuard.markClean();
+			formDirty = false;
+			initialFormSnapshot = getFormSnapshot();
 			saveStatus = 'saved';
 			scheduleBannerClear();
 		} catch (err) {
-			saveError = err instanceof ApiError ? err.message : 'Save failed.';
-			saveStatus = 'error';
+			const classified = classifyFormError(err, [
+				{ field: 'name', messages: ['name cannot be empty', 'already exists'] },
+				{
+					field: 'base_url',
+					messages: [
+						'base_url must be a valid http or https URL with a host',
+						'Indexer base_url must be a valid http or https URL with a host'
+					]
+				},
+				{ field: 'protocol', messages: ['unsupported protocol', 'invalid value'] }
+			]);
+			if (Object.keys(classified.fieldErrors).length > 0) {
+				formErrors = { ...formErrors, ...classified.fieldErrors };
+				saveStatus = 'idle';
+				saveError = '';
+			} else {
+				saveError = classified.bannerMessage || 'Save failed.';
+				saveStatus = 'error';
+			}
 		} finally {
 			formSaving = false;
 		}
@@ -254,6 +319,18 @@
 
 	function protocolLabel(protocol: string): string {
 		return PROTOCOLS.find((p) => p.value === protocol)?.label ?? protocol;
+	}
+
+	function confirmLeave() {
+		leaveDialogOpen = false;
+		modalOpen = false;
+		editingIndexer = null;
+		void unsavedGuard.confirmNavigation();
+	}
+
+	function cancelLeave() {
+		leaveDialogOpen = false;
+		unsavedGuard.discardNavigation();
 	}
 </script>
 
@@ -334,13 +411,29 @@
 			>
 				<div class="field" class:has-error={!!formErrors.name}>
 					<label for="idx-name">Name <span aria-hidden="true">*</span></label>
-					<input id="idx-name" type="text" bind:value={formName} placeholder="My Indexer" />
+					<input
+						id="idx-name"
+						type="text"
+						bind:value={formName}
+						placeholder="My Indexer"
+						oninput={() => {
+							clearFieldError('name');
+							syncDirtyState();
+						}}
+					/>
 					{#if formErrors.name}<span class="field-error">{formErrors.name}</span>{/if}
 				</div>
 
 				<div class="field">
 					<label for="idx-protocol">Protocol</label>
-					<select id="idx-protocol" bind:value={formProtocol}>
+					<select
+						id="idx-protocol"
+						bind:value={formProtocol}
+						onchange={() => {
+							clearFieldError('protocol');
+							syncDirtyState();
+						}}
+					>
 						{#each PROTOCOLS as p}
 							<option value={p.value}>{p.label}</option>
 						{/each}
@@ -354,6 +447,10 @@
 						type="url"
 						bind:value={formBaseUrl}
 						placeholder="http://localhost:9117"
+						oninput={() => {
+							clearFieldError('base_url');
+							syncDirtyState();
+						}}
 					/>
 					{#if formErrors.base_url}<span class="field-error">{formErrors.base_url}</span>{/if}
 				</div>
@@ -365,12 +462,29 @@
 							<span class="hint">(leave blank to keep existing)</span>
 						{/if}
 					</label>
-					<input id="idx-apikey" type="password" bind:value={formApiKey} autocomplete="off" />
+					<input
+						id="idx-apikey"
+						type="password"
+						bind:value={formApiKey}
+						autocomplete="off"
+						oninput={() => {
+							clearFieldError('api_key');
+							syncDirtyState();
+						}}
+					/>
 				</div>
 
 				<div class="field field-inline">
 					<label for="idx-enabled">Enabled</label>
-					<input id="idx-enabled" type="checkbox" bind:checked={formEnabled} />
+					<input
+						id="idx-enabled"
+						type="checkbox"
+						bind:checked={formEnabled}
+						onchange={() => {
+							clearFieldError('enabled');
+							syncDirtyState();
+						}}
+					/>
 				</div>
 
 				<!-- Test result banner -->
@@ -404,7 +518,7 @@
 					>
 						{testStatus === 'testing' ? 'Testing…' : 'Test'}
 					</button>
-					<button type="submit" class="btn-primary" disabled={formSaving}>
+					<button type="submit" class="btn-primary" disabled={formSaving || !formDirty}>
 						{formSaving ? 'Saving…' : editingIndexer ? 'Save Changes' : 'Add Indexer'}
 					</button>
 				</div>
@@ -412,6 +526,16 @@
 		</div>
 	</div>
 {/if}
+
+<ConfirmDialog
+	open={leaveDialogOpen}
+	title="Leave with unsaved changes?"
+	message="You have unsaved changes. Leave anyway?"
+	confirmLabel="Leave"
+	destructive
+	onconfirm={confirmLeave}
+	oncancel={cancelLeave}
+/>
 
 <!-- ── Delete confirmation ──────────────────────────────────────────────── -->
 <ConfirmDialog

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -219,10 +219,10 @@
 				const created = await createIndexer(payload);
 				indexers = [...indexers, created];
 			}
-			closeModal();
 			unsavedGuard.markClean();
 			formDirty = false;
 			initialFormSnapshot = getFormSnapshot();
+			closeModal();
 			saveStatus = 'saved';
 			scheduleBannerClear();
 		} catch (err) {
@@ -424,7 +424,7 @@
 					{#if formErrors.name}<span class="field-error">{formErrors.name}</span>{/if}
 				</div>
 
-				<div class="field">
+				<div class="field" class:has-error={!!formErrors.protocol}>
 					<label for="idx-protocol">Protocol</label>
 					<select
 						id="idx-protocol"
@@ -438,6 +438,7 @@
 							<option value={p.value}>{p.label}</option>
 						{/each}
 					</select>
+					{#if formErrors.protocol}<span class="field-error">{formErrors.protocol}</span>{/if}
 				</div>
 
 				<div class="field" class:has-error={!!formErrors.base_url}>

--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -14,6 +14,8 @@
 		deleteMetadataProfile,
 		ApiError
 	} from '$lib/api';
+	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
+	import { classifyFormError } from '$lib/settingsValidation';
 	import type {
 		MetadataProfile,
 		CreateMetadataProfileRequest,
@@ -66,6 +68,9 @@
 	let loadError = $state('');
 	let saveStatus = $state<SaveStatus>('idle');
 	let saveError = $state('');
+	let formDirty = $state(false);
+	let leaveDialogOpen = $state(false);
+	let initialFormSnapshot = '';
 
 	let modalOpen = $state(false);
 	let editingProfile = $state<MetadataProfile | null>(null);
@@ -85,6 +90,34 @@
 	let deleting = $state(false);
 
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
+	const unsavedGuard = useUnsavedGuard(() => {
+		leaveDialogOpen = true;
+	});
+
+	function getFormSnapshot(): string {
+		return JSON.stringify({
+			name: formName.trim(),
+			primaryAlbumTypes: orderedValues(formPrimaryTypes, PRIMARY_ALBUM_TYPE_PRESETS),
+			secondaryAlbumTypes: orderedValues(formSecondaryTypes, SECONDARY_ALBUM_TYPE_PRESETS),
+			releaseStatuses: orderedValues(formReleaseStatuses, RELEASE_STATUS_PRESETS)
+		});
+	}
+
+	function syncDirtyState() {
+		formDirty = getFormSnapshot() !== initialFormSnapshot;
+		if (formDirty) {
+			unsavedGuard.markDirty();
+		} else {
+			unsavedGuard.markClean();
+		}
+	}
+
+	function clearFieldError(field: string) {
+		if (formErrors[field]) {
+			const { [field]: _removed, ...rest } = formErrors;
+			formErrors = rest;
+		}
+	}
 
 	let primaryTypeOptions = $derived(
 		allOptions(
@@ -142,7 +175,10 @@
 		formCustomSecondaryType = '';
 		formCustomReleaseStatus = '';
 		formErrors = {};
+		leaveDialogOpen = false;
 		modalOpen = true;
+		initialFormSnapshot = getFormSnapshot();
+		syncDirtyState();
 	}
 
 	function openEdit(profile: MetadataProfile) {
@@ -155,10 +191,18 @@
 		formCustomSecondaryType = '';
 		formCustomReleaseStatus = '';
 		formErrors = {};
+		leaveDialogOpen = false;
 		modalOpen = true;
+		initialFormSnapshot = getFormSnapshot();
+		syncDirtyState();
 	}
 
 	function closeModal() {
+		if (formDirty) {
+			leaveDialogOpen = true;
+			return;
+		}
+		unsavedGuard.discardNavigation();
 		modalOpen = false;
 		editingProfile = null;
 	}
@@ -183,6 +227,7 @@
 		if (!trimmed) return;
 		setSet(new Set([...currentSet, trimmed]));
 		setField('');
+		syncDirtyState();
 	}
 
 	function validateForm(): boolean {
@@ -224,11 +269,23 @@
 			}
 
 			closeModal();
+			unsavedGuard.markClean();
+			formDirty = false;
+			initialFormSnapshot = getFormSnapshot();
 			saveStatus = 'saved';
 			scheduleBannerClear();
 		} catch (err) {
-			saveError = err instanceof ApiError ? err.message : 'Save failed.';
-			saveStatus = 'error';
+			const classified = classifyFormError(err, [
+				{ field: 'name', messages: ['name cannot be empty', 'already exists'] }
+			]);
+			if (Object.keys(classified.fieldErrors).length > 0) {
+				formErrors = { ...formErrors, ...classified.fieldErrors };
+				saveStatus = 'idle';
+				saveError = '';
+			} else {
+				saveError = classified.bannerMessage || 'Save failed.';
+				saveStatus = 'error';
+			}
 		} finally {
 			formSaving = false;
 		}
@@ -260,6 +317,18 @@
 			deleteDialogOpen = false;
 			deleteTarget = null;
 		}
+	}
+
+	function confirmLeave() {
+		leaveDialogOpen = false;
+		modalOpen = false;
+		editingProfile = null;
+		void unsavedGuard.confirmNavigation();
+	}
+
+	function cancelLeave() {
+		leaveDialogOpen = false;
+		unsavedGuard.discardNavigation();
 	}
 </script>
 
@@ -349,6 +418,10 @@
 						type="text"
 						bind:value={formName}
 						placeholder="MusicBrainz Default"
+						oninput={() => {
+							clearFieldError('name');
+							syncDirtyState();
+						}}
 					/>
 					{#if formErrors.name}<span class="field-error">{formErrors.name}</span>{/if}
 				</div>
@@ -361,7 +434,11 @@
 								<input
 									type="checkbox"
 									checked={formPrimaryTypes.has(value)}
-									onchange={() => (formPrimaryTypes = toggleSelection(formPrimaryTypes, value))}
+									onchange={() => {
+									formPrimaryTypes = toggleSelection(formPrimaryTypes, value);
+									clearFieldError('primary_album_types');
+									syncDirtyState();
+								}}
 								/>
 								{value}
 							</label>
@@ -372,6 +449,10 @@
 							type="text"
 							bind:value={formCustomPrimaryType}
 							placeholder="Custom primary type"
+							oninput={() => {
+								clearFieldError('primary_album_types');
+								syncDirtyState();
+							}}
 							onkeydown={(e) => {
 								if (e.key === 'Enter') {
 									e.preventDefault();
@@ -408,8 +489,11 @@
 								<input
 									type="checkbox"
 									checked={formSecondaryTypes.has(value)}
-									onchange={() =>
-										(formSecondaryTypes = toggleSelection(formSecondaryTypes, value))}
+									onchange={() => {
+									formSecondaryTypes = toggleSelection(formSecondaryTypes, value);
+									clearFieldError('secondary_album_types');
+									syncDirtyState();
+								}}
 								/>
 								{value}
 							</label>
@@ -420,6 +504,10 @@
 							type="text"
 							bind:value={formCustomSecondaryType}
 							placeholder="Custom secondary type"
+							oninput={() => {
+								clearFieldError('secondary_album_types');
+								syncDirtyState();
+							}}
 							onkeydown={(e) => {
 								if (e.key === 'Enter') {
 									e.preventDefault();
@@ -456,8 +544,11 @@
 								<input
 									type="checkbox"
 									checked={formReleaseStatuses.has(value)}
-									onchange={() =>
-										(formReleaseStatuses = toggleSelection(formReleaseStatuses, value))}
+									onchange={() => {
+									formReleaseStatuses = toggleSelection(formReleaseStatuses, value);
+									clearFieldError('release_statuses');
+									syncDirtyState();
+								}}
 								/>
 								{value}
 							</label>
@@ -468,6 +559,10 @@
 							type="text"
 							bind:value={formCustomReleaseStatus}
 							placeholder="Custom release status"
+							oninput={() => {
+								clearFieldError('release_statuses');
+								syncDirtyState();
+							}}
 							onkeydown={(e) => {
 								if (e.key === 'Enter') {
 									e.preventDefault();
@@ -498,7 +593,7 @@
 
 				<div class="modal-actions">
 					<button type="button" class="btn-cancel" onclick={closeModal}>Cancel</button>
-					<button type="submit" class="btn-primary" disabled={formSaving}>
+					<button type="submit" class="btn-primary" disabled={formSaving || !formDirty}>
 						{formSaving ? 'Saving...' : editingProfile ? 'Save Changes' : 'Add Profile'}
 					</button>
 				</div>
@@ -506,6 +601,16 @@
 		</div>
 	</div>
 {/if}
+
+<ConfirmDialog
+	open={leaveDialogOpen}
+	title="Leave with unsaved changes?"
+	message="You have unsaved changes. Leave anyway?"
+	confirmLabel="Leave"
+	destructive
+	onconfirm={confirmLeave}
+	oncancel={cancelLeave}
+/>
 
 <ConfirmDialog
 	open={deleteDialogOpen}

--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -268,10 +268,10 @@
 				profiles = [...profiles, created];
 			}
 
-			closeModal();
 			unsavedGuard.markClean();
 			formDirty = false;
 			initialFormSnapshot = getFormSnapshot();
+			closeModal();
 			saveStatus = 'saved';
 			scheduleBannerClear();
 		} catch (err) {

--- a/web/src/routes/(app)/settings/quality-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/quality-profiles/+page.svelte
@@ -199,7 +199,7 @@
 			next.add(q);
 		}
 		formAllowedQualities = next;
-		clearFieldError('allowed_qualities');
+		clearFieldError('qualities');
 		syncDirtyState();
 	}
 
@@ -208,7 +208,7 @@
 		if (!q) return;
 		formAllowedQualities = new Set([...formAllowedQualities, q]);
 		formCustomQuality = '';
-		clearFieldError('allowed_qualities');
+		clearFieldError('qualities');
 		syncDirtyState();
 	}
 
@@ -248,22 +248,24 @@
 				const created = await createQualityProfile(payload);
 				profiles = [...profiles, created];
 			}
-			closeModal();
 			unsavedGuard.markClean();
 			formDirty = false;
 			initialFormSnapshot = getFormSnapshot();
+			closeModal();
 			saveStatus = 'saved';
 			scheduleBannerClear();
 		} catch (err) {
 			const classified = classifyFormError(err, [
 				{ field: 'name', messages: ['name cannot be empty', 'already exists'] },
-				{
-					field: 'allowed_qualities',
-					messages: ['allowed_qualities must contain at least one non-empty value']
-				}
+				{ field: 'qualities', messages: ['allowed_qualities must contain at least one non-empty value'] }
 			]);
-			if (Object.keys(classified.fieldErrors).length > 0) {
-				formErrors = { ...formErrors, ...classified.fieldErrors };
+			const normalizedFieldErrors = { ...classified.fieldErrors };
+			if (normalizedFieldErrors.allowed_qualities && !normalizedFieldErrors.qualities) {
+				normalizedFieldErrors.qualities = normalizedFieldErrors.allowed_qualities;
+				delete normalizedFieldErrors.allowed_qualities;
+			}
+			if (Object.keys(normalizedFieldErrors).length > 0) {
+				formErrors = { ...formErrors, ...normalizedFieldErrors };
 				saveStatus = 'idle';
 				saveError = '';
 			} else {
@@ -432,7 +434,7 @@
 							bind:value={formCustomQuality}
 							placeholder="Custom quality…"
 							oninput={() => {
-								clearFieldError('allowed_qualities');
+								clearFieldError('qualities');
 								syncDirtyState();
 							}}
 							onkeydown={(e) => {

--- a/web/src/routes/(app)/settings/quality-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/quality-profiles/+page.svelte
@@ -14,6 +14,8 @@
 		deleteQualityProfile,
 		ApiError
 	} from '$lib/api';
+	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
+	import { classifyFormError } from '$lib/settingsValidation';
 	import type {
 		QualityProfile,
 		CreateQualityProfileRequest,
@@ -56,6 +58,9 @@
 	let loadError = $state('');
 	let saveStatus = $state<SaveStatus>('idle');
 	let saveError = $state('');
+	let formDirty = $state(false);
+	let leaveDialogOpen = $state(false);
+	let initialFormSnapshot = '';
 
 	// modal state
 	let modalOpen = $state(false);
@@ -85,6 +90,34 @@
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
+	const unsavedGuard = useUnsavedGuard(() => {
+		leaveDialogOpen = true;
+	});
+
+	function getFormSnapshot(): string {
+		return JSON.stringify({
+			name: formName.trim(),
+			allowedQualities: orderedAllowedQualities(formAllowedQualities),
+			cutoffQuality: formCutoffQuality,
+			upgradeAllowed: formUpgradeAllowed
+		});
+	}
+
+	function syncDirtyState() {
+		formDirty = getFormSnapshot() !== initialFormSnapshot;
+		if (formDirty) {
+			unsavedGuard.markDirty();
+		} else {
+			unsavedGuard.markClean();
+		}
+	}
+
+	function clearFieldError(field: string) {
+		if (formErrors[field]) {
+			const { [field]: _removed, ...rest } = formErrors;
+			formErrors = rest;
+		}
+	}
 
 	function scheduleBannerClear() {
 		if (saveStatusTimer !== null) clearTimeout(saveStatusTimer);
@@ -123,7 +156,10 @@
 		formUpgradeAllowed = true;
 		formCutoffQuality = '';
 		formErrors = {};
+		leaveDialogOpen = false;
 		modalOpen = true;
+		initialFormSnapshot = getFormSnapshot();
+		syncDirtyState();
 	}
 
 	function openEdit(profile: QualityProfile) {
@@ -138,10 +174,18 @@
 				? profile.cutoff_quality
 				: '';
 		formErrors = {};
+		leaveDialogOpen = false;
 		modalOpen = true;
+		initialFormSnapshot = getFormSnapshot();
+		syncDirtyState();
 	}
 
 	function closeModal() {
+		if (formDirty) {
+			leaveDialogOpen = true;
+			return;
+		}
+		unsavedGuard.discardNavigation();
 		modalOpen = false;
 		editingProfile = null;
 	}
@@ -155,6 +199,8 @@
 			next.add(q);
 		}
 		formAllowedQualities = next;
+		clearFieldError('allowed_qualities');
+		syncDirtyState();
 	}
 
 	function addCustomQuality() {
@@ -162,6 +208,8 @@
 		if (!q) return;
 		formAllowedQualities = new Set([...formAllowedQualities, q]);
 		formCustomQuality = '';
+		clearFieldError('allowed_qualities');
+		syncDirtyState();
 	}
 
 	function validateForm(): boolean {
@@ -201,11 +249,27 @@
 				profiles = [...profiles, created];
 			}
 			closeModal();
+			unsavedGuard.markClean();
+			formDirty = false;
+			initialFormSnapshot = getFormSnapshot();
 			saveStatus = 'saved';
 			scheduleBannerClear();
 		} catch (err) {
-			saveError = err instanceof ApiError ? err.message : 'Save failed.';
-			saveStatus = 'error';
+			const classified = classifyFormError(err, [
+				{ field: 'name', messages: ['name cannot be empty', 'already exists'] },
+				{
+					field: 'allowed_qualities',
+					messages: ['allowed_qualities must contain at least one non-empty value']
+				}
+			]);
+			if (Object.keys(classified.fieldErrors).length > 0) {
+				formErrors = { ...formErrors, ...classified.fieldErrors };
+				saveStatus = 'idle';
+				saveError = '';
+			} else {
+				saveError = classified.bannerMessage || 'Save failed.';
+				saveStatus = 'error';
+			}
 		} finally {
 			formSaving = false;
 		}
@@ -238,6 +302,18 @@
 	function cancelDelete() {
 		deleteDialogOpen = false;
 		deleteTarget = null;
+	}
+
+	function confirmLeave() {
+		leaveDialogOpen = false;
+		modalOpen = false;
+		editingProfile = null;
+		void unsavedGuard.confirmNavigation();
+	}
+
+	function cancelLeave() {
+		leaveDialogOpen = false;
+		unsavedGuard.discardNavigation();
 	}
 </script>
 
@@ -323,7 +399,16 @@
 			>
 				<div class="field" class:has-error={!!formErrors.name}>
 					<label for="qp-name">Name <span aria-hidden="true">*</span></label>
-					<input id="qp-name" type="text" bind:value={formName} placeholder="My Quality Profile" />
+					<input
+						id="qp-name"
+						type="text"
+						bind:value={formName}
+						placeholder="My Quality Profile"
+						oninput={() => {
+							clearFieldError('name');
+							syncDirtyState();
+						}}
+					/>
 					{#if formErrors.name}<span class="field-error">{formErrors.name}</span>{/if}
 				</div>
 
@@ -346,6 +431,10 @@
 							type="text"
 							bind:value={formCustomQuality}
 							placeholder="Custom quality…"
+							oninput={() => {
+								clearFieldError('allowed_qualities');
+								syncDirtyState();
+							}}
 							onkeydown={(e) => {
 								if (e.key === 'Enter') {
 									e.preventDefault();
@@ -360,7 +449,14 @@
 
 				<div class="field">
 					<label for="qp-cutoff">Cutoff Quality</label>
-					<select id="qp-cutoff" bind:value={formCutoffQuality}>
+					<select
+						id="qp-cutoff"
+						bind:value={formCutoffQuality}
+						onchange={() => {
+							clearFieldError('cutoff_quality');
+							syncDirtyState();
+						}}
+					>
 						<option value="">— None —</option>
 						{#each orderedFormAllowedQualities as q}
 							<option value={q}>{q}</option>
@@ -371,12 +467,20 @@
 
 				<div class="field field-inline">
 					<label for="qp-upgrade">Upgrade Allowed</label>
-					<input id="qp-upgrade" type="checkbox" bind:checked={formUpgradeAllowed} />
+					<input
+						id="qp-upgrade"
+						type="checkbox"
+						bind:checked={formUpgradeAllowed}
+						onchange={() => {
+							clearFieldError('upgrade_allowed');
+							syncDirtyState();
+						}}
+					/>
 				</div>
 
 				<div class="modal-actions">
 					<button type="button" class="btn-cancel" onclick={closeModal}>Cancel</button>
-					<button type="submit" class="btn-primary" disabled={formSaving}>
+					<button type="submit" class="btn-primary" disabled={formSaving || !formDirty}>
 						{formSaving ? 'Saving…' : editingProfile ? 'Save Changes' : 'Add Profile'}
 					</button>
 				</div>
@@ -384,6 +488,16 @@
 		</div>
 	</div>
 {/if}
+
+<ConfirmDialog
+	open={leaveDialogOpen}
+	title="Leave with unsaved changes?"
+	message="You have unsaved changes. Leave anyway?"
+	confirmLabel="Leave"
+	destructive
+	onconfirm={confirmLeave}
+	oncancel={cancelLeave}
+/>
 
 <!-- ── Delete confirmation ──────────────────────────────────────────────── -->
 <ConfirmDialog


### PR DESCRIPTION
## Summary

Implements Issue #463, the polish pass for the four settings CRUD pages.

## Changes

- Added reusable unsaved-change guard support that resumes blocked navigation after confirmation
- Added a shared form validation helper that maps API validation/conflict responses to field-level errors
- Wired dirty-state tracking and pristine-save disablement into:
  - Download Clients
  - Indexers
  - Quality Profiles
  - Metadata Profiles
- Added leave-confirm dialogs for in-app navigation/tab switching when a form has unsaved edits
- Cleared field errors as soon as the related control changes

## Validation

- 
px svelte-check --tsconfig tsconfig.json
- Result: 0 errors, 0 warnings

Closes #463
