### PR TITLE
test(settings): expand settings UX test coverage (#466)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - name: Cargo build
         run: cargo build --workspace --all-targets --locked
@@ -111,6 +112,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - name: Install chromaprint (Ubuntu)
         run: |
@@ -167,6 +169,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - name: Install chromaprint (Ubuntu)
         run: |
@@ -251,6 +254,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - name: Test chorrosion-infrastructure
         run: cargo test -p chorrosion-infrastructure --no-fail-fast -- --nocapture

--- a/web/e2e/settings-crud.spec.ts
+++ b/web/e2e/settings-crud.spec.ts
@@ -1,0 +1,436 @@
+import { expect, test, type Page } from '@playwright/test';
+import { injectAuth, mockApiRoutes } from './helpers';
+
+type DownloadClient = {
+	id: string;
+	name: string;
+	client_type: string;
+	base_url: string;
+	username: string | null;
+	category: string | null;
+	enabled: boolean;
+	has_password: boolean;
+};
+
+type Indexer = {
+	id: string;
+	name: string;
+	base_url: string;
+	protocol: string;
+	enabled: boolean;
+	has_api_key: boolean;
+};
+
+type QualityProfile = {
+	id: string;
+	name: string;
+	allowed_qualities: string[];
+	upgrade_allowed: boolean;
+	cutoff_quality: string | null;
+};
+
+type MetadataProfile = {
+	id: string;
+	name: string;
+	primary_album_types: string[];
+	secondary_album_types: string[];
+	release_statuses: string[];
+};
+
+function routeJson(page: Page, glob: string, handler: (route: Parameters<Page['route']>[1] extends (route: infer R) => unknown ? R : never) => Promise<void> | void) {
+	return page.route(glob, handler);
+}
+
+async function mockDownloadClientsCrud(page: Page) {
+	let nextId = 2;
+	const items: DownloadClient[] = [
+		{
+			id: 'dc-1',
+			name: 'Seed Client',
+			client_type: 'qbittorrent',
+			base_url: 'http://localhost:8080',
+			username: null,
+			category: null,
+			enabled: true,
+			has_password: false
+		}
+	];
+
+	await routeJson(page, '**/api/v1/settings/download-clients**', async (route) => {
+		const req = route.request();
+		const method = req.method();
+		const url = new URL(req.url());
+		const path = url.pathname;
+
+		if (path.endsWith('/settings/download-clients') && method === 'GET') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
+			});
+			return;
+		}
+
+		if (path.endsWith('/settings/download-clients') && method === 'POST') {
+			const body = req.postDataJSON() as Partial<DownloadClient>;
+			const created: DownloadClient = {
+				id: `dc-${nextId++}`,
+				name: body.name ?? 'Unnamed',
+				client_type: body.client_type ?? 'qbittorrent',
+				base_url: body.base_url ?? 'http://localhost:8080',
+				username: body.username ?? null,
+				category: body.category ?? null,
+				enabled: body.enabled ?? true,
+				has_password: false
+			};
+			items.push(created);
+			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
+			return;
+		}
+
+		const id = path.split('/').pop() ?? '';
+		const idx = items.findIndex((item) => item.id === id);
+
+		if (idx === -1) {
+			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+			return;
+		}
+
+		if (method === 'PUT') {
+			const patch = req.postDataJSON() as Partial<DownloadClient>;
+			items[idx] = { ...items[idx], ...patch };
+			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
+			return;
+		}
+
+		if (method === 'DELETE') {
+			items.splice(idx, 1);
+			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+async function mockIndexersCrud(page: Page) {
+	let nextId = 2;
+	const items: Indexer[] = [
+		{
+			id: 'idx-1',
+			name: 'Seed Indexer',
+			base_url: 'http://localhost:9117',
+			protocol: 'torznab',
+			enabled: true,
+			has_api_key: false
+		}
+	];
+
+	await routeJson(page, '**/api/v1/settings/indexers**', async (route) => {
+		const req = route.request();
+		const method = req.method();
+		const url = new URL(req.url());
+		const path = url.pathname;
+
+		if (path.endsWith('/settings/indexers') && method === 'GET') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
+			});
+			return;
+		}
+
+		if (path.endsWith('/settings/indexers') && method === 'POST') {
+			const body = req.postDataJSON() as Partial<Indexer>;
+			const created: Indexer = {
+				id: `idx-${nextId++}`,
+				name: body.name ?? 'Unnamed',
+				base_url: body.base_url ?? 'http://localhost:9117',
+				protocol: body.protocol ?? 'torznab',
+				enabled: body.enabled ?? true,
+				has_api_key: Boolean(body.has_api_key)
+			};
+			items.push(created);
+			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
+			return;
+		}
+
+		if (path.endsWith('/indexers/test') && method === 'POST') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					success: true,
+					message: 'ok',
+					protocol: 'torznab',
+					capabilities: {
+						supports_search: true,
+						supports_rss: true,
+						supports_capabilities_detection: true,
+						supports_categories: true,
+						supported_categories: ['music']
+					}
+				})
+			});
+			return;
+		}
+
+		const id = path.split('/').pop() ?? '';
+		const idx = items.findIndex((item) => item.id === id);
+		if (idx === -1) {
+			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+			return;
+		}
+
+		if (method === 'PUT') {
+			const patch = req.postDataJSON() as Partial<Indexer>;
+			items[idx] = { ...items[idx], ...patch };
+			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
+			return;
+		}
+
+		if (method === 'DELETE') {
+			items.splice(idx, 1);
+			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+async function mockQualityProfilesCrud(page: Page) {
+	let nextId = 2;
+	const items: QualityProfile[] = [
+		{
+			id: 'qp-1',
+			name: 'Seed Quality',
+			allowed_qualities: ['FLAC'],
+			upgrade_allowed: true,
+			cutoff_quality: 'FLAC'
+		}
+	];
+
+	await routeJson(page, '**/api/v1/settings/quality-profiles**', async (route) => {
+		const req = route.request();
+		const method = req.method();
+		const path = new URL(req.url()).pathname;
+
+		if (path.endsWith('/settings/quality-profiles') && method === 'GET') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
+			});
+			return;
+		}
+
+		if (path.endsWith('/settings/quality-profiles') && method === 'POST') {
+			const body = req.postDataJSON() as Partial<QualityProfile>;
+			const created: QualityProfile = {
+				id: `qp-${nextId++}`,
+				name: body.name ?? 'Unnamed',
+				allowed_qualities: body.allowed_qualities ?? ['FLAC'],
+				upgrade_allowed: body.upgrade_allowed ?? true,
+				cutoff_quality: body.cutoff_quality ?? null
+			};
+			items.push(created);
+			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
+			return;
+		}
+
+		const id = path.split('/').pop() ?? '';
+		const idx = items.findIndex((item) => item.id === id);
+		if (idx === -1) {
+			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+			return;
+		}
+
+		if (method === 'PUT') {
+			const patch = req.postDataJSON() as Partial<QualityProfile>;
+			items[idx] = { ...items[idx], ...patch };
+			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
+			return;
+		}
+
+		if (method === 'DELETE') {
+			items.splice(idx, 1);
+			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+async function mockMetadataProfilesCrud(page: Page) {
+	let nextId = 2;
+	const items: MetadataProfile[] = [
+		{
+			id: 'mp-1',
+			name: 'Seed Metadata',
+			primary_album_types: ['Album'],
+			secondary_album_types: [],
+			release_statuses: ['Official']
+		}
+	];
+
+	await routeJson(page, '**/api/v1/settings/metadata-profiles**', async (route) => {
+		const req = route.request();
+		const method = req.method();
+		const path = new URL(req.url()).pathname;
+
+		if (path.endsWith('/settings/metadata-profiles') && method === 'GET') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
+			});
+			return;
+		}
+
+		if (path.endsWith('/settings/metadata-profiles') && method === 'POST') {
+			const body = req.postDataJSON() as Partial<MetadataProfile>;
+			const created: MetadataProfile = {
+				id: `mp-${nextId++}`,
+				name: body.name ?? 'Unnamed',
+				primary_album_types: body.primary_album_types ?? ['Album'],
+				secondary_album_types: body.secondary_album_types ?? [],
+				release_statuses: body.release_statuses ?? ['Official']
+			};
+			items.push(created);
+			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
+			return;
+		}
+
+		const id = path.split('/').pop() ?? '';
+		const idx = items.findIndex((item) => item.id === id);
+		if (idx === -1) {
+			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+			return;
+		}
+
+		if (method === 'PUT') {
+			const patch = req.postDataJSON() as Partial<MetadataProfile>;
+			items[idx] = { ...items[idx], ...patch };
+			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
+			return;
+		}
+
+		if (method === 'DELETE') {
+			items.splice(idx, 1);
+			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+test.describe.skip('Settings CRUD (blocked by /settings preview routing)', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockApiRoutes(page);
+		await injectAuth(page);
+	});
+
+	async function openSettingsSubpage(page: Page, linkName: string) {
+		await page.goto('/settings');
+		await page.getByRole('link', { name: linkName }).click();
+	}
+
+	test('download clients CRUD round trip', async ({ page }) => {
+		await mockDownloadClientsCrud(page);
+		await openSettingsSubpage(page, 'Download Clients');
+
+		await expect(page.getByText('Seed Client')).toBeVisible();
+
+		await page.getByRole('button', { name: 'Add Client' }).click();
+		await page.getByLabel('Name *').fill('Created Client');
+		await page.getByLabel('Base URL *').fill('http://localhost:8081');
+		await page.getByRole('button', { name: 'Add Client' }).last().click();
+		await expect(page.getByText('Created Client')).toBeVisible();
+
+		const row = page.locator('.client-item').filter({ hasText: 'Created Client' });
+		await row.getByRole('button', { name: /Edit/ }).click();
+		await page.getByLabel('Name *').fill('Updated Client');
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(page.getByText('Updated Client')).toBeVisible();
+
+		const updatedRow = page.locator('.client-item').filter({ hasText: 'Updated Client' });
+		await updatedRow.getByRole('button', { name: /Delete/ }).click();
+		const dialog = page.getByRole('dialog');
+		await dialog.getByRole('button', { name: 'Delete' }).click();
+		await expect(page.getByText('Updated Client')).not.toBeVisible();
+	});
+
+	test('indexers CRUD round trip', async ({ page }) => {
+		await mockIndexersCrud(page);
+		await openSettingsSubpage(page, 'Indexers');
+
+		await expect(page.getByText('Seed Indexer')).toBeVisible();
+
+		await page.getByRole('button', { name: 'Add Indexer' }).click();
+		await page.getByLabel('Name *').fill('Created Indexer');
+		await page.getByLabel('Base URL *').fill('http://localhost:9118');
+		await page.getByRole('button', { name: 'Add Indexer' }).last().click();
+		await expect(page.getByText('Created Indexer')).toBeVisible();
+
+		const row = page.locator('.indexer-item').filter({ hasText: 'Created Indexer' });
+		await row.getByRole('button', { name: /Edit/ }).click();
+		await page.getByLabel('Name *').fill('Updated Indexer');
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(page.getByText('Updated Indexer')).toBeVisible();
+
+		const updatedRow = page.locator('.indexer-item').filter({ hasText: 'Updated Indexer' });
+		await updatedRow.getByRole('button', { name: /Delete/ }).click();
+		await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click();
+		await expect(page.getByText('Updated Indexer')).not.toBeVisible();
+	});
+
+	test('quality profiles CRUD round trip', async ({ page }) => {
+		await mockQualityProfilesCrud(page);
+		await openSettingsSubpage(page, 'Quality Profiles');
+
+		await expect(page.getByText('Seed Quality')).toBeVisible();
+
+		await page.getByRole('button', { name: 'Add Profile' }).click();
+		await page.getByLabel('Name *').fill('Created Quality');
+		await page.getByRole('button', { name: 'Add Profile' }).last().click();
+		await expect(page.getByText('Created Quality')).toBeVisible();
+
+		const row = page.locator('.profile-item').filter({ hasText: 'Created Quality' });
+		await row.getByRole('button', { name: /Edit/ }).click();
+		await page.getByLabel('Name *').fill('Updated Quality');
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(page.getByText('Updated Quality')).toBeVisible();
+
+		const updatedRow = page.locator('.profile-item').filter({ hasText: 'Updated Quality' });
+		await updatedRow.getByRole('button', { name: /Delete/ }).click();
+		await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click();
+		await expect(page.getByText('Updated Quality')).not.toBeVisible();
+	});
+
+	test('metadata profiles CRUD round trip', async ({ page }) => {
+		await mockMetadataProfilesCrud(page);
+		await openSettingsSubpage(page, 'Metadata Profiles');
+
+		await expect(page.getByText('Seed Metadata')).toBeVisible();
+
+		await page.getByRole('button', { name: 'Add Profile' }).click();
+		await page.getByLabel('Name *').fill('Created Metadata');
+		await page.getByRole('button', { name: 'Add Profile' }).last().click();
+		await expect(page.getByText('Created Metadata')).toBeVisible();
+
+		const row = page.locator('.profile-item').filter({ hasText: 'Created Metadata' });
+		await row.getByRole('button', { name: /Edit/ }).click();
+		await page.getByLabel('Name *').fill('Updated Metadata');
+		await page.getByRole('button', { name: 'Save Changes' }).click();
+		await expect(page.getByText('Updated Metadata')).toBeVisible();
+
+		const updatedRow = page.locator('.profile-item').filter({ hasText: 'Updated Metadata' });
+		await updatedRow.getByRole('button', { name: /Delete/ }).click();
+		await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click();
+		await expect(page.getByText('Updated Metadata')).not.toBeVisible();
+	});
+});

--- a/web/e2e/settings-crud.spec.ts
+++ b/web/e2e/settings-crud.spec.ts
@@ -126,6 +126,30 @@ async function mockIndexersCrud(page: Page) {
 		}
 	];
 
+	await routeJson(page, '**/api/v1/indexers/test', async (route) => {
+		if (route.request().method() !== 'POST') {
+			await route.fallback();
+			return;
+		}
+
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				success: true,
+				message: 'ok',
+				protocol: 'torznab',
+				capabilities: {
+					supports_search: true,
+					supports_rss: true,
+					supports_capabilities_detection: true,
+					supports_categories: true,
+					supported_categories: ['music']
+				}
+			})
+		});
+	});
+
 	await routeJson(page, '**/api/v1/settings/indexers**', async (route) => {
 		const req = route.request();
 		const method = req.method();
@@ -153,26 +177,6 @@ async function mockIndexersCrud(page: Page) {
 			};
 			items.push(created);
 			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
-			return;
-		}
-
-		if (path.endsWith('/indexers/test') && method === 'POST') {
-			await route.fulfill({
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify({
-					success: true,
-					message: 'ok',
-					protocol: 'torznab',
-					capabilities: {
-						supports_search: true,
-						supports_rss: true,
-						supports_capabilities_detection: true,
-						supports_categories: true,
-						supported_categories: ['music']
-					}
-				})
-			});
 			return;
 		}
 

--- a/web/src/lib/api.client.test.ts
+++ b/web/src/lib/api.client.test.ts
@@ -53,7 +53,9 @@ describe('settings API client methods', () => {
 		await getDownloadClients({ limit: 50, offset: 0 });
 
 		expect(fetchMock).toHaveBeenCalledOnce();
-		expect(fetchMock.mock.calls[0][0]).toMatch('/api/v1/settings/download-clients?limit=50&offset=0');
+		expect(String(fetchMock.mock.calls[0][0])).toContain(
+			'/api/v1/settings/download-clients?limit=50&offset=0'
+		);
 	});
 
 	it('gets indexers list', async () => {
@@ -63,7 +65,7 @@ describe('settings API client methods', () => {
 
 		await getIndexers({ limit: 25 });
 
-		expect(fetchMock.mock.calls[0][0]).toMatch('/api/v1/settings/indexers?limit=25');
+		expect(String(fetchMock.mock.calls[0][0])).toContain('/api/v1/settings/indexers?limit=25');
 	});
 
 	it('gets quality profiles list', async () => {
@@ -73,7 +75,7 @@ describe('settings API client methods', () => {
 
 		await getQualityProfiles({ limit: 100 });
 
-		expect(fetchMock.mock.calls[0][0]).toMatch('/api/v1/settings/quality-profiles?limit=100');
+		expect(String(fetchMock.mock.calls[0][0])).toContain('/api/v1/settings/quality-profiles?limit=100');
 	});
 
 	it('gets metadata profiles list', async () => {
@@ -83,7 +85,7 @@ describe('settings API client methods', () => {
 
 		await getMetadataProfiles({ limit: 100 });
 
-		expect(fetchMock.mock.calls[0][0]).toMatch('/api/v1/settings/metadata-profiles?limit=100');
+		expect(String(fetchMock.mock.calls[0][0])).toContain('/api/v1/settings/metadata-profiles?limit=100');
 	});
 
 	it('creates a download client', async () => {

--- a/web/src/lib/api.client.test.ts
+++ b/web/src/lib/api.client.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	ApiError,
+	createDownloadClient,
+	createQualityProfile,
+	deleteMetadataProfile,
+	getDownloadClients,
+	getIndexers,
+	getMetadataProfiles,
+	getQualityProfiles,
+	parseApiError,
+	updateIndexer
+} from '$lib/api';
+
+describe('parseApiError', () => {
+	it('returns the API error field when present', () => {
+		expect(parseApiError({ error: 'bad request' }, 'fallback')).toBe('bad request');
+	});
+
+	it('falls back when body does not include error', () => {
+		expect(parseApiError({ message: 'nope' }, 'fallback')).toBe('fallback');
+	});
+
+	it('falls back for non-object values', () => {
+		expect(parseApiError('oops', 'fallback')).toBe('fallback');
+	});
+});
+
+describe('settings API client methods', () => {
+	const fetchMock = vi.fn<typeof fetch>();
+
+	beforeEach(() => {
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		fetchMock.mockReset();
+	});
+
+	function mockJson(status: number, body: unknown): Response {
+		return new Response(JSON.stringify(body), {
+			status,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	}
+
+	it('gets download clients with query params', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockJson(200, { items: [], total: 0, limit: 50, offset: 0 })
+		);
+
+		await getDownloadClients({ limit: 50, offset: 0 });
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(fetchMock.mock.calls[0][0]).toMatch('/api/v1/settings/download-clients?limit=50&offset=0');
+	});
+
+	it('gets indexers list', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockJson(200, { items: [], total: 0, limit: 25, offset: 0 })
+		);
+
+		await getIndexers({ limit: 25 });
+
+		expect(fetchMock.mock.calls[0][0]).toMatch('/api/v1/settings/indexers?limit=25');
+	});
+
+	it('gets quality profiles list', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockJson(200, { items: [], total: 0, limit: 100, offset: 0 })
+		);
+
+		await getQualityProfiles({ limit: 100 });
+
+		expect(fetchMock.mock.calls[0][0]).toMatch('/api/v1/settings/quality-profiles?limit=100');
+	});
+
+	it('gets metadata profiles list', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockJson(200, { items: [], total: 0, limit: 100, offset: 0 })
+		);
+
+		await getMetadataProfiles({ limit: 100 });
+
+		expect(fetchMock.mock.calls[0][0]).toMatch('/api/v1/settings/metadata-profiles?limit=100');
+	});
+
+	it('creates a download client', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockJson(201, {
+				id: 'dc-1',
+				name: 'Main',
+				client_type: 'qbittorrent',
+				base_url: 'http://localhost:8080',
+				username: null,
+				category: null,
+				enabled: true,
+				has_password: false
+			})
+		);
+
+		await createDownloadClient({
+			name: 'Main',
+			client_type: 'qbittorrent',
+			base_url: 'http://localhost:8080',
+			enabled: true
+		});
+
+		const [, init] = fetchMock.mock.calls[0];
+		expect(init?.method).toBe('POST');
+		expect(String(init?.body)).toContain('qbittorrent');
+	});
+
+	it('updates an indexer', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockJson(200, {
+				id: 'idx-1',
+				name: 'Idx',
+				base_url: 'http://localhost:9117',
+				protocol: 'torznab',
+				enabled: false,
+				has_api_key: false
+			})
+		);
+
+		await updateIndexer('idx-1', { enabled: false });
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toContain('/api/v1/settings/indexers/idx-1');
+		expect(init?.method).toBe('PUT');
+	});
+
+	it('creates a quality profile', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockJson(201, {
+				id: 'qp-1',
+				name: 'Lossless',
+				allowed_qualities: ['FLAC'],
+				upgrade_allowed: true,
+				cutoff_quality: 'FLAC'
+			})
+		);
+
+		await createQualityProfile({
+			name: 'Lossless',
+			allowed_qualities: ['FLAC'],
+			upgrade_allowed: true,
+			cutoff_quality: 'FLAC'
+		});
+
+		const [, init] = fetchMock.mock.calls[0];
+		expect(init?.method).toBe('POST');
+	});
+
+	it('deletes a metadata profile', async () => {
+		fetchMock.mockResolvedValueOnce(mockJson(204, {}));
+
+		await deleteMetadataProfile('mp-1');
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toContain('/api/v1/settings/metadata-profiles/mp-1');
+		expect(init?.method).toBe('DELETE');
+	});
+
+	it('throws ApiError with parsed message for 422/validation style body', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockJson(422, {
+				error: 'validation failed',
+				fields: [{ field: 'name', message: 'required' }]
+			})
+		);
+
+		const promise = getDownloadClients();
+		await expect(promise).rejects.toBeInstanceOf(ApiError);
+		await expect(promise).rejects.toMatchObject({ message: 'validation failed', status: 422 });
+	});
+
+	it('throws fallback ApiError message for 500 with non-json body', async () => {
+		fetchMock.mockResolvedValueOnce(new Response('server exploded', { status: 500 }));
+
+		await expect(getIndexers()).rejects.toMatchObject({
+			message: 'Request failed with status 500',
+			status: 500
+		});
+	});
+});

--- a/web/src/lib/stores/unsavedGuard.test.ts
+++ b/web/src/lib/stores/unsavedGuard.test.ts
@@ -73,4 +73,21 @@ describe('useUnsavedGuard', () => {
 		expect(guard.hasPendingNavigation).toBe(false);
 		expect(mockGoto).not.toHaveBeenCalled();
 	});
+
+	it('markClean prevents navigation from being blocked', () => {
+		const onBlocked = vi.fn();
+		const guard = useUnsavedGuard(onBlocked);
+		guard.markDirty();
+		guard.markClean();
+		const cancel = vi.fn();
+
+		navigationState.handler?.({
+			cancel,
+			to: { url: new URL('http://localhost/settings/metadata-profiles') }
+		});
+
+		expect(cancel).not.toHaveBeenCalled();
+		expect(onBlocked).not.toHaveBeenCalled();
+		expect(guard.hasPendingNavigation).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary
- add API client unit tests for settings list/create/update/delete methods and error handling
- extend unsaved guard tests with clean-state navigation behavior
- add settings CRUD E2E coverage scaffold for four settings pages
- mark settings CRUD E2E suite as skipped due existing preview routing 404 blocker for /settings paths

## Validation
- npm run test -- src/lib/api.client.test.ts src/lib/stores/unsavedGuard.test.ts src/lib/api.test.ts
- npm run check
- npx playwright test e2e/settings-crud.spec.ts --project=chromium (suite currently skipped)

Closes #466
