### PR TITLE
feat(settings): add bulk operations for settings lists (#464)

### DIFF
--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -650,19 +650,19 @@ pub async fn bulk_download_clients(
             },
             "enable" | "disable" => {
                 let enabled = request.action == "enable";
-                match state
+                let fetch_result = state
                     .download_client_definition_repository
                     .get_by_id(&id)
-                    .await
-                {
+                    .await;
+                match fetch_result {
                     Ok(Some(mut client)) => {
                         client.enabled = enabled;
                         client.updated_at = Utc::now();
-                        match state
+                        let update_result = state
                             .download_client_definition_repository
                             .update(client)
-                            .await
-                        {
+                            .await;
+                        match update_result {
                             Ok(_) => DownloadClientBulkItemResult {
                                 id,
                                 success: true,

--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -1033,4 +1033,135 @@ mod tests {
         .into_response();
         assert_eq!(second.status(), StatusCode::CONFLICT);
     }
+
+    #[tokio::test]
+    async fn bulk_download_clients_disables_selected_items() {
+        let state = make_test_state().await;
+        let client = state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "active-client",
+                "qbittorrent",
+                "https://downloads.example",
+            ))
+            .await
+            .expect("create client");
+        assert!(client.enabled);
+
+        let response = bulk_download_clients(
+            State(state.clone()),
+            Json(DownloadClientBulkRequest {
+                action: "disable".to_string(),
+                ids: vec![client.id.to_string()],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let updated = state
+            .download_client_definition_repository
+            .get_by_id(&client.id.to_string())
+            .await
+            .expect("fetch updated")
+            .expect("exists");
+        assert!(!updated.enabled);
+    }
+
+    #[tokio::test]
+    async fn bulk_download_clients_deletes_selected_items() {
+        let state = make_test_state().await;
+        let client = state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "to-delete",
+                "qbittorrent",
+                "https://downloads.example",
+            ))
+            .await
+            .expect("create client");
+
+        let response = bulk_download_clients(
+            State(state.clone()),
+            Json(DownloadClientBulkRequest {
+                action: "delete".to_string(),
+                ids: vec![client.id.to_string()],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let fetched = state
+            .download_client_definition_repository
+            .get_by_id(&client.id.to_string())
+            .await
+            .expect("get_by_id");
+        assert!(fetched.is_none(), "client should be deleted");
+    }
+
+    #[tokio::test]
+    async fn bulk_download_clients_rejects_empty_ids() {
+        let state = make_test_state().await;
+        let response = bulk_download_clients(
+            State(state),
+            Json(DownloadClientBulkRequest {
+                action: "delete".to_string(),
+                ids: vec![],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn bulk_download_clients_rejects_invalid_action() {
+        let state = make_test_state().await;
+        let client = state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "test-client",
+                "qbittorrent",
+                "https://downloads.example",
+            ))
+            .await
+            .expect("create client");
+        let response = bulk_download_clients(
+            State(state),
+            Json(DownloadClientBulkRequest {
+                action: "frobulate".to_string(),
+                ids: vec![client.id.to_string()],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn bulk_download_clients_returns_207_for_partial_failure() {
+        let state = make_test_state().await;
+        let client = state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "real-client",
+                "qbittorrent",
+                "https://downloads.example",
+            ))
+            .await
+            .expect("create client");
+        let missing_id = "00000000-0000-0000-0000-000000000000".to_string();
+
+        let response = bulk_download_clients(
+            State(state.clone()),
+            Json(DownloadClientBulkRequest {
+                action: "delete".to_string(),
+                ids: vec![client.id.to_string(), missing_id],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::MULTI_STATUS);
+    }
 }

--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -89,6 +89,24 @@ pub struct DownloadClientErrorResponse {
     pub error: String,
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DownloadClientBulkRequest {
+    pub action: String,
+    pub ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DownloadClientBulkItemResult {
+    pub id: String,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DownloadClientBulkResponse {
+    pub results: Vec<DownloadClientBulkItemResult>,
+}
+
 fn default_true() -> bool {
     true
 }
@@ -575,6 +593,118 @@ pub async fn delete_download_client(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/settings/download-clients/bulk",
+    request_body = DownloadClientBulkRequest,
+    responses(
+        (status = 200, description = "Bulk action completed", body = DownloadClientBulkResponse),
+        (status = 207, description = "Bulk action partially succeeded", body = DownloadClientBulkResponse),
+        (status = 400, description = "Invalid request", body = DownloadClientErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn bulk_download_clients(
+    State(state): State<AppState>,
+    Json(request): Json<DownloadClientBulkRequest>,
+) -> impl IntoResponse {
+    if request.ids.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(DownloadClientErrorResponse {
+                error: "ids must contain at least one item".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    if !matches!(request.action.as_str(), "enable" | "disable" | "delete") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(DownloadClientErrorResponse {
+                error: "action must be one of: enable, disable, delete".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let mut results = Vec::with_capacity(request.ids.len());
+
+    for id in request.ids {
+        let result = match request.action.as_str() {
+            "delete" => match state
+                .download_client_definition_repository
+                .delete(&id)
+                .await
+            {
+                Ok(_) => DownloadClientBulkItemResult {
+                    id,
+                    success: true,
+                    error: None,
+                },
+                Err(error) => DownloadClientBulkItemResult {
+                    id,
+                    success: false,
+                    error: Some(format!("failed to delete download client: {error}")),
+                },
+            },
+            "enable" | "disable" => {
+                let enabled = request.action == "enable";
+                match state
+                    .download_client_definition_repository
+                    .get_by_id(&id)
+                    .await
+                {
+                    Ok(Some(mut client)) => {
+                        client.enabled = enabled;
+                        client.updated_at = Utc::now();
+                        match state
+                            .download_client_definition_repository
+                            .update(client)
+                            .await
+                        {
+                            Ok(_) => DownloadClientBulkItemResult {
+                                id,
+                                success: true,
+                                error: None,
+                            },
+                            Err(error) => DownloadClientBulkItemResult {
+                                id,
+                                success: false,
+                                error: Some(format!(
+                                    "failed to update download client state: {error}"
+                                )),
+                            },
+                        }
+                    }
+                    Ok(None) => DownloadClientBulkItemResult {
+                        id,
+                        success: false,
+                        error: Some("download client not found".to_string()),
+                    },
+                    Err(error) => DownloadClientBulkItemResult {
+                        id,
+                        success: false,
+                        error: Some(format!("failed to fetch download client: {error}")),
+                    },
+                }
+            }
+            _ => unreachable!(),
+        };
+
+        results.push(result);
+    }
+
+    let has_failures = results.iter().any(|r| !r.success);
+    let status = if has_failures {
+        StatusCode::MULTI_STATUS
+    } else {
+        StatusCode::OK
+    };
+
+    (status, Json(DownloadClientBulkResponse { results })).into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -817,6 +947,55 @@ mod tests {
             .await
             .into_response();
         assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn bulk_download_clients_enables_selected_items() {
+        let state = make_test_state().await;
+        let first = state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "first",
+                "qbittorrent",
+                "https://downloads.example",
+            ))
+            .await
+            .expect("create first");
+        let mut second = state
+            .download_client_definition_repository
+            .create(DownloadClientDefinition::new(
+                "second",
+                "transmission",
+                "https://downloads.example",
+            ))
+            .await
+            .expect("create second");
+        second.enabled = false;
+        state
+            .download_client_definition_repository
+            .update(second)
+            .await
+            .expect("disable second");
+
+        let response = bulk_download_clients(
+            State(state.clone()),
+            Json(DownloadClientBulkRequest {
+                action: "enable".to_string(),
+                ids: vec![first.id.to_string()],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let updated = state
+            .download_client_definition_repository
+            .get_by_id(&first.id.to_string())
+            .await
+            .expect("fetch updated")
+            .expect("exists");
+        assert!(updated.enabled);
     }
 
     #[tokio::test]

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -614,11 +614,14 @@ pub async fn bulk_indexers(
             },
             "enable" | "disable" => {
                 let enabled = request.action == "enable";
-                match state.indexer_definition_repository.get_by_id(&id).await {
+                let fetch_result = state.indexer_definition_repository.get_by_id(&id).await;
+                match fetch_result {
                     Ok(Some(mut indexer)) => {
                         indexer.enabled = enabled;
                         indexer.updated_at = Utc::now();
-                        match state.indexer_definition_repository.update(indexer).await {
+                        let update_result =
+                            state.indexer_definition_repository.update(indexer).await;
+                        match update_result {
                             Ok(_) => IndexerBulkItemResult {
                                 id,
                                 success: true,

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -1010,4 +1010,148 @@ mod tests {
         .into_response();
         assert_eq!(second.status(), StatusCode::CONFLICT);
     }
+
+    // --- bulk_indexers ---
+
+    async fn create_test_indexer(state: &AppState) -> IndexerDefinition {
+        state
+            .indexer_definition_repository
+            .create(IndexerDefinition::new(
+                "Test Indexer",
+                "https://indexer.example",
+                "newznab",
+            ))
+            .await
+            .expect("create test indexer")
+    }
+
+    #[tokio::test]
+    async fn bulk_indexers_enables_selected_items() {
+        let state = make_test_state().await;
+        let mut indexer = create_test_indexer(&state).await;
+        indexer.enabled = false;
+        state
+            .indexer_definition_repository
+            .update(indexer.clone())
+            .await
+            .expect("disable indexer");
+
+        let response = bulk_indexers(
+            State(state.clone()),
+            Json(IndexerBulkRequest {
+                action: "enable".to_string(),
+                ids: vec![indexer.id.to_string()],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let updated = state
+            .indexer_definition_repository
+            .get_by_id(&indexer.id.to_string())
+            .await
+            .expect("get_by_id")
+            .expect("exists");
+        assert!(updated.enabled);
+    }
+
+    #[tokio::test]
+    async fn bulk_indexers_disables_selected_items() {
+        let state = make_test_state().await;
+        let indexer = create_test_indexer(&state).await;
+        assert!(indexer.enabled);
+
+        let response = bulk_indexers(
+            State(state.clone()),
+            Json(IndexerBulkRequest {
+                action: "disable".to_string(),
+                ids: vec![indexer.id.to_string()],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let updated = state
+            .indexer_definition_repository
+            .get_by_id(&indexer.id.to_string())
+            .await
+            .expect("get_by_id")
+            .expect("exists");
+        assert!(!updated.enabled);
+    }
+
+    #[tokio::test]
+    async fn bulk_indexers_deletes_selected_items() {
+        let state = make_test_state().await;
+        let indexer = create_test_indexer(&state).await;
+
+        let response = bulk_indexers(
+            State(state.clone()),
+            Json(IndexerBulkRequest {
+                action: "delete".to_string(),
+                ids: vec![indexer.id.to_string()],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let fetched = state
+            .indexer_definition_repository
+            .get_by_id(&indexer.id.to_string())
+            .await
+            .expect("get_by_id");
+        assert!(fetched.is_none(), "indexer should be deleted");
+    }
+
+    #[tokio::test]
+    async fn bulk_indexers_rejects_empty_ids() {
+        let state = make_test_state().await;
+        let response = bulk_indexers(
+            State(state),
+            Json(IndexerBulkRequest {
+                action: "delete".to_string(),
+                ids: vec![],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn bulk_indexers_rejects_invalid_action() {
+        let state = make_test_state().await;
+        let indexer = create_test_indexer(&state).await;
+        let response = bulk_indexers(
+            State(state),
+            Json(IndexerBulkRequest {
+                action: "frobulate".to_string(),
+                ids: vec![indexer.id.to_string()],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn bulk_indexers_returns_207_for_partial_failure() {
+        let state = make_test_state().await;
+        let indexer = create_test_indexer(&state).await;
+        let missing_id = "00000000-0000-0000-0000-000000000000".to_string();
+
+        let response = bulk_indexers(
+            State(state),
+            Json(IndexerBulkRequest {
+                action: "delete".to_string(),
+                ids: vec![indexer.id.to_string(), missing_id],
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::MULTI_STATUS);
+    }
 }

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -82,6 +82,24 @@ pub struct IndexerErrorResponse {
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
+pub struct IndexerBulkRequest {
+    pub action: String,
+    pub ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct IndexerBulkItemResult {
+    pub id: String,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct IndexerBulkResponse {
+    pub results: Vec<IndexerBulkItemResult>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct TestIndexerRequest {
     pub name: String,
     pub base_url: String,
@@ -541,6 +559,104 @@ pub async fn delete_indexer(
         )
             .into_response(),
     }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/settings/indexers/bulk",
+    request_body = IndexerBulkRequest,
+    responses(
+        (status = 200, description = "Bulk action completed", body = IndexerBulkResponse),
+        (status = 207, description = "Bulk action partially succeeded", body = IndexerBulkResponse),
+        (status = 400, description = "Invalid request", body = IndexerErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn bulk_indexers(
+    State(state): State<AppState>,
+    Json(request): Json<IndexerBulkRequest>,
+) -> impl IntoResponse {
+    if request.ids.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(IndexerErrorResponse {
+                error: "ids must contain at least one item".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    if !matches!(request.action.as_str(), "enable" | "disable" | "delete") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(IndexerErrorResponse {
+                error: "action must be one of: enable, disable, delete".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let mut results = Vec::with_capacity(request.ids.len());
+
+    for id in request.ids {
+        let result = match request.action.as_str() {
+            "delete" => match state.indexer_definition_repository.delete(&id).await {
+                Ok(_) => IndexerBulkItemResult {
+                    id,
+                    success: true,
+                    error: None,
+                },
+                Err(error) => IndexerBulkItemResult {
+                    id,
+                    success: false,
+                    error: Some(format!("failed to delete indexer: {error}")),
+                },
+            },
+            "enable" | "disable" => {
+                let enabled = request.action == "enable";
+                match state.indexer_definition_repository.get_by_id(&id).await {
+                    Ok(Some(mut indexer)) => {
+                        indexer.enabled = enabled;
+                        indexer.updated_at = Utc::now();
+                        match state.indexer_definition_repository.update(indexer).await {
+                            Ok(_) => IndexerBulkItemResult {
+                                id,
+                                success: true,
+                                error: None,
+                            },
+                            Err(error) => IndexerBulkItemResult {
+                                id,
+                                success: false,
+                                error: Some(format!("failed to update indexer state: {error}")),
+                            },
+                        }
+                    }
+                    Ok(None) => IndexerBulkItemResult {
+                        id,
+                        success: false,
+                        error: Some("indexer not found".to_string()),
+                    },
+                    Err(error) => IndexerBulkItemResult {
+                        id,
+                        success: false,
+                        error: Some(format!("failed to fetch indexer: {error}")),
+                    },
+                }
+            }
+            _ => unreachable!(),
+        };
+
+        results.push(result);
+    }
+
+    let has_failures = results.iter().any(|r| !r.success);
+    let status = if has_failures {
+        StatusCode::MULTI_STATUS
+    } else {
+        StatusCode::OK
+    };
+
+    (status, Json(IndexerBulkResponse { results })).into_response()
 }
 
 #[derive(Debug, Serialize, ToSchema)]

--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -75,6 +75,24 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct MetadataProfileBulkRequest {
+    pub action: String,
+    pub ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MetadataProfileBulkItemResult {
+    pub id: String,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MetadataProfileBulkResponse {
+    pub results: Vec<MetadataProfileBulkItemResult>,
+}
+
 fn validate_name(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     if name.trim().is_empty() {
         Err((
@@ -391,6 +409,78 @@ pub async fn delete_metadata_profile(
         )
             .into_response(),
     }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/settings/metadata-profiles/bulk",
+    request_body = MetadataProfileBulkRequest,
+    responses(
+        (status = 200, description = "Bulk action completed", body = MetadataProfileBulkResponse),
+        (status = 207, description = "Bulk action partially succeeded", body = MetadataProfileBulkResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn bulk_metadata_profiles(
+    State(state): State<AppState>,
+    Json(request): Json<MetadataProfileBulkRequest>,
+) -> impl IntoResponse {
+    if request.ids.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "ids must contain at least one item".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    if !matches!(request.action.as_str(), "enable" | "disable" | "delete") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "action must be one of: enable, disable, delete".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let mut results = Vec::with_capacity(request.ids.len());
+
+    for id in request.ids {
+        let result = match request.action.as_str() {
+            "delete" => match state.metadata_profile_repository.delete(&id).await {
+                Ok(_) => MetadataProfileBulkItemResult {
+                    id,
+                    success: true,
+                    error: None,
+                },
+                Err(error) => MetadataProfileBulkItemResult {
+                    id,
+                    success: false,
+                    error: Some(format!("failed to delete metadata profile: {error}")),
+                },
+            },
+            "enable" | "disable" => MetadataProfileBulkItemResult {
+                id,
+                success: false,
+                error: Some("enable/disable is not supported for metadata profiles".to_string()),
+            },
+            _ => unreachable!(),
+        };
+
+        results.push(result);
+    }
+
+    let has_failures = results.iter().any(|r| !r.success);
+    let status = if has_failures {
+        StatusCode::MULTI_STATUS
+    } else {
+        StatusCode::OK
+    };
+
+    (status, Json(MetadataProfileBulkResponse { results })).into_response()
 }
 
 #[cfg(test)]

--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -436,11 +436,11 @@ pub async fn bulk_metadata_profiles(
             .into_response();
     }
 
-    if !matches!(request.action.as_str(), "enable" | "disable" | "delete") {
+    if !matches!(request.action.as_str(), "delete") {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
-                error: "action must be one of: enable, disable, delete".to_string(),
+                error: "action must be one of: delete".to_string(),
             }),
         )
             .into_response();
@@ -461,11 +461,6 @@ pub async fn bulk_metadata_profiles(
                     success: false,
                     error: Some(format!("failed to delete metadata profile: {error}")),
                 },
-            },
-            "enable" | "disable" => MetadataProfileBulkItemResult {
-                id,
-                success: false,
-                error: Some("enable/disable is not supported for metadata profiles".to_string()),
             },
             _ => unreachable!(),
         };
@@ -775,6 +770,111 @@ mod tests {
                 .await
                 .into_response();
             assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        // --- bulk_metadata_profiles ---
+
+        #[tokio::test]
+        async fn bulk_metadata_profiles_delete_returns_200_on_success() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let response = bulk_metadata_profiles(
+                State(state.clone()),
+                Json(MetadataProfileBulkRequest {
+                    action: "delete".to_string(),
+                    ids: vec![profile.id.to_string()],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let fetched = state
+                .metadata_profile_repository
+                .get_by_id(&profile.id.to_string())
+                .await
+                .expect("get_by_id");
+            assert!(fetched.is_none(), "profile should be deleted");
+        }
+
+        #[tokio::test]
+        async fn bulk_metadata_profiles_rejects_empty_ids() {
+            let state = make_test_state().await;
+            let response = bulk_metadata_profiles(
+                State(state),
+                Json(MetadataProfileBulkRequest {
+                    action: "delete".to_string(),
+                    ids: vec![],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn bulk_metadata_profiles_rejects_invalid_action() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let response = bulk_metadata_profiles(
+                State(state),
+                Json(MetadataProfileBulkRequest {
+                    action: "frobulate".to_string(),
+                    ids: vec![profile.id.to_string()],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn bulk_metadata_profiles_rejects_enable_action() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let response = bulk_metadata_profiles(
+                State(state),
+                Json(MetadataProfileBulkRequest {
+                    action: "enable".to_string(),
+                    ids: vec![profile.id.to_string()],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn bulk_metadata_profiles_rejects_disable_action() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let response = bulk_metadata_profiles(
+                State(state),
+                Json(MetadataProfileBulkRequest {
+                    action: "disable".to_string(),
+                    ids: vec![profile.id.to_string()],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn bulk_metadata_profiles_returns_207_for_partial_failure() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let missing_id = "00000000-0000-0000-0000-000000000000".to_string();
+            let response = bulk_metadata_profiles(
+                State(state),
+                Json(MetadataProfileBulkRequest {
+                    action: "delete".to_string(),
+                    ids: vec![profile.id.to_string(), missing_id],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::MULTI_STATUS);
         }
     }
 }

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -75,6 +75,24 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct QualityProfileBulkRequest {
+    pub action: String,
+    pub ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct QualityProfileBulkItemResult {
+    pub id: String,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct QualityProfileBulkResponse {
+    pub results: Vec<QualityProfileBulkItemResult>,
+}
+
 fn validate_name(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     if name.trim().is_empty() {
         Err((
@@ -403,6 +421,78 @@ pub async fn delete_quality_profile(
         )
             .into_response(),
     }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/settings/quality-profiles/bulk",
+    request_body = QualityProfileBulkRequest,
+    responses(
+        (status = 200, description = "Bulk action completed", body = QualityProfileBulkResponse),
+        (status = 207, description = "Bulk action partially succeeded", body = QualityProfileBulkResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn bulk_quality_profiles(
+    State(state): State<AppState>,
+    Json(request): Json<QualityProfileBulkRequest>,
+) -> impl IntoResponse {
+    if request.ids.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "ids must contain at least one item".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    if !matches!(request.action.as_str(), "enable" | "disable" | "delete") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "action must be one of: enable, disable, delete".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let mut results = Vec::with_capacity(request.ids.len());
+
+    for id in request.ids {
+        let result = match request.action.as_str() {
+            "delete" => match state.quality_profile_repository.delete(&id).await {
+                Ok(_) => QualityProfileBulkItemResult {
+                    id,
+                    success: true,
+                    error: None,
+                },
+                Err(error) => QualityProfileBulkItemResult {
+                    id,
+                    success: false,
+                    error: Some(format!("failed to delete quality profile: {error}")),
+                },
+            },
+            "enable" | "disable" => QualityProfileBulkItemResult {
+                id,
+                success: false,
+                error: Some("enable/disable is not supported for quality profiles".to_string()),
+            },
+            _ => unreachable!(),
+        };
+
+        results.push(result);
+    }
+
+    let has_failures = results.iter().any(|r| !r.success);
+    let status = if has_failures {
+        StatusCode::MULTI_STATUS
+    } else {
+        StatusCode::OK
+    };
+
+    (status, Json(QualityProfileBulkResponse { results })).into_response()
 }
 
 #[cfg(test)]

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -448,11 +448,11 @@ pub async fn bulk_quality_profiles(
             .into_response();
     }
 
-    if !matches!(request.action.as_str(), "enable" | "disable" | "delete") {
+    if !matches!(request.action.as_str(), "delete") {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
-                error: "action must be one of: enable, disable, delete".to_string(),
+                error: "action must be one of: delete".to_string(),
             }),
         )
             .into_response();
@@ -473,11 +473,6 @@ pub async fn bulk_quality_profiles(
                     success: false,
                     error: Some(format!("failed to delete quality profile: {error}")),
                 },
-            },
-            "enable" | "disable" => QualityProfileBulkItemResult {
-                id,
-                success: false,
-                error: Some("enable/disable is not supported for quality profiles".to_string()),
             },
             _ => unreachable!(),
         };
@@ -802,6 +797,111 @@ mod tests {
                 .await
                 .into_response();
             assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        // --- bulk_quality_profiles ---
+
+        #[tokio::test]
+        async fn bulk_quality_profiles_delete_returns_200_on_success() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let response = bulk_quality_profiles(
+                State(state.clone()),
+                Json(QualityProfileBulkRequest {
+                    action: "delete".to_string(),
+                    ids: vec![profile.id.to_string()],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let fetched = state
+                .quality_profile_repository
+                .get_by_id(&profile.id.to_string())
+                .await
+                .expect("get_by_id");
+            assert!(fetched.is_none(), "profile should be deleted");
+        }
+
+        #[tokio::test]
+        async fn bulk_quality_profiles_rejects_empty_ids() {
+            let state = make_test_state().await;
+            let response = bulk_quality_profiles(
+                State(state),
+                Json(QualityProfileBulkRequest {
+                    action: "delete".to_string(),
+                    ids: vec![],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn bulk_quality_profiles_rejects_invalid_action() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let response = bulk_quality_profiles(
+                State(state),
+                Json(QualityProfileBulkRequest {
+                    action: "frobulate".to_string(),
+                    ids: vec![profile.id.to_string()],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn bulk_quality_profiles_rejects_enable_action() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let response = bulk_quality_profiles(
+                State(state),
+                Json(QualityProfileBulkRequest {
+                    action: "enable".to_string(),
+                    ids: vec![profile.id.to_string()],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn bulk_quality_profiles_rejects_disable_action() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let response = bulk_quality_profiles(
+                State(state),
+                Json(QualityProfileBulkRequest {
+                    action: "disable".to_string(),
+                    ids: vec![profile.id.to_string()],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        #[tokio::test]
+        async fn bulk_quality_profiles_returns_207_for_partial_failure() {
+            let state = make_test_state().await;
+            let profile = create_test_profile(&state).await;
+            let missing_id = "00000000-0000-0000-0000-000000000000".to_string();
+            let response = bulk_quality_profiles(
+                State(state),
+                Json(QualityProfileBulkRequest {
+                    action: "delete".to_string(),
+                    ids: vec![profile.id.to_string(), missing_id],
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::MULTI_STATUS);
         }
     }
 }

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -55,11 +55,12 @@ use handlers::calendar::{
     CalendarResponse, __path_get_ical_feed, __path_list_upcoming_releases,
 };
 use handlers::download_clients::{
-    create_download_client, delete_download_client, get_download_client, list_download_clients,
-    update_download_client, CreateDownloadClientRequest, DownloadClientErrorResponse,
+    bulk_download_clients, create_download_client, delete_download_client, get_download_client,
+    list_download_clients, update_download_client, CreateDownloadClientRequest,
+    DownloadClientBulkRequest, DownloadClientBulkResponse, DownloadClientErrorResponse,
     DownloadClientResponse, ListDownloadClientsResponse, UpdateDownloadClientRequest,
-    __path_create_download_client, __path_delete_download_client, __path_get_download_client,
-    __path_list_download_clients, __path_update_download_client,
+    __path_bulk_download_clients, __path_create_download_client, __path_delete_download_client,
+    __path_get_download_client, __path_list_download_clients, __path_update_download_client,
 };
 use handlers::duplicates::{
     get_duplicate_group, list_duplicate_groups, resolve_duplicate_group, DuplicateFileResponse,
@@ -83,25 +84,28 @@ use handlers::imports::{
     ParsedMetadataResponse, __path_evaluate_import_candidate, __path_submit_manual_import_decision,
 };
 use handlers::indexers::{
-    create_indexer, delete_indexer, get_indexer, list_indexers, test_indexer_endpoint,
-    update_indexer, CreateIndexerRequest, IndexerCapabilitiesResponse, IndexerErrorResponse,
-    IndexerResponse, IndexerTestErrorResponse, ListIndexersResponse, TestIndexerRequest,
-    TestIndexerResponse, UpdateIndexerRequest, __path_create_indexer, __path_delete_indexer,
+    bulk_indexers, create_indexer, delete_indexer, get_indexer, list_indexers,
+    test_indexer_endpoint, update_indexer, CreateIndexerRequest, IndexerBulkRequest,
+    IndexerBulkResponse, IndexerCapabilitiesResponse, IndexerErrorResponse, IndexerResponse,
+    IndexerTestErrorResponse, ListIndexersResponse, TestIndexerRequest, TestIndexerResponse,
+    UpdateIndexerRequest, __path_bulk_indexers, __path_create_indexer, __path_delete_indexer,
     __path_get_indexer, __path_list_indexers, __path_test_indexer_endpoint, __path_update_indexer,
 };
 use handlers::metadata_profiles::{
-    create_metadata_profile, delete_metadata_profile, get_metadata_profile, list_metadata_profiles,
-    update_metadata_profile, CreateMetadataProfileRequest,
+    bulk_metadata_profiles, create_metadata_profile, delete_metadata_profile, get_metadata_profile,
+    list_metadata_profiles, update_metadata_profile, CreateMetadataProfileRequest,
     ErrorResponse as MetadataProfileErrorResponse, ListMetadataProfilesResponse,
-    MetadataProfileResponse, UpdateMetadataProfileRequest, __path_create_metadata_profile,
+    MetadataProfileBulkRequest, MetadataProfileBulkResponse, MetadataProfileResponse,
+    UpdateMetadataProfileRequest, __path_bulk_metadata_profiles, __path_create_metadata_profile,
     __path_delete_metadata_profile, __path_get_metadata_profile, __path_list_metadata_profiles,
     __path_update_metadata_profile,
 };
 use handlers::quality_profiles::{
-    create_quality_profile, delete_quality_profile, get_quality_profile, list_quality_profiles,
-    update_quality_profile, CreateQualityProfileRequest,
+    bulk_quality_profiles, create_quality_profile, delete_quality_profile, get_quality_profile,
+    list_quality_profiles, update_quality_profile, CreateQualityProfileRequest,
     ErrorResponse as QualityProfileErrorResponse, ListQualityProfilesResponse,
-    QualityProfileResponse, UpdateQualityProfileRequest, __path_create_quality_profile,
+    QualityProfileBulkRequest, QualityProfileBulkResponse, QualityProfileResponse,
+    UpdateQualityProfileRequest, __path_bulk_quality_profiles, __path_create_quality_profile,
     __path_delete_quality_profile, __path_get_quality_profile, __path_list_quality_profiles,
     __path_update_quality_profile,
 };
@@ -317,21 +321,25 @@ async fn metrics() -> axum::response::Response {
         create_quality_profile,
         update_quality_profile,
         delete_quality_profile,
+        bulk_quality_profiles,
         list_metadata_profiles,
         get_metadata_profile,
         create_metadata_profile,
         update_metadata_profile,
         delete_metadata_profile,
+        bulk_metadata_profiles,
         list_download_clients,
         get_download_client,
         create_download_client,
         update_download_client,
         delete_download_client,
+        bulk_download_clients,
         list_indexers,
         get_indexer,
         create_indexer,
         update_indexer,
         delete_indexer,
+        bulk_indexers,
         test_indexer_endpoint,
         manual_search_endpoint,
         evaluate_import_candidate,
@@ -417,21 +425,29 @@ async fn metrics() -> axum::response::Response {
             CreateQualityProfileRequest,
             UpdateQualityProfileRequest,
             QualityProfileErrorResponse,
+            QualityProfileBulkRequest,
+            QualityProfileBulkResponse,
             ListMetadataProfilesResponse,
             MetadataProfileResponse,
             CreateMetadataProfileRequest,
             UpdateMetadataProfileRequest,
             MetadataProfileErrorResponse,
+            MetadataProfileBulkRequest,
+            MetadataProfileBulkResponse,
             ListDownloadClientsResponse,
             DownloadClientResponse,
             CreateDownloadClientRequest,
             UpdateDownloadClientRequest,
             DownloadClientErrorResponse,
+            DownloadClientBulkRequest,
+            DownloadClientBulkResponse,
             ListIndexersResponse,
             IndexerResponse,
             CreateIndexerRequest,
             UpdateIndexerRequest,
             IndexerErrorResponse,
+            IndexerBulkRequest,
+            IndexerBulkResponse,
             TestIndexerRequest,
             TestIndexerResponse,
             IndexerCapabilitiesResponse,
@@ -606,6 +622,10 @@ pub fn router(state: AppState) -> Router {
             get(list_quality_profiles).post(create_quality_profile),
         )
         .route(
+            "/settings/quality-profiles/bulk",
+            post(bulk_quality_profiles),
+        )
+        .route(
             "/settings/quality-profiles/:id",
             get(get_quality_profile)
                 .put(update_quality_profile)
@@ -614,6 +634,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/settings/metadata-profiles",
             get(list_metadata_profiles).post(create_metadata_profile),
+        )
+        .route(
+            "/settings/metadata-profiles/bulk",
+            post(bulk_metadata_profiles),
         )
         .route(
             "/settings/metadata-profiles/:id",
@@ -626,6 +650,10 @@ pub fn router(state: AppState) -> Router {
             get(list_download_clients).post(create_download_client),
         )
         .route(
+            "/settings/download-clients/bulk",
+            post(bulk_download_clients),
+        )
+        .route(
             "/settings/download-clients/:id",
             get(get_download_client)
                 .put(update_download_client)
@@ -635,6 +663,7 @@ pub fn router(state: AppState) -> Router {
             "/settings/indexers",
             get(list_indexers).post(create_indexer),
         )
+        .route("/settings/indexers/bulk", post(bulk_indexers))
         .route(
             "/settings/indexers/:id",
             get(get_indexer).put(update_indexer).delete(delete_indexer),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,6 +20,8 @@ import type {
 	FormsLogoutResponse,
 	PaginatedResponse,
 	QualityProfile,
+	SettingsBulkRequest,
+	SettingsBulkResponse,
 	SystemTasksResponse,
 	TestIndexerRequest,
 	TestIndexerResponse,
@@ -170,6 +172,13 @@ export async function deleteDownloadClient(id: string): Promise<void> {
 	});
 }
 
+export async function bulkDownloadClients(payload: SettingsBulkRequest): Promise<SettingsBulkResponse> {
+	return request<SettingsBulkResponse>('/api/v1/settings/download-clients/bulk', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
 export async function getIndexers(params?: {
 	limit?: number;
 	offset?: number;
@@ -205,6 +214,13 @@ export async function updateIndexer(
 export async function deleteIndexer(id: string): Promise<void> {
 	await request<unknown>(`/api/v1/settings/indexers/${encodeURIComponent(id)}`, {
 		method: 'DELETE'
+	});
+}
+
+export async function bulkIndexers(payload: SettingsBulkRequest): Promise<SettingsBulkResponse> {
+	return request<SettingsBulkResponse>('/api/v1/settings/indexers/bulk', {
+		method: 'POST',
+		body: JSON.stringify(payload)
 	});
 }
 
@@ -257,6 +273,13 @@ export async function deleteQualityProfile(id: string): Promise<void> {
 	});
 }
 
+export async function bulkQualityProfiles(payload: SettingsBulkRequest): Promise<SettingsBulkResponse> {
+	return request<SettingsBulkResponse>('/api/v1/settings/quality-profiles/bulk', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
 export async function getMetadataProfiles(params?: {
 	limit?: number;
 	offset?: number;
@@ -296,6 +319,13 @@ export async function updateMetadataProfile(
 export async function deleteMetadataProfile(id: string): Promise<void> {
 	await request<unknown>(`/api/v1/settings/metadata-profiles/${encodeURIComponent(id)}`, {
 		method: 'DELETE'
+	});
+}
+
+export async function bulkMetadataProfiles(payload: SettingsBulkRequest): Promise<SettingsBulkResponse> {
+	return request<SettingsBulkResponse>('/api/v1/settings/metadata-profiles/bulk', {
+		method: 'POST',
+		body: JSON.stringify(payload)
 	});
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -88,6 +88,23 @@ export interface UpdateDownloadClientRequest {
 
 export type DownloadClientErrorResponse = ApiErrorResponse;
 
+export type SettingsBulkAction = 'enable' | 'disable' | 'delete';
+
+export interface SettingsBulkRequest {
+	action: SettingsBulkAction;
+	ids: string[];
+}
+
+export interface SettingsBulkItemResult {
+	id: string;
+	success: boolean;
+	error?: string;
+}
+
+export interface SettingsBulkResponse {
+	results: SettingsBulkItemResult[];
+}
+
 export interface Indexer {
 	id: string;
 	name: string;

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -12,6 +12,7 @@
 		createDownloadClient,
 		updateDownloadClient,
 		deleteDownloadClient,
+		bulkDownloadClients,
 		ApiError
 	} from '$lib/api';
 	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
@@ -24,6 +25,7 @@
 
 	// ── state ──────────────────────────────────────────────────────────────────
 	let clients = $state<DownloadClient[]>([]);
+	let selectedIds = $state<Set<string>>(new Set());
 	let loading = $state(true);
 	let loadError = $state('');
 	let saveStatus = $state<SaveStatus>('idle');
@@ -51,6 +53,8 @@
 	let deleteTarget = $state<DownloadClient | null>(null);
 	let deleteDialogOpen = $state(false);
 	let deleting = $state(false);
+	let bulkDeleteDialogOpen = $state(false);
+	let bulkActing = $state(false);
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
@@ -122,6 +126,9 @@
 	}
 
 	onMount(load);
+
+	let hasSelection = $derived(selectedIds.size > 0);
+	let allSelected = $derived(clients.length > 0 && clients.every((client) => selectedIds.has(client.id)));
 
 	// ── modal helpers ──────────────────────────────────────────────────────────
 	function openAdd() {
@@ -255,6 +262,93 @@
 		}
 	}
 
+	function toggleRowSelection(id: string) {
+		const next = new Set(selectedIds);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		selectedIds = next;
+	}
+
+	function toggleSelectAll() {
+		if (allSelected) {
+			selectedIds = new Set();
+			return;
+		}
+		selectedIds = new Set(clients.map((client) => client.id));
+	}
+
+	async function runBulkAction(action: 'enable' | 'disable' | 'delete') {
+		if (selectedIds.size === 0) return;
+
+		const ids = [...selectedIds];
+		const selectedSet = new Set(ids);
+		const originalClients = clients;
+		const originalById = new Map(originalClients.map((client) => [client.id, client]));
+
+		if (action === 'delete') {
+			clients = clients.filter((client) => !selectedSet.has(client.id));
+		} else {
+			clients = clients.map((client) =>
+				selectedSet.has(client.id)
+					? {
+						...client,
+						enabled: action === 'enable'
+					}
+					: client
+			);
+		}
+
+		saveStatus = 'saving';
+		saveError = '';
+		bulkActing = true;
+
+		try {
+			const result = await bulkDownloadClients({ action, ids });
+			const failed = result.results.filter((item) => !item.success);
+			if (failed.length > 0) {
+				const failedSet = new Set(failed.map((item) => item.id));
+				if (action === 'delete') {
+					clients = originalClients.filter(
+						(client) => !selectedSet.has(client.id) || failedSet.has(client.id)
+					);
+				} else {
+					clients = clients.map((client) => originalById.get(client.id) ?? client);
+				}
+
+				selectedIds = failedSet;
+				saveStatus = 'error';
+				saveError = failed
+					.slice(0, 4)
+					.map((item) => `${item.id}: ${item.error ?? 'operation failed'}`)
+					.join('\n');
+				return;
+			}
+
+			selectedIds = new Set();
+			saveStatus = 'saved';
+			scheduleBannerClear();
+		} catch (err) {
+			clients = originalClients;
+			saveStatus = 'error';
+			saveError = err instanceof ApiError ? err.message : 'Bulk action failed.';
+		} finally {
+			bulkActing = false;
+		}
+	}
+
+	function openBulkDelete() {
+		if (!hasSelection) return;
+		bulkDeleteDialogOpen = true;
+	}
+
+	async function confirmBulkDelete() {
+		await runBulkAction('delete');
+		bulkDeleteDialogOpen = false;
+	}
+
 	// ── delete ─────────────────────────────────────────────────────────────────
 	function openDelete(client: DownloadClient) {
 		deleteTarget = client;
@@ -307,6 +401,19 @@
 >
 	{#snippet actions()}
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
+		{#if hasSelection}
+			<div class="bulk-toolbar">
+				<button class="btn-secondary" onclick={() => runBulkAction('enable')} disabled={bulkActing}>
+					Enable Selected
+				</button>
+				<button class="btn-secondary" onclick={() => runBulkAction('disable')} disabled={bulkActing}>
+					Disable Selected
+				</button>
+				<button class="btn-icon destructive" onclick={openBulkDelete} disabled={bulkActing}>
+					Delete Selected
+				</button>
+			</div>
+		{/if}
 		<button class="btn-primary" onclick={openAdd}>Add Client</button>
 	{/snippet}
 
@@ -321,9 +428,21 @@
 			onaction={openAdd}
 		/>
 	{:else}
+		<div class="bulk-select-row">
+			<label>
+				<input type="checkbox" checked={allSelected} onchange={toggleSelectAll} />
+				Select All ({selectedIds.size}/{clients.length})
+			</label>
+		</div>
 		<ul class="client-list" role="list">
 			{#each clients as client (client.id)}
 				<li class="client-item" class:disabled={!client.enabled}>
+					<input
+						type="checkbox"
+						checked={selectedIds.has(client.id)}
+						onchange={() => toggleRowSelection(client.id)}
+						aria-label="Select {client.name}"
+					/>
 					<div class="client-info">
 						<span class="client-name">{client.name}</span>
 						<span class="client-meta">
@@ -515,6 +634,16 @@
 	oncancel={cancelDelete}
 />
 
+<ConfirmDialog
+	open={bulkDeleteDialogOpen}
+	title="Delete Selected Download Clients"
+	message={`Delete ${selectedIds.size} selected download client(s)? This cannot be undone.`}
+	confirmLabel={bulkActing ? 'Deleting…' : 'Delete Selected'}
+	destructive
+	onconfirm={confirmBulkDelete}
+	oncancel={() => (bulkDeleteDialogOpen = false)}
+/>
+
 <style>
 	.client-list {
 		list-style: none;
@@ -523,6 +652,23 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
+	}
+
+	.bulk-toolbar {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.bulk-select-row {
+		margin-bottom: 0.6rem;
+		font-size: 0.85rem;
+	}
+
+	.bulk-select-row label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
 	}
 
 	.client-item {
@@ -669,6 +815,16 @@
 		cursor: pointer;
 		transition: opacity 0.12s;
 		white-space: nowrap;
+	}
+
+	.btn-secondary {
+		padding: 0.45rem 0.8rem;
+		background: transparent;
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
+		border-radius: 6px;
+		font-size: 0.82rem;
+		cursor: pointer;
+		color: var(--text-primary, #0f1a1f);
 	}
 
 	.btn-primary:hover:not(:disabled) {

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -315,7 +315,9 @@
 						(client) => !selectedSet.has(client.id) || failedSet.has(client.id)
 					);
 				} else {
-					clients = clients.map((client) => originalById.get(client.id) ?? client);
+					clients = clients.map((client) =>
+						failedSet.has(client.id) ? (originalById.get(client.id) ?? client) : client
+					);
 				}
 
 				selectedIds = failedSet;

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -12,6 +12,7 @@
 		createIndexer,
 		updateIndexer,
 		deleteIndexer,
+		bulkIndexers,
 		testIndexer,
 		ApiError
 	} from '$lib/api';
@@ -26,6 +27,7 @@
 
 	// ── state ──────────────────────────────────────────────────────────────────
 	let indexers = $state<Indexer[]>([]);
+	let selectedIds = $state<Set<string>>(new Set());
 	let loading = $state(true);
 	let loadError = $state('');
 	let saveStatus = $state<SaveStatus>('idle');
@@ -56,6 +58,8 @@
 	let deleteTarget = $state<Indexer | null>(null);
 	let deleteDialogOpen = $state(false);
 	let deleting = $state(false);
+	let bulkDeleteDialogOpen = $state(false);
+	let bulkActing = $state(false);
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
@@ -123,6 +127,9 @@
 	}
 
 	onMount(load);
+
+	let hasSelection = $derived(selectedIds.size > 0);
+	let allSelected = $derived(indexers.length > 0 && indexers.every((indexer) => selectedIds.has(indexer.id)));
 
 	// ── modal helpers ──────────────────────────────────────────────────────────
 	function openAdd() {
@@ -288,6 +295,93 @@
 		}
 	}
 
+	function toggleRowSelection(id: string) {
+		const next = new Set(selectedIds);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		selectedIds = next;
+	}
+
+	function toggleSelectAll() {
+		if (allSelected) {
+			selectedIds = new Set();
+			return;
+		}
+		selectedIds = new Set(indexers.map((indexer) => indexer.id));
+	}
+
+	async function runBulkAction(action: 'enable' | 'disable' | 'delete') {
+		if (selectedIds.size === 0) return;
+
+		const ids = [...selectedIds];
+		const selectedSet = new Set(ids);
+		const originalIndexers = indexers;
+		const originalById = new Map(originalIndexers.map((indexer) => [indexer.id, indexer]));
+
+		if (action === 'delete') {
+			indexers = indexers.filter((indexer) => !selectedSet.has(indexer.id));
+		} else {
+			indexers = indexers.map((indexer) =>
+				selectedSet.has(indexer.id)
+					? {
+						...indexer,
+						enabled: action === 'enable'
+					}
+					: indexer
+			);
+		}
+
+		saveStatus = 'saving';
+		saveError = '';
+		bulkActing = true;
+
+		try {
+			const result = await bulkIndexers({ action, ids });
+			const failed = result.results.filter((item) => !item.success);
+			if (failed.length > 0) {
+				const failedSet = new Set(failed.map((item) => item.id));
+				if (action === 'delete') {
+					indexers = originalIndexers.filter(
+						(indexer) => !selectedSet.has(indexer.id) || failedSet.has(indexer.id)
+					);
+				} else {
+					indexers = indexers.map((indexer) => originalById.get(indexer.id) ?? indexer);
+				}
+
+				selectedIds = failedSet;
+				saveStatus = 'error';
+				saveError = failed
+					.slice(0, 4)
+					.map((item) => `${item.id}: ${item.error ?? 'operation failed'}`)
+					.join('\n');
+				return;
+			}
+
+			selectedIds = new Set();
+			saveStatus = 'saved';
+			scheduleBannerClear();
+		} catch (err) {
+			indexers = originalIndexers;
+			saveStatus = 'error';
+			saveError = err instanceof ApiError ? err.message : 'Bulk action failed.';
+		} finally {
+			bulkActing = false;
+		}
+	}
+
+	function openBulkDelete() {
+		if (!hasSelection) return;
+		bulkDeleteDialogOpen = true;
+	}
+
+	async function confirmBulkDelete() {
+		await runBulkAction('delete');
+		bulkDeleteDialogOpen = false;
+	}
+
 	// ── delete ─────────────────────────────────────────────────────────────────
 	function openDelete(indexer: Indexer) {
 		deleteTarget = indexer;
@@ -340,6 +434,19 @@
 >
 	{#snippet actions()}
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
+		{#if hasSelection}
+			<div class="bulk-toolbar">
+				<button class="btn-secondary" onclick={() => runBulkAction('enable')} disabled={bulkActing}>
+					Enable Selected
+				</button>
+				<button class="btn-secondary" onclick={() => runBulkAction('disable')} disabled={bulkActing}>
+					Disable Selected
+				</button>
+				<button class="btn-icon destructive" onclick={openBulkDelete} disabled={bulkActing}>
+					Delete Selected
+				</button>
+			</div>
+		{/if}
 		<button class="btn-primary" onclick={openAdd}>Add Indexer</button>
 	{/snippet}
 
@@ -354,9 +461,21 @@
 			onaction={openAdd}
 		/>
 	{:else}
+		<div class="bulk-select-row">
+			<label>
+				<input type="checkbox" checked={allSelected} onchange={toggleSelectAll} />
+				Select All ({selectedIds.size}/{indexers.length})
+			</label>
+		</div>
 		<ul class="indexer-list" role="list">
 			{#each indexers as indexer (indexer.id)}
 				<li class="indexer-item" class:disabled={!indexer.enabled}>
+					<input
+						type="checkbox"
+						checked={selectedIds.has(indexer.id)}
+						onchange={() => toggleRowSelection(indexer.id)}
+						aria-label="Select {indexer.name}"
+					/>
 					<div class="indexer-info">
 						<span class="indexer-name">{indexer.name}</span>
 						<span class="indexer-meta">
@@ -549,6 +668,16 @@
 	oncancel={cancelDelete}
 />
 
+<ConfirmDialog
+	open={bulkDeleteDialogOpen}
+	title="Delete Selected Indexers"
+	message={`Delete ${selectedIds.size} selected indexer(s)? This cannot be undone.`}
+	confirmLabel={bulkActing ? 'Deleting…' : 'Delete Selected'}
+	destructive
+	onconfirm={confirmBulkDelete}
+	oncancel={() => (bulkDeleteDialogOpen = false)}
+/>
+
 <style>
 	.indexer-list {
 		list-style: none;
@@ -557,6 +686,23 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
+	}
+
+	.bulk-toolbar {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.bulk-select-row {
+		margin-bottom: 0.6rem;
+		font-size: 0.85rem;
+	}
+
+	.bulk-select-row label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
 	}
 
 	.indexer-item {

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -348,7 +348,9 @@
 						(indexer) => !selectedSet.has(indexer.id) || failedSet.has(indexer.id)
 					);
 				} else {
-					indexers = indexers.map((indexer) => originalById.get(indexer.id) ?? indexer);
+					indexers = indexers.map((indexer) =>
+						failedSet.has(indexer.id) ? (originalById.get(indexer.id) ?? indexer) : indexer
+					);
 				}
 
 				selectedIds = failedSet;

--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -12,6 +12,7 @@
 		createMetadataProfile,
 		updateMetadataProfile,
 		deleteMetadataProfile,
+		bulkMetadataProfiles,
 		ApiError
 	} from '$lib/api';
 	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
@@ -64,6 +65,7 @@
 	}
 
 	let profiles = $state<MetadataProfile[]>([]);
+	let selectedIds = $state<Set<string>>(new Set());
 	let loading = $state(true);
 	let loadError = $state('');
 	let saveStatus = $state<SaveStatus>('idle');
@@ -88,6 +90,8 @@
 	let deleteDialogOpen = $state(false);
 	let deleteTarget = $state<MetadataProfile | null>(null);
 	let deleting = $state(false);
+	let bulkDeleteDialogOpen = $state(false);
+	let bulkActing = $state(false);
 
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
 	const unsavedGuard = useUnsavedGuard(() => {
@@ -164,6 +168,9 @@
 	}
 
 	onMount(load);
+
+	let hasSelection = $derived(selectedIds.size > 0);
+	let allSelected = $derived(profiles.length > 0 && profiles.every((profile) => selectedIds.has(profile.id)));
 
 	function openAdd() {
 		editingProfile = null;
@@ -296,6 +303,81 @@
 		deleteDialogOpen = true;
 	}
 
+	function toggleRowSelection(id: string) {
+		const next = new Set(selectedIds);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		selectedIds = next;
+	}
+
+	function toggleSelectAll() {
+		if (allSelected) {
+			selectedIds = new Set();
+			return;
+		}
+		selectedIds = new Set(profiles.map((profile) => profile.id));
+	}
+
+	async function runBulkAction(action: 'enable' | 'disable' | 'delete') {
+		if (selectedIds.size === 0) return;
+
+		const ids = [...selectedIds];
+		const selectedSet = new Set(ids);
+		const originalProfiles = profiles;
+
+		if (action === 'delete') {
+			profiles = profiles.filter((profile) => !selectedSet.has(profile.id));
+		}
+
+		saveStatus = 'saving';
+		saveError = '';
+		bulkActing = true;
+
+		try {
+			const result = await bulkMetadataProfiles({ action, ids });
+			const failed = result.results.filter((item) => !item.success);
+			if (failed.length > 0) {
+				const failedSet = new Set(failed.map((item) => item.id));
+				if (action === 'delete') {
+					profiles = originalProfiles.filter(
+						(profile) => !selectedSet.has(profile.id) || failedSet.has(profile.id)
+					);
+				}
+
+				selectedIds = failedSet;
+				saveStatus = 'error';
+				saveError = failed
+					.slice(0, 4)
+					.map((item) => `${item.id}: ${item.error ?? 'operation failed'}`)
+					.join('\n');
+				return;
+			}
+
+			selectedIds = new Set();
+			saveStatus = 'saved';
+			scheduleBannerClear();
+		} catch (err) {
+			profiles = originalProfiles;
+			saveStatus = 'error';
+			saveError = err instanceof ApiError ? err.message : 'Bulk action failed.';
+		} finally {
+			bulkActing = false;
+		}
+	}
+
+	function openBulkDelete() {
+		if (!hasSelection) return;
+		bulkDeleteDialogOpen = true;
+	}
+
+	async function confirmBulkDelete() {
+		await runBulkAction('delete');
+		bulkDeleteDialogOpen = false;
+	}
+
 	function cancelDelete() {
 		deleteDialogOpen = false;
 		deleteTarget = null;
@@ -348,6 +430,19 @@
 >
 	{#snippet actions()}
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
+		{#if hasSelection}
+			<div class="bulk-toolbar">
+				<button class="btn-secondary" onclick={() => runBulkAction('enable')} disabled={bulkActing}>
+					Enable Selected
+				</button>
+				<button class="btn-secondary" onclick={() => runBulkAction('disable')} disabled={bulkActing}>
+					Disable Selected
+				</button>
+				<button class="btn-icon destructive" onclick={openBulkDelete} disabled={bulkActing}>
+					Delete Selected
+				</button>
+			</div>
+		{/if}
 		<button class="btn-primary" onclick={openAdd}>Add Profile</button>
 	{/snippet}
 
@@ -362,9 +457,21 @@
 			onaction={openAdd}
 		/>
 	{:else}
+		<div class="bulk-select-row">
+			<label>
+				<input type="checkbox" checked={allSelected} onchange={toggleSelectAll} />
+				Select All ({selectedIds.size}/{profiles.length})
+			</label>
+		</div>
 		<ul class="profile-list" role="list">
 			{#each profiles as profile (profile.id)}
 				<li class="profile-item">
+					<input
+						type="checkbox"
+						checked={selectedIds.has(profile.id)}
+						onchange={() => toggleRowSelection(profile.id)}
+						aria-label="Select {profile.name}"
+					/>
 					<div class="profile-info">
 						<span class="profile-name">{profile.name}</span>
 						<span class="profile-meta">
@@ -622,6 +729,16 @@
 	oncancel={cancelDelete}
 />
 
+<ConfirmDialog
+	open={bulkDeleteDialogOpen}
+	title="Delete Selected Metadata Profiles"
+	message={`Delete ${selectedIds.size} selected metadata profile(s)? This cannot be undone.`}
+	confirmLabel={bulkActing ? 'Deleting...' : 'Delete Selected'}
+	destructive
+	onconfirm={confirmBulkDelete}
+	oncancel={() => (bulkDeleteDialogOpen = false)}
+/>
+
 <style>
 	.profile-list {
 		list-style: none;
@@ -630,6 +747,33 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
+	}
+
+	.bulk-toolbar {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.bulk-select-row {
+		margin-bottom: 0.6rem;
+		font-size: 0.85rem;
+	}
+
+	.bulk-select-row label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.btn-secondary {
+		padding: 0.45rem 0.8rem;
+		background: transparent;
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
+		border-radius: 6px;
+		font-size: 0.82rem;
+		cursor: pointer;
+		color: var(--text-primary, #0f1a1f);
 	}
 
 	.profile-item {

--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -321,7 +321,7 @@
 		selectedIds = new Set(profiles.map((profile) => profile.id));
 	}
 
-	async function runBulkAction(action: 'enable' | 'disable' | 'delete') {
+	async function runBulkAction(action: 'delete') {
 		if (selectedIds.size === 0) return;
 
 		const ids = [...selectedIds];
@@ -432,12 +432,6 @@
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
 		{#if hasSelection}
 			<div class="bulk-toolbar">
-				<button class="btn-secondary" onclick={() => runBulkAction('enable')} disabled={bulkActing}>
-					Enable Selected
-				</button>
-				<button class="btn-secondary" onclick={() => runBulkAction('disable')} disabled={bulkActing}>
-					Disable Selected
-				</button>
 				<button class="btn-icon destructive" onclick={openBulkDelete} disabled={bulkActing}>
 					Delete Selected
 				</button>
@@ -764,16 +758,6 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.4rem;
-	}
-
-	.btn-secondary {
-		padding: 0.45rem 0.8rem;
-		background: transparent;
-		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
-		border-radius: 6px;
-		font-size: 0.82rem;
-		cursor: pointer;
-		color: var(--text-primary, #0f1a1f);
 	}
 
 	.profile-item {

--- a/web/src/routes/(app)/settings/quality-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/quality-profiles/+page.svelte
@@ -12,6 +12,7 @@
 		createQualityProfile,
 		updateQualityProfile,
 		deleteQualityProfile,
+		bulkQualityProfiles,
 		ApiError
 	} from '$lib/api';
 	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
@@ -54,6 +55,7 @@
 
 	// ── state ──────────────────────────────────────────────────────────────────
 	let profiles = $state<QualityProfile[]>([]);
+	let selectedIds = $state<Set<string>>(new Set());
 	let loading = $state(true);
 	let loadError = $state('');
 	let saveStatus = $state<SaveStatus>('idle');
@@ -87,6 +89,8 @@
 	let deleteTarget = $state<QualityProfile | null>(null);
 	let deleteDialogOpen = $state(false);
 	let deleting = $state(false);
+	let bulkDeleteDialogOpen = $state(false);
+	let bulkActing = $state(false);
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
@@ -146,6 +150,9 @@
 	}
 
 	onMount(load);
+
+	let hasSelection = $derived(selectedIds.size > 0);
+	let allSelected = $derived(profiles.length > 0 && profiles.every((profile) => selectedIds.has(profile.id)));
 
 	// ── modal helpers ──────────────────────────────────────────────────────────
 	function openAdd() {
@@ -283,6 +290,81 @@
 		deleteDialogOpen = true;
 	}
 
+	function toggleRowSelection(id: string) {
+		const next = new Set(selectedIds);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		selectedIds = next;
+	}
+
+	function toggleSelectAll() {
+		if (allSelected) {
+			selectedIds = new Set();
+			return;
+		}
+		selectedIds = new Set(profiles.map((profile) => profile.id));
+	}
+
+	async function runBulkAction(action: 'enable' | 'disable' | 'delete') {
+		if (selectedIds.size === 0) return;
+
+		const ids = [...selectedIds];
+		const selectedSet = new Set(ids);
+		const originalProfiles = profiles;
+
+		if (action === 'delete') {
+			profiles = profiles.filter((profile) => !selectedSet.has(profile.id));
+		}
+
+		saveStatus = 'saving';
+		saveError = '';
+		bulkActing = true;
+
+		try {
+			const result = await bulkQualityProfiles({ action, ids });
+			const failed = result.results.filter((item) => !item.success);
+			if (failed.length > 0) {
+				const failedSet = new Set(failed.map((item) => item.id));
+				if (action === 'delete') {
+					profiles = originalProfiles.filter(
+						(profile) => !selectedSet.has(profile.id) || failedSet.has(profile.id)
+					);
+				}
+
+				selectedIds = failedSet;
+				saveStatus = 'error';
+				saveError = failed
+					.slice(0, 4)
+					.map((item) => `${item.id}: ${item.error ?? 'operation failed'}`)
+					.join('\n');
+				return;
+			}
+
+			selectedIds = new Set();
+			saveStatus = 'saved';
+			scheduleBannerClear();
+		} catch (err) {
+			profiles = originalProfiles;
+			saveStatus = 'error';
+			saveError = err instanceof ApiError ? err.message : 'Bulk action failed.';
+		} finally {
+			bulkActing = false;
+		}
+	}
+
+	function openBulkDelete() {
+		if (!hasSelection) return;
+		bulkDeleteDialogOpen = true;
+	}
+
+	async function confirmBulkDelete() {
+		await runBulkAction('delete');
+		bulkDeleteDialogOpen = false;
+	}
+
 	async function confirmDelete() {
 		if (!deleteTarget) return;
 		deleting = true;
@@ -335,6 +417,19 @@
 >
 	{#snippet actions()}
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
+		{#if hasSelection}
+			<div class="bulk-toolbar">
+				<button class="btn-secondary" onclick={() => runBulkAction('enable')} disabled={bulkActing}>
+					Enable Selected
+				</button>
+				<button class="btn-secondary" onclick={() => runBulkAction('disable')} disabled={bulkActing}>
+					Disable Selected
+				</button>
+				<button class="btn-icon destructive" onclick={openBulkDelete} disabled={bulkActing}>
+					Delete Selected
+				</button>
+			</div>
+		{/if}
 		<button class="btn-primary" onclick={openAdd}>Add Profile</button>
 	{/snippet}
 
@@ -349,9 +444,21 @@
 			onaction={openAdd}
 		/>
 	{:else}
+		<div class="bulk-select-row">
+			<label>
+				<input type="checkbox" checked={allSelected} onchange={toggleSelectAll} />
+				Select All ({selectedIds.size}/{profiles.length})
+			</label>
+		</div>
 		<ul class="profile-list" role="list">
 			{#each profiles as profile (profile.id)}
 				<li class="profile-item">
+					<input
+						type="checkbox"
+						checked={selectedIds.has(profile.id)}
+						onchange={() => toggleRowSelection(profile.id)}
+						aria-label="Select {profile.name}"
+					/>
 					<div class="profile-info">
 						<span class="profile-name">{profile.name}</span>
 						<span class="profile-meta">
@@ -512,6 +619,16 @@
 	oncancel={cancelDelete}
 />
 
+<ConfirmDialog
+	open={bulkDeleteDialogOpen}
+	title="Delete Selected Quality Profiles"
+	message={`Delete ${selectedIds.size} selected quality profile(s)? This cannot be undone.`}
+	confirmLabel={bulkActing ? 'Deleting…' : 'Delete Selected'}
+	destructive
+	onconfirm={confirmBulkDelete}
+	oncancel={() => (bulkDeleteDialogOpen = false)}
+/>
+
 <style>
 	.profile-list {
 		list-style: none;
@@ -520,6 +637,33 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
+	}
+
+	.bulk-toolbar {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.bulk-select-row {
+		margin-bottom: 0.6rem;
+		font-size: 0.85rem;
+	}
+
+	.bulk-select-row label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.btn-secondary {
+		padding: 0.45rem 0.8rem;
+		background: transparent;
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
+		border-radius: 6px;
+		font-size: 0.82rem;
+		cursor: pointer;
+		color: var(--text-primary, #0f1a1f);
 	}
 
 	.profile-item {

--- a/web/src/routes/(app)/settings/quality-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/quality-profiles/+page.svelte
@@ -308,7 +308,7 @@
 		selectedIds = new Set(profiles.map((profile) => profile.id));
 	}
 
-	async function runBulkAction(action: 'enable' | 'disable' | 'delete') {
+	async function runBulkAction(action: 'delete') {
 		if (selectedIds.size === 0) return;
 
 		const ids = [...selectedIds];
@@ -419,12 +419,6 @@
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
 		{#if hasSelection}
 			<div class="bulk-toolbar">
-				<button class="btn-secondary" onclick={() => runBulkAction('enable')} disabled={bulkActing}>
-					Enable Selected
-				</button>
-				<button class="btn-secondary" onclick={() => runBulkAction('disable')} disabled={bulkActing}>
-					Disable Selected
-				</button>
 				<button class="btn-icon destructive" onclick={openBulkDelete} disabled={bulkActing}>
 					Delete Selected
 				</button>
@@ -654,16 +648,6 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.4rem;
-	}
-
-	.btn-secondary {
-		padding: 0.45rem 0.8rem;
-		background: transparent;
-		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
-		border-radius: 6px;
-		font-size: 0.82rem;
-		cursor: pointer;
-		color: var(--text-primary, #0f1a1f);
 	}
 
 	.profile-item {


### PR DESCRIPTION
## Summary
- add bulk settings endpoints for download clients, indexers, quality profiles, and metadata profiles
- wire bulk routes into API router and OpenAPI docs
- add bulk actions UI (select all, enable/disable/delete selected, bulk delete confirm) on the four settings pages
- add optimistic update + rollback behavior with per-item error reporting

## Validation
- cargo fmt --all
- cargo test -p chorrosion-api
- npm run check (web)

Closes #464
