### PR TITLE
feat(settings): add import/export workflows for settings domains (#465)

### DIFF
--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -802,7 +802,7 @@ pub async fn export_download_clients(State(state): State<AppState>) -> impl Into
                         client_type: item.client_type,
                         base_url: item.base_url,
                         username: item.username,
-                        password: item.password_encrypted,
+                        password: None,
                         category: item.category,
                         enabled: item.enabled,
                     })
@@ -849,10 +849,6 @@ pub async fn import_download_clients(
     }
 
     let mut validation_errors = Vec::new();
-    if request.items.is_empty() {
-        validation_errors.push("items must contain at least one entry".to_string());
-    }
-
     for (idx, item) in request.items.iter().enumerate() {
         if item.name.trim().is_empty() {
             validation_errors.push(format!("items[{idx}].name cannot be empty"));

--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -9,6 +9,7 @@ use chorrosion_application::AppState;
 use chorrosion_domain::DownloadClientDefinition;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Deserialize, IntoParams)]
@@ -105,6 +106,76 @@ pub struct DownloadClientBulkItemResult {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct DownloadClientBulkResponse {
     pub results: Vec<DownloadClientBulkItemResult>,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct SettingsImportQuery {
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct DownloadClientImportItem {
+    pub name: String,
+    pub client_type: String,
+    pub base_url: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub category: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct DownloadClientExportEnvelope {
+    pub version: String,
+    pub exported_at: String,
+    pub items: Vec<DownloadClientImportItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportConflictPolicy {
+    Merge,
+    ReplaceAll,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DownloadClientImportRequest {
+    pub version: String,
+    #[serde(default = "default_import_conflict_policy")]
+    pub conflict_policy: ImportConflictPolicy,
+    pub items: Vec<DownloadClientImportItem>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportPreviewSummary {
+    pub added: usize,
+    pub updated: usize,
+    pub deleted: usize,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportPreviewItem {
+    pub name: String,
+    pub action: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DownloadClientImportResponse {
+    pub dry_run: bool,
+    pub summary: ImportPreviewSummary,
+    pub preview: Vec<ImportPreviewItem>,
+    pub results: Vec<DownloadClientBulkItemResult>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DownloadClientImportErrorResponse {
+    pub error: String,
+    pub details: Vec<String>,
+}
+
+fn default_import_conflict_policy() -> ImportConflictPolicy {
+    ImportConflictPolicy::Merge
 }
 
 fn default_true() -> bool {
@@ -703,6 +774,278 @@ pub async fn bulk_download_clients(
     };
 
     (status, Json(DownloadClientBulkResponse { results })).into_response()
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/settings/download-clients/export",
+    responses(
+        (status = 200, description = "Export download clients", body = DownloadClientExportEnvelope),
+        (status = 500, description = "Internal server error", body = DownloadClientErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn export_download_clients(State(state): State<AppState>) -> impl IntoResponse {
+    match state
+        .download_client_definition_repository
+        .list(5000, 0)
+        .await
+    {
+        Ok(items) => {
+            let exported = DownloadClientExportEnvelope {
+                version: "1".to_string(),
+                exported_at: Utc::now().to_rfc3339(),
+                items: items
+                    .into_iter()
+                    .map(|item| DownloadClientImportItem {
+                        name: item.name,
+                        client_type: item.client_type,
+                        base_url: item.base_url,
+                        username: item.username,
+                        password: item.password_encrypted,
+                        category: item.category,
+                        enabled: item.enabled,
+                    })
+                    .collect(),
+            };
+            (StatusCode::OK, Json(exported)).into_response()
+        }
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(DownloadClientErrorResponse {
+                error: format!("failed to export download clients: {error}"),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/settings/download-clients/import",
+    params(SettingsImportQuery),
+    request_body = DownloadClientImportRequest,
+    responses(
+        (status = 200, description = "Import processed", body = DownloadClientImportResponse),
+        (status = 400, description = "Invalid request", body = DownloadClientImportErrorResponse),
+        (status = 500, description = "Internal server error", body = DownloadClientErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn import_download_clients(
+    State(state): State<AppState>,
+    Query(query): Query<SettingsImportQuery>,
+    Json(request): Json<DownloadClientImportRequest>,
+) -> impl IntoResponse {
+    if request.version.trim() != "1" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(DownloadClientImportErrorResponse {
+                error: "unsupported import version".to_string(),
+                details: vec!["version must be '1'".to_string()],
+            }),
+        )
+            .into_response();
+    }
+
+    let mut validation_errors = Vec::new();
+    if request.items.is_empty() {
+        validation_errors.push("items must contain at least one entry".to_string());
+    }
+
+    for (idx, item) in request.items.iter().enumerate() {
+        if item.name.trim().is_empty() {
+            validation_errors.push(format!("items[{idx}].name cannot be empty"));
+        }
+        if validate_base_url(&item.base_url).is_err() {
+            validation_errors.push(format!("items[{idx}].base_url is invalid"));
+        }
+        if normalize_client_type(&item.client_type).is_err() {
+            validation_errors.push(format!("items[{idx}].client_type is not supported"));
+        }
+    }
+
+    if !validation_errors.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(DownloadClientImportErrorResponse {
+                error: "invalid import payload".to_string(),
+                details: validation_errors,
+            }),
+        )
+            .into_response();
+    }
+
+    let existing = match state
+        .download_client_definition_repository
+        .list(5000, 0)
+        .await
+    {
+        Ok(existing) => existing,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(DownloadClientErrorResponse {
+                    error: format!("failed to read existing download clients: {error}"),
+                }),
+            )
+                .into_response()
+        }
+    };
+
+    let mut existing_by_name: HashMap<String, DownloadClientDefinition> = HashMap::new();
+    for item in existing {
+        existing_by_name.insert(item.name.to_lowercase(), item);
+    }
+
+    let mut import_names = HashSet::new();
+    let mut preview = Vec::new();
+    let mut summary = ImportPreviewSummary {
+        added: 0,
+        updated: 0,
+        deleted: 0,
+    };
+
+    for item in &request.items {
+        let key = item.name.to_lowercase();
+        import_names.insert(key.clone());
+        if existing_by_name.contains_key(&key) {
+            summary.updated += 1;
+            preview.push(ImportPreviewItem {
+                name: item.name.clone(),
+                action: "update".to_string(),
+            });
+        } else {
+            summary.added += 1;
+            preview.push(ImportPreviewItem {
+                name: item.name.clone(),
+                action: "add".to_string(),
+            });
+        }
+    }
+
+    if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
+        for existing_item in existing_by_name.values() {
+            if !import_names.contains(&existing_item.name.to_lowercase()) {
+                summary.deleted += 1;
+                preview.push(ImportPreviewItem {
+                    name: existing_item.name.clone(),
+                    action: "delete".to_string(),
+                });
+            }
+        }
+    }
+
+    if query.dry_run {
+        return (
+            StatusCode::OK,
+            Json(DownloadClientImportResponse {
+                dry_run: true,
+                summary,
+                preview,
+                results: vec![],
+            }),
+        )
+            .into_response();
+    }
+
+    let mut results = Vec::new();
+
+    for item in &request.items {
+        let key = item.name.to_lowercase();
+        let client_type = match normalize_client_type(&item.client_type) {
+            Ok(client_type) => client_type,
+            Err(_) => {
+                results.push(DownloadClientBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some("unsupported client_type".to_string()),
+                });
+                continue;
+            }
+        };
+
+        if let Some(mut existing_item) = existing_by_name.get(&key).cloned() {
+            existing_item.name = item.name.trim().to_string();
+            existing_item.client_type = client_type;
+            existing_item.base_url = item.base_url.trim().to_string();
+            existing_item.username = normalize_optional(item.username.clone());
+            existing_item.password_encrypted = normalize_optional(item.password.clone());
+            existing_item.category = normalize_optional(item.category.clone());
+            existing_item.enabled = item.enabled;
+            existing_item.updated_at = Utc::now();
+
+            match state
+                .download_client_definition_repository
+                .update(existing_item)
+                .await
+            {
+                Ok(updated) => results.push(DownloadClientBulkItemResult {
+                    id: updated.id.to_string(),
+                    success: true,
+                    error: None,
+                }),
+                Err(error) => results.push(DownloadClientBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some(format!("failed to update download client: {error}")),
+                }),
+            }
+        } else {
+            let mut new_item =
+                DownloadClientDefinition::new(item.name.trim(), client_type, item.base_url.trim());
+            new_item.username = normalize_optional(item.username.clone());
+            new_item.password_encrypted = normalize_optional(item.password.clone());
+            new_item.category = normalize_optional(item.category.clone());
+            new_item.enabled = item.enabled;
+
+            match state
+                .download_client_definition_repository
+                .create(new_item)
+                .await
+            {
+                Ok(created) => results.push(DownloadClientBulkItemResult {
+                    id: created.id.to_string(),
+                    success: true,
+                    error: None,
+                }),
+                Err(error) => results.push(DownloadClientBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some(format!("failed to create download client: {error}")),
+                }),
+            }
+        }
+    }
+
+    if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
+        for existing_item in existing_by_name.values() {
+            if !import_names.contains(&existing_item.name.to_lowercase()) {
+                if let Err(error) = state
+                    .download_client_definition_repository
+                    .delete(&existing_item.id.to_string())
+                    .await
+                {
+                    results.push(DownloadClientBulkItemResult {
+                        id: existing_item.id.to_string(),
+                        success: false,
+                        error: Some(format!("failed to delete stale download client: {error}")),
+                    });
+                }
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(DownloadClientImportResponse {
+            dry_run: false,
+            summary,
+            preview,
+            results,
+        }),
+    )
+        .into_response()
 }
 
 #[cfg(test)]

--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -971,11 +971,11 @@ pub async fn import_download_clients(
             existing_item.enabled = item.enabled;
             existing_item.updated_at = Utc::now();
 
-            match state
+            let update_result = state
                 .download_client_definition_repository
                 .update(existing_item)
-                .await
-            {
+                .await;
+            match update_result {
                 Ok(updated) => results.push(DownloadClientBulkItemResult {
                     id: updated.id.to_string(),
                     success: true,
@@ -995,11 +995,11 @@ pub async fn import_download_clients(
             new_item.category = normalize_optional(item.category.clone());
             new_item.enabled = item.enabled;
 
-            match state
+            let create_result = state
                 .download_client_definition_repository
                 .create(new_item)
-                .await
-            {
+                .await;
+            match create_result {
                 Ok(created) => results.push(DownloadClientBulkItemResult {
                     id: created.id.to_string(),
                     success: true,
@@ -1017,11 +1017,11 @@ pub async fn import_download_clients(
     if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
         for existing_item in existing_by_name.values() {
             if !import_names.contains(&existing_item.name.to_lowercase()) {
-                if let Err(error) = state
+                let delete_result = state
                     .download_client_definition_repository
                     .delete(&existing_item.id.to_string())
-                    .await
-                {
+                    .await;
+                if let Err(error) = delete_result {
                     results.push(DownloadClientBulkItemResult {
                         id: existing_item.id.to_string(),
                         success: false,

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -9,6 +9,7 @@ use chorrosion_application::{AppState, IndexerCapabilities, IndexerProtocol};
 use chorrosion_domain::IndexerDefinition;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Deserialize, IntoParams)]
@@ -97,6 +98,74 @@ pub struct IndexerBulkItemResult {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct IndexerBulkResponse {
     pub results: Vec<IndexerBulkItemResult>,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct SettingsImportQuery {
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct IndexerImportItem {
+    pub name: String,
+    pub base_url: String,
+    pub protocol: String,
+    pub api_key: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct IndexerExportEnvelope {
+    pub version: String,
+    pub exported_at: String,
+    pub items: Vec<IndexerImportItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportConflictPolicy {
+    Merge,
+    ReplaceAll,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct IndexerImportRequest {
+    pub version: String,
+    #[serde(default = "default_import_conflict_policy")]
+    pub conflict_policy: ImportConflictPolicy,
+    pub items: Vec<IndexerImportItem>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportPreviewSummary {
+    pub added: usize,
+    pub updated: usize,
+    pub deleted: usize,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportPreviewItem {
+    pub name: String,
+    pub action: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct IndexerImportResponse {
+    pub dry_run: bool,
+    pub summary: ImportPreviewSummary,
+    pub preview: Vec<ImportPreviewItem>,
+    pub results: Vec<IndexerBulkItemResult>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct IndexerImportErrorResponse {
+    pub error: String,
+    pub details: Vec<String>,
+}
+
+fn default_import_conflict_policy() -> ImportConflictPolicy {
+    ImportConflictPolicy::Merge
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -660,6 +729,261 @@ pub async fn bulk_indexers(
     };
 
     (status, Json(IndexerBulkResponse { results })).into_response()
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/settings/indexers/export",
+    responses(
+        (status = 200, description = "Export indexers", body = IndexerExportEnvelope),
+        (status = 500, description = "Internal server error", body = IndexerErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn export_indexers(State(state): State<AppState>) -> impl IntoResponse {
+    match state.indexer_definition_repository.list(5000, 0).await {
+        Ok(items) => (
+            StatusCode::OK,
+            Json(IndexerExportEnvelope {
+                version: "1".to_string(),
+                exported_at: Utc::now().to_rfc3339(),
+                items: items
+                    .into_iter()
+                    .map(|item| IndexerImportItem {
+                        name: item.name,
+                        base_url: item.base_url,
+                        protocol: item.protocol,
+                        api_key: item.api_key,
+                        enabled: item.enabled,
+                    })
+                    .collect(),
+            }),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(IndexerErrorResponse {
+                error: format!("failed to export indexers: {error}"),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/settings/indexers/import",
+    params(SettingsImportQuery),
+    request_body = IndexerImportRequest,
+    responses(
+        (status = 200, description = "Import processed", body = IndexerImportResponse),
+        (status = 400, description = "Invalid request", body = IndexerImportErrorResponse),
+        (status = 500, description = "Internal server error", body = IndexerErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn import_indexers(
+    State(state): State<AppState>,
+    Query(query): Query<SettingsImportQuery>,
+    Json(request): Json<IndexerImportRequest>,
+) -> impl IntoResponse {
+    if request.version.trim() != "1" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(IndexerImportErrorResponse {
+                error: "unsupported import version".to_string(),
+                details: vec!["version must be '1'".to_string()],
+            }),
+        )
+            .into_response();
+    }
+
+    let mut validation_errors = Vec::new();
+    if request.items.is_empty() {
+        validation_errors.push("items must contain at least one entry".to_string());
+    }
+
+    for (idx, item) in request.items.iter().enumerate() {
+        if item.name.trim().is_empty() {
+            validation_errors.push(format!("items[{idx}].name cannot be empty"));
+        }
+        if validate_base_url(&item.base_url).is_err() {
+            validation_errors.push(format!("items[{idx}].base_url is invalid"));
+        }
+        if parse_protocol(&item.protocol).is_err() {
+            validation_errors.push(format!("items[{idx}].protocol is invalid"));
+        }
+    }
+
+    if !validation_errors.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(IndexerImportErrorResponse {
+                error: "invalid import payload".to_string(),
+                details: validation_errors,
+            }),
+        )
+            .into_response();
+    }
+
+    let existing = match state.indexer_definition_repository.list(5000, 0).await {
+        Ok(existing) => existing,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(IndexerErrorResponse {
+                    error: format!("failed to read existing indexers: {error}"),
+                }),
+            )
+                .into_response()
+        }
+    };
+
+    let mut existing_by_name: HashMap<String, IndexerDefinition> = HashMap::new();
+    for item in existing {
+        existing_by_name.insert(item.name.to_lowercase(), item);
+    }
+
+    let mut import_names = HashSet::new();
+    let mut preview = Vec::new();
+    let mut summary = ImportPreviewSummary {
+        added: 0,
+        updated: 0,
+        deleted: 0,
+    };
+
+    for item in &request.items {
+        let key = item.name.to_lowercase();
+        import_names.insert(key.clone());
+        if existing_by_name.contains_key(&key) {
+            summary.updated += 1;
+            preview.push(ImportPreviewItem {
+                name: item.name.clone(),
+                action: "update".to_string(),
+            });
+        } else {
+            summary.added += 1;
+            preview.push(ImportPreviewItem {
+                name: item.name.clone(),
+                action: "add".to_string(),
+            });
+        }
+    }
+
+    if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
+        for existing_item in existing_by_name.values() {
+            if !import_names.contains(&existing_item.name.to_lowercase()) {
+                summary.deleted += 1;
+                preview.push(ImportPreviewItem {
+                    name: existing_item.name.clone(),
+                    action: "delete".to_string(),
+                });
+            }
+        }
+    }
+
+    if query.dry_run {
+        return (
+            StatusCode::OK,
+            Json(IndexerImportResponse {
+                dry_run: true,
+                summary,
+                preview,
+                results: vec![],
+            }),
+        )
+            .into_response();
+    }
+
+    let mut results = Vec::new();
+
+    for item in &request.items {
+        let key = item.name.to_lowercase();
+        let protocol = match parse_protocol(&item.protocol) {
+            Ok(protocol) => protocol,
+            Err(_) => {
+                results.push(IndexerBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some("unsupported protocol".to_string()),
+                });
+                continue;
+            }
+        };
+
+        if let Some(mut existing_item) = existing_by_name.get(&key).cloned() {
+            existing_item.name = item.name.trim().to_string();
+            existing_item.base_url = item.base_url.trim().to_string();
+            existing_item.protocol = protocol.as_str().to_string();
+            existing_item.api_key = item.api_key.clone();
+            existing_item.enabled = item.enabled;
+            existing_item.updated_at = Utc::now();
+
+            match state
+                .indexer_definition_repository
+                .update(existing_item)
+                .await
+            {
+                Ok(updated) => results.push(IndexerBulkItemResult {
+                    id: updated.id.to_string(),
+                    success: true,
+                    error: None,
+                }),
+                Err(error) => results.push(IndexerBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some(format!("failed to update indexer: {error}")),
+                }),
+            }
+        } else {
+            let mut new_item =
+                IndexerDefinition::new(item.name.trim(), item.base_url.trim(), protocol.as_str());
+            new_item.api_key = item.api_key.clone();
+            new_item.enabled = item.enabled;
+
+            match state.indexer_definition_repository.create(new_item).await {
+                Ok(created) => results.push(IndexerBulkItemResult {
+                    id: created.id.to_string(),
+                    success: true,
+                    error: None,
+                }),
+                Err(error) => results.push(IndexerBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some(format!("failed to create indexer: {error}")),
+                }),
+            }
+        }
+    }
+
+    if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
+        for existing_item in existing_by_name.values() {
+            if !import_names.contains(&existing_item.name.to_lowercase()) {
+                if let Err(error) = state
+                    .indexer_definition_repository
+                    .delete(&existing_item.id.to_string())
+                    .await
+                {
+                    results.push(IndexerBulkItemResult {
+                        id: existing_item.id.to_string(),
+                        success: false,
+                        error: Some(format!("failed to delete stale indexer: {error}")),
+                    });
+                }
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(IndexerImportResponse {
+            dry_run: false,
+            summary,
+            preview,
+            results,
+        }),
+    )
+        .into_response()
 }
 
 #[derive(Debug, Serialize, ToSchema)]

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -753,7 +753,7 @@ pub async fn export_indexers(State(state): State<AppState>) -> impl IntoResponse
                         name: item.name,
                         base_url: item.base_url,
                         protocol: item.protocol,
-                        api_key: item.api_key,
+                        api_key: None,
                         enabled: item.enabled,
                     })
                     .collect(),
@@ -799,10 +799,6 @@ pub async fn import_indexers(
     }
 
     let mut validation_errors = Vec::new();
-    if request.items.is_empty() {
-        validation_errors.push("items must contain at least one entry".to_string());
-    }
-
     for (idx, item) in request.items.iter().enumerate() {
         if item.name.trim().is_empty() {
             validation_errors.push(format!("items[{idx}].name cannot be empty"));
@@ -915,7 +911,10 @@ pub async fn import_indexers(
             existing_item.name = item.name.trim().to_string();
             existing_item.base_url = item.base_url.trim().to_string();
             existing_item.protocol = protocol.as_str().to_string();
-            existing_item.api_key = item.api_key.clone();
+            existing_item.api_key = item.api_key.as_ref().and_then(|key| {
+                let trimmed = key.trim();
+                if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+            });
             existing_item.enabled = item.enabled;
             existing_item.updated_at = Utc::now();
 
@@ -938,7 +937,10 @@ pub async fn import_indexers(
         } else {
             let mut new_item =
                 IndexerDefinition::new(item.name.trim(), item.base_url.trim(), protocol.as_str());
-            new_item.api_key = item.api_key.clone();
+            new_item.api_key = item.api_key.as_ref().and_then(|key| {
+                let trimmed = key.trim();
+                if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+            });
             new_item.enabled = item.enabled;
 
             match state.indexer_definition_repository.create(new_item).await {

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -918,11 +918,11 @@ pub async fn import_indexers(
             existing_item.enabled = item.enabled;
             existing_item.updated_at = Utc::now();
 
-            match state
+            let update_result = state
                 .indexer_definition_repository
                 .update(existing_item)
-                .await
-            {
+                .await;
+            match update_result {
                 Ok(updated) => results.push(IndexerBulkItemResult {
                     id: updated.id.to_string(),
                     success: true,
@@ -943,7 +943,8 @@ pub async fn import_indexers(
             });
             new_item.enabled = item.enabled;
 
-            match state.indexer_definition_repository.create(new_item).await {
+            let create_result = state.indexer_definition_repository.create(new_item).await;
+            match create_result {
                 Ok(created) => results.push(IndexerBulkItemResult {
                     id: created.id.to_string(),
                     success: true,
@@ -961,11 +962,11 @@ pub async fn import_indexers(
     if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
         for existing_item in existing_by_name.values() {
             if !import_names.contains(&existing_item.name.to_lowercase()) {
-                if let Err(error) = state
+                let delete_result = state
                     .indexer_definition_repository
                     .delete(&existing_item.id.to_string())
-                    .await
-                {
+                    .await;
+                if let Err(error) = delete_result {
                     results.push(IndexerBulkItemResult {
                         id: existing_item.id.to_string(),
                         success: false,

--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -9,6 +9,7 @@ use chorrosion_application::AppState;
 use chorrosion_domain::MetadataProfile;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use tracing::debug;
 use utoipa::{IntoParams, ToSchema};
 
@@ -91,6 +92,73 @@ pub struct MetadataProfileBulkItemResult {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct MetadataProfileBulkResponse {
     pub results: Vec<MetadataProfileBulkItemResult>,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct SettingsImportQuery {
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct MetadataProfileImportItem {
+    pub name: String,
+    pub primary_album_types: Vec<String>,
+    pub secondary_album_types: Vec<String>,
+    pub release_statuses: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct MetadataProfileExportEnvelope {
+    pub version: String,
+    pub exported_at: String,
+    pub items: Vec<MetadataProfileImportItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportConflictPolicy {
+    Merge,
+    ReplaceAll,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct MetadataProfileImportRequest {
+    pub version: String,
+    #[serde(default = "default_import_conflict_policy")]
+    pub conflict_policy: ImportConflictPolicy,
+    pub items: Vec<MetadataProfileImportItem>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportPreviewSummary {
+    pub added: usize,
+    pub updated: usize,
+    pub deleted: usize,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportPreviewItem {
+    pub name: String,
+    pub action: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MetadataProfileImportResponse {
+    pub dry_run: bool,
+    pub summary: ImportPreviewSummary,
+    pub preview: Vec<ImportPreviewItem>,
+    pub results: Vec<MetadataProfileBulkItemResult>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MetadataProfileImportErrorResponse {
+    pub error: String,
+    pub details: Vec<String>,
+}
+
+fn default_import_conflict_policy() -> ImportConflictPolicy {
+    ImportConflictPolicy::Merge
 }
 
 fn validate_name(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
@@ -476,6 +544,233 @@ pub async fn bulk_metadata_profiles(
     };
 
     (status, Json(MetadataProfileBulkResponse { results })).into_response()
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/settings/metadata-profiles/export",
+    responses(
+        (status = 200, description = "Export metadata profiles", body = MetadataProfileExportEnvelope),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn export_metadata_profiles(State(state): State<AppState>) -> impl IntoResponse {
+    match state.metadata_profile_repository.list(5000, 0).await {
+        Ok(items) => (
+            StatusCode::OK,
+            Json(MetadataProfileExportEnvelope {
+                version: "1".to_string(),
+                exported_at: Utc::now().to_rfc3339(),
+                items: items
+                    .into_iter()
+                    .map(|item| MetadataProfileImportItem {
+                        name: item.name,
+                        primary_album_types: item.primary_album_types,
+                        secondary_album_types: item.secondary_album_types,
+                        release_statuses: item.release_statuses,
+                    })
+                    .collect(),
+            }),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("failed to export metadata profiles: {error}"),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/settings/metadata-profiles/import",
+    params(SettingsImportQuery),
+    request_body = MetadataProfileImportRequest,
+    responses(
+        (status = 200, description = "Import processed", body = MetadataProfileImportResponse),
+        (status = 400, description = "Invalid request", body = MetadataProfileImportErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn import_metadata_profiles(
+    State(state): State<AppState>,
+    Query(query): Query<SettingsImportQuery>,
+    Json(request): Json<MetadataProfileImportRequest>,
+) -> impl IntoResponse {
+    if request.version.trim() != "1" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(MetadataProfileImportErrorResponse {
+                error: "unsupported import version".to_string(),
+                details: vec!["version must be '1'".to_string()],
+            }),
+        )
+            .into_response();
+    }
+
+    let mut validation_errors = Vec::new();
+    if request.items.is_empty() {
+        validation_errors.push("items must contain at least one entry".to_string());
+    }
+    for (idx, item) in request.items.iter().enumerate() {
+        if item.name.trim().is_empty() {
+            validation_errors.push(format!("items[{idx}].name cannot be empty"));
+        }
+    }
+    if !validation_errors.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(MetadataProfileImportErrorResponse {
+                error: "invalid import payload".to_string(),
+                details: validation_errors,
+            }),
+        )
+            .into_response();
+    }
+
+    let existing = match state.metadata_profile_repository.list(5000, 0).await {
+        Ok(existing) => existing,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("failed to read existing metadata profiles: {error}"),
+                }),
+            )
+                .into_response()
+        }
+    };
+    let mut existing_by_name: HashMap<String, MetadataProfile> = HashMap::new();
+    for item in existing {
+        existing_by_name.insert(item.name.to_lowercase(), item);
+    }
+
+    let mut import_names = HashSet::new();
+    let mut preview = Vec::new();
+    let mut summary = ImportPreviewSummary {
+        added: 0,
+        updated: 0,
+        deleted: 0,
+    };
+    for item in &request.items {
+        let key = item.name.to_lowercase();
+        import_names.insert(key.clone());
+        if existing_by_name.contains_key(&key) {
+            summary.updated += 1;
+            preview.push(ImportPreviewItem {
+                name: item.name.clone(),
+                action: "update".to_string(),
+            });
+        } else {
+            summary.added += 1;
+            preview.push(ImportPreviewItem {
+                name: item.name.clone(),
+                action: "add".to_string(),
+            });
+        }
+    }
+    if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
+        for existing_item in existing_by_name.values() {
+            if !import_names.contains(&existing_item.name.to_lowercase()) {
+                summary.deleted += 1;
+                preview.push(ImportPreviewItem {
+                    name: existing_item.name.clone(),
+                    action: "delete".to_string(),
+                });
+            }
+        }
+    }
+
+    if query.dry_run {
+        return (
+            StatusCode::OK,
+            Json(MetadataProfileImportResponse {
+                dry_run: true,
+                summary,
+                preview,
+                results: vec![],
+            }),
+        )
+            .into_response();
+    }
+
+    let mut results = Vec::new();
+    for item in &request.items {
+        let key = item.name.to_lowercase();
+        if let Some(mut existing_item) = existing_by_name.get(&key).cloned() {
+            existing_item.name = item.name.clone();
+            existing_item.primary_album_types = item.primary_album_types.clone();
+            existing_item.secondary_album_types = item.secondary_album_types.clone();
+            existing_item.release_statuses = item.release_statuses.clone();
+            existing_item.updated_at = Utc::now();
+            match state
+                .metadata_profile_repository
+                .update(existing_item)
+                .await
+            {
+                Ok(updated) => results.push(MetadataProfileBulkItemResult {
+                    id: updated.id.to_string(),
+                    success: true,
+                    error: None,
+                }),
+                Err(error) => results.push(MetadataProfileBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some(format!("failed to update metadata profile: {error}")),
+                }),
+            }
+        } else {
+            let mut new_item = MetadataProfile::new(item.name.clone());
+            new_item.primary_album_types = item.primary_album_types.clone();
+            new_item.secondary_album_types = item.secondary_album_types.clone();
+            new_item.release_statuses = item.release_statuses.clone();
+            match state.metadata_profile_repository.create(new_item).await {
+                Ok(created) => results.push(MetadataProfileBulkItemResult {
+                    id: created.id.to_string(),
+                    success: true,
+                    error: None,
+                }),
+                Err(error) => results.push(MetadataProfileBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some(format!("failed to create metadata profile: {error}")),
+                }),
+            }
+        }
+    }
+
+    if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
+        for existing_item in existing_by_name.values() {
+            if !import_names.contains(&existing_item.name.to_lowercase()) {
+                if let Err(error) = state
+                    .metadata_profile_repository
+                    .delete(&existing_item.id.to_string())
+                    .await
+                {
+                    results.push(MetadataProfileBulkItemResult {
+                        id: existing_item.id.to_string(),
+                        success: false,
+                        error: Some(format!("failed to delete stale metadata profile: {error}")),
+                    });
+                }
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(MetadataProfileImportResponse {
+            dry_run: false,
+            summary,
+            preview,
+            results,
+        }),
+    )
+        .into_response()
 }
 
 #[cfg(test)]

--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -704,11 +704,11 @@ pub async fn import_metadata_profiles(
             existing_item.secondary_album_types = item.secondary_album_types.clone();
             existing_item.release_statuses = item.release_statuses.clone();
             existing_item.updated_at = Utc::now();
-            match state
+            let update_result = state
                 .metadata_profile_repository
                 .update(existing_item)
-                .await
-            {
+                .await;
+            match update_result {
                 Ok(updated) => results.push(MetadataProfileBulkItemResult {
                     id: updated.id.to_string(),
                     success: true,
@@ -725,7 +725,8 @@ pub async fn import_metadata_profiles(
             new_item.primary_album_types = item.primary_album_types.clone();
             new_item.secondary_album_types = item.secondary_album_types.clone();
             new_item.release_statuses = item.release_statuses.clone();
-            match state.metadata_profile_repository.create(new_item).await {
+            let create_result = state.metadata_profile_repository.create(new_item).await;
+            match create_result {
                 Ok(created) => results.push(MetadataProfileBulkItemResult {
                     id: created.id.to_string(),
                     success: true,
@@ -743,11 +744,11 @@ pub async fn import_metadata_profiles(
     if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
         for existing_item in existing_by_name.values() {
             if !import_names.contains(&existing_item.name.to_lowercase()) {
-                if let Err(error) = state
+                let delete_result = state
                     .metadata_profile_repository
                     .delete(&existing_item.id.to_string())
-                    .await
-                {
+                    .await;
+                if let Err(error) = delete_result {
                     results.push(MetadataProfileBulkItemResult {
                         id: existing_item.id.to_string(),
                         success: false,

--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -613,9 +613,6 @@ pub async fn import_metadata_profiles(
     }
 
     let mut validation_errors = Vec::new();
-    if request.items.is_empty() {
-        validation_errors.push("items must contain at least one entry".to_string());
-    }
     for (idx, item) in request.items.iter().enumerate() {
         if item.name.trim().is_empty() {
             validation_errors.push(format!("items[{idx}].name cannot be empty"));

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -8,6 +8,7 @@ use axum::{
 use chorrosion_application::AppState;
 use chorrosion_domain::QualityProfile;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use tracing::debug;
 use utoipa::{IntoParams, ToSchema};
 
@@ -91,6 +92,73 @@ pub struct QualityProfileBulkItemResult {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct QualityProfileBulkResponse {
     pub results: Vec<QualityProfileBulkItemResult>,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct SettingsImportQuery {
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct QualityProfileImportItem {
+    pub name: String,
+    pub allowed_qualities: Vec<String>,
+    pub upgrade_allowed: bool,
+    pub cutoff_quality: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct QualityProfileExportEnvelope {
+    pub version: String,
+    pub exported_at: String,
+    pub items: Vec<QualityProfileImportItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportConflictPolicy {
+    Merge,
+    ReplaceAll,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct QualityProfileImportRequest {
+    pub version: String,
+    #[serde(default = "default_import_conflict_policy")]
+    pub conflict_policy: ImportConflictPolicy,
+    pub items: Vec<QualityProfileImportItem>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportPreviewSummary {
+    pub added: usize,
+    pub updated: usize,
+    pub deleted: usize,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportPreviewItem {
+    pub name: String,
+    pub action: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct QualityProfileImportResponse {
+    pub dry_run: bool,
+    pub summary: ImportPreviewSummary,
+    pub preview: Vec<ImportPreviewItem>,
+    pub results: Vec<QualityProfileBulkItemResult>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct QualityProfileImportErrorResponse {
+    pub error: String,
+    pub details: Vec<String>,
+}
+
+fn default_import_conflict_policy() -> ImportConflictPolicy {
+    ImportConflictPolicy::Merge
 }
 
 fn validate_name(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
@@ -488,6 +556,233 @@ pub async fn bulk_quality_profiles(
     };
 
     (status, Json(QualityProfileBulkResponse { results })).into_response()
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/settings/quality-profiles/export",
+    responses(
+        (status = 200, description = "Export quality profiles", body = QualityProfileExportEnvelope),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn export_quality_profiles(State(state): State<AppState>) -> impl IntoResponse {
+    match state.quality_profile_repository.list(5000, 0).await {
+        Ok(items) => (
+            StatusCode::OK,
+            Json(QualityProfileExportEnvelope {
+                version: "1".to_string(),
+                exported_at: chrono::Utc::now().to_rfc3339(),
+                items: items
+                    .into_iter()
+                    .map(|item| QualityProfileImportItem {
+                        name: item.name,
+                        allowed_qualities: item.allowed_qualities,
+                        upgrade_allowed: item.upgrade_allowed,
+                        cutoff_quality: item.cutoff_quality,
+                    })
+                    .collect(),
+            }),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("failed to export quality profiles: {error}"),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/settings/quality-profiles/import",
+    params(SettingsImportQuery),
+    request_body = QualityProfileImportRequest,
+    responses(
+        (status = 200, description = "Import processed", body = QualityProfileImportResponse),
+        (status = 400, description = "Invalid request", body = QualityProfileImportErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "settings"
+)]
+pub async fn import_quality_profiles(
+    State(state): State<AppState>,
+    Query(query): Query<SettingsImportQuery>,
+    Json(request): Json<QualityProfileImportRequest>,
+) -> impl IntoResponse {
+    if request.version.trim() != "1" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(QualityProfileImportErrorResponse {
+                error: "unsupported import version".to_string(),
+                details: vec!["version must be '1'".to_string()],
+            }),
+        )
+            .into_response();
+    }
+
+    let mut validation_errors = Vec::new();
+    if request.items.is_empty() {
+        validation_errors.push("items must contain at least one entry".to_string());
+    }
+    for (idx, item) in request.items.iter().enumerate() {
+        if item.name.trim().is_empty() {
+            validation_errors.push(format!("items[{idx}].name cannot be empty"));
+        }
+        if validate_allowed_qualities(&item.allowed_qualities).is_err() {
+            validation_errors.push(format!(
+                "items[{idx}].allowed_qualities must contain at least one value"
+            ));
+        }
+    }
+    if !validation_errors.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(QualityProfileImportErrorResponse {
+                error: "invalid import payload".to_string(),
+                details: validation_errors,
+            }),
+        )
+            .into_response();
+    }
+
+    let existing = match state.quality_profile_repository.list(5000, 0).await {
+        Ok(existing) => existing,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("failed to read existing quality profiles: {error}"),
+                }),
+            )
+                .into_response()
+        }
+    };
+    let mut existing_by_name: HashMap<String, QualityProfile> = HashMap::new();
+    for item in existing {
+        existing_by_name.insert(item.name.to_lowercase(), item);
+    }
+
+    let mut import_names = HashSet::new();
+    let mut preview = Vec::new();
+    let mut summary = ImportPreviewSummary {
+        added: 0,
+        updated: 0,
+        deleted: 0,
+    };
+    for item in &request.items {
+        let key = item.name.to_lowercase();
+        import_names.insert(key.clone());
+        if existing_by_name.contains_key(&key) {
+            summary.updated += 1;
+            preview.push(ImportPreviewItem {
+                name: item.name.clone(),
+                action: "update".to_string(),
+            });
+        } else {
+            summary.added += 1;
+            preview.push(ImportPreviewItem {
+                name: item.name.clone(),
+                action: "add".to_string(),
+            });
+        }
+    }
+    if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
+        for existing_item in existing_by_name.values() {
+            if !import_names.contains(&existing_item.name.to_lowercase()) {
+                summary.deleted += 1;
+                preview.push(ImportPreviewItem {
+                    name: existing_item.name.clone(),
+                    action: "delete".to_string(),
+                });
+            }
+        }
+    }
+
+    if query.dry_run {
+        return (
+            StatusCode::OK,
+            Json(QualityProfileImportResponse {
+                dry_run: true,
+                summary,
+                preview,
+                results: vec![],
+            }),
+        )
+            .into_response();
+    }
+
+    let mut results = Vec::new();
+    for item in &request.items {
+        let key = item.name.to_lowercase();
+        if let Some(mut existing_item) = existing_by_name.get(&key).cloned() {
+            existing_item.name = item.name.clone();
+            existing_item.allowed_qualities = item.allowed_qualities.clone();
+            existing_item.upgrade_allowed = item.upgrade_allowed;
+            existing_item.cutoff_quality = item.cutoff_quality.clone();
+            match state.quality_profile_repository.update(existing_item).await {
+                Ok(updated) => results.push(QualityProfileBulkItemResult {
+                    id: updated.id.to_string(),
+                    success: true,
+                    error: None,
+                }),
+                Err(error) => results.push(QualityProfileBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some(format!("failed to update quality profile: {error}")),
+                }),
+            }
+        } else {
+            let mut new_item =
+                QualityProfile::new(item.name.clone(), item.allowed_qualities.clone());
+            new_item.upgrade_allowed = item.upgrade_allowed;
+            new_item.cutoff_quality = item.cutoff_quality.clone();
+            match state.quality_profile_repository.create(new_item).await {
+                Ok(created) => results.push(QualityProfileBulkItemResult {
+                    id: created.id.to_string(),
+                    success: true,
+                    error: None,
+                }),
+                Err(error) => results.push(QualityProfileBulkItemResult {
+                    id: item.name.clone(),
+                    success: false,
+                    error: Some(format!("failed to create quality profile: {error}")),
+                }),
+            }
+        }
+    }
+
+    if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
+        for existing_item in existing_by_name.values() {
+            if !import_names.contains(&existing_item.name.to_lowercase()) {
+                if let Err(error) = state
+                    .quality_profile_repository
+                    .delete(&existing_item.id.to_string())
+                    .await
+                {
+                    results.push(QualityProfileBulkItemResult {
+                        id: existing_item.id.to_string(),
+                        success: false,
+                        error: Some(format!("failed to delete stale quality profile: {error}")),
+                    });
+                }
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(QualityProfileImportResponse {
+            dry_run: false,
+            summary,
+            preview,
+            results,
+        }),
+    )
+        .into_response()
 }
 
 #[cfg(test)]

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -625,9 +625,6 @@ pub async fn import_quality_profiles(
     }
 
     let mut validation_errors = Vec::new();
-    if request.items.is_empty() {
-        validation_errors.push("items must contain at least one entry".to_string());
-    }
     for (idx, item) in request.items.iter().enumerate() {
         if item.name.trim().is_empty() {
             validation_errors.push(format!("items[{idx}].name cannot be empty"));

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -720,7 +720,8 @@ pub async fn import_quality_profiles(
             existing_item.allowed_qualities = item.allowed_qualities.clone();
             existing_item.upgrade_allowed = item.upgrade_allowed;
             existing_item.cutoff_quality = item.cutoff_quality.clone();
-            match state.quality_profile_repository.update(existing_item).await {
+            let update_result = state.quality_profile_repository.update(existing_item).await;
+            match update_result {
                 Ok(updated) => results.push(QualityProfileBulkItemResult {
                     id: updated.id.to_string(),
                     success: true,
@@ -737,7 +738,8 @@ pub async fn import_quality_profiles(
                 QualityProfile::new(item.name.clone(), item.allowed_qualities.clone());
             new_item.upgrade_allowed = item.upgrade_allowed;
             new_item.cutoff_quality = item.cutoff_quality.clone();
-            match state.quality_profile_repository.create(new_item).await {
+            let create_result = state.quality_profile_repository.create(new_item).await;
+            match create_result {
                 Ok(created) => results.push(QualityProfileBulkItemResult {
                     id: created.id.to_string(),
                     success: true,
@@ -755,11 +757,11 @@ pub async fn import_quality_profiles(
     if matches!(request.conflict_policy, ImportConflictPolicy::ReplaceAll) {
         for existing_item in existing_by_name.values() {
             if !import_names.contains(&existing_item.name.to_lowercase()) {
-                if let Err(error) = state
+                let delete_result = state
                     .quality_profile_repository
                     .delete(&existing_item.id.to_string())
-                    .await
-                {
+                    .await;
+                if let Err(error) = delete_result {
                     results.push(QualityProfileBulkItemResult {
                         id: existing_item.id.to_string(),
                         success: false,

--- a/crates/chorrosion-api/src/lib.rs
+++ b/crates/chorrosion-api/src/lib.rs
@@ -55,12 +55,15 @@ use handlers::calendar::{
     CalendarResponse, __path_get_ical_feed, __path_list_upcoming_releases,
 };
 use handlers::download_clients::{
-    bulk_download_clients, create_download_client, delete_download_client, get_download_client,
-    list_download_clients, update_download_client, CreateDownloadClientRequest,
-    DownloadClientBulkRequest, DownloadClientBulkResponse, DownloadClientErrorResponse,
-    DownloadClientResponse, ListDownloadClientsResponse, UpdateDownloadClientRequest,
-    __path_bulk_download_clients, __path_create_download_client, __path_delete_download_client,
-    __path_get_download_client, __path_list_download_clients, __path_update_download_client,
+    bulk_download_clients, create_download_client, delete_download_client, export_download_clients,
+    get_download_client, import_download_clients, list_download_clients, update_download_client,
+    CreateDownloadClientRequest, DownloadClientBulkRequest, DownloadClientBulkResponse,
+    DownloadClientErrorResponse, DownloadClientExportEnvelope, DownloadClientImportErrorResponse,
+    DownloadClientImportRequest, DownloadClientImportResponse, DownloadClientResponse,
+    ListDownloadClientsResponse, UpdateDownloadClientRequest, __path_bulk_download_clients,
+    __path_create_download_client, __path_delete_download_client, __path_export_download_clients,
+    __path_get_download_client, __path_import_download_clients, __path_list_download_clients,
+    __path_update_download_client,
 };
 use handlers::duplicates::{
     get_duplicate_group, list_duplicate_groups, resolve_duplicate_group, DuplicateFileResponse,
@@ -84,30 +87,37 @@ use handlers::imports::{
     ParsedMetadataResponse, __path_evaluate_import_candidate, __path_submit_manual_import_decision,
 };
 use handlers::indexers::{
-    bulk_indexers, create_indexer, delete_indexer, get_indexer, list_indexers,
-    test_indexer_endpoint, update_indexer, CreateIndexerRequest, IndexerBulkRequest,
-    IndexerBulkResponse, IndexerCapabilitiesResponse, IndexerErrorResponse, IndexerResponse,
+    bulk_indexers, create_indexer, delete_indexer, export_indexers, get_indexer, import_indexers,
+    list_indexers, test_indexer_endpoint, update_indexer, CreateIndexerRequest, IndexerBulkRequest,
+    IndexerBulkResponse, IndexerCapabilitiesResponse, IndexerErrorResponse, IndexerExportEnvelope,
+    IndexerImportErrorResponse, IndexerImportRequest, IndexerImportResponse, IndexerResponse,
     IndexerTestErrorResponse, ListIndexersResponse, TestIndexerRequest, TestIndexerResponse,
     UpdateIndexerRequest, __path_bulk_indexers, __path_create_indexer, __path_delete_indexer,
-    __path_get_indexer, __path_list_indexers, __path_test_indexer_endpoint, __path_update_indexer,
+    __path_export_indexers, __path_get_indexer, __path_import_indexers, __path_list_indexers,
+    __path_test_indexer_endpoint, __path_update_indexer,
 };
 use handlers::metadata_profiles::{
-    bulk_metadata_profiles, create_metadata_profile, delete_metadata_profile, get_metadata_profile,
+    bulk_metadata_profiles, create_metadata_profile, delete_metadata_profile,
+    export_metadata_profiles, get_metadata_profile, import_metadata_profiles,
     list_metadata_profiles, update_metadata_profile, CreateMetadataProfileRequest,
     ErrorResponse as MetadataProfileErrorResponse, ListMetadataProfilesResponse,
-    MetadataProfileBulkRequest, MetadataProfileBulkResponse, MetadataProfileResponse,
-    UpdateMetadataProfileRequest, __path_bulk_metadata_profiles, __path_create_metadata_profile,
-    __path_delete_metadata_profile, __path_get_metadata_profile, __path_list_metadata_profiles,
-    __path_update_metadata_profile,
+    MetadataProfileBulkRequest, MetadataProfileBulkResponse, MetadataProfileExportEnvelope,
+    MetadataProfileImportErrorResponse, MetadataProfileImportRequest,
+    MetadataProfileImportResponse, MetadataProfileResponse, UpdateMetadataProfileRequest,
+    __path_bulk_metadata_profiles, __path_create_metadata_profile, __path_delete_metadata_profile,
+    __path_export_metadata_profiles, __path_get_metadata_profile, __path_import_metadata_profiles,
+    __path_list_metadata_profiles, __path_update_metadata_profile,
 };
 use handlers::quality_profiles::{
-    bulk_quality_profiles, create_quality_profile, delete_quality_profile, get_quality_profile,
-    list_quality_profiles, update_quality_profile, CreateQualityProfileRequest,
-    ErrorResponse as QualityProfileErrorResponse, ListQualityProfilesResponse,
-    QualityProfileBulkRequest, QualityProfileBulkResponse, QualityProfileResponse,
-    UpdateQualityProfileRequest, __path_bulk_quality_profiles, __path_create_quality_profile,
-    __path_delete_quality_profile, __path_get_quality_profile, __path_list_quality_profiles,
-    __path_update_quality_profile,
+    bulk_quality_profiles, create_quality_profile, delete_quality_profile, export_quality_profiles,
+    get_quality_profile, import_quality_profiles, list_quality_profiles, update_quality_profile,
+    CreateQualityProfileRequest, ErrorResponse as QualityProfileErrorResponse,
+    ListQualityProfilesResponse, QualityProfileBulkRequest, QualityProfileBulkResponse,
+    QualityProfileExportEnvelope, QualityProfileImportErrorResponse, QualityProfileImportRequest,
+    QualityProfileImportResponse, QualityProfileResponse, UpdateQualityProfileRequest,
+    __path_bulk_quality_profiles, __path_create_quality_profile, __path_delete_quality_profile,
+    __path_export_quality_profiles, __path_get_quality_profile, __path_import_quality_profiles,
+    __path_list_quality_profiles, __path_update_quality_profile,
 };
 use handlers::search::{
     manual_search_endpoint, ManualSearchApiRequest, ManualSearchApiResponse,
@@ -322,24 +332,32 @@ async fn metrics() -> axum::response::Response {
         update_quality_profile,
         delete_quality_profile,
         bulk_quality_profiles,
+        export_quality_profiles,
+        import_quality_profiles,
         list_metadata_profiles,
         get_metadata_profile,
         create_metadata_profile,
         update_metadata_profile,
         delete_metadata_profile,
         bulk_metadata_profiles,
+        export_metadata_profiles,
+        import_metadata_profiles,
         list_download_clients,
         get_download_client,
         create_download_client,
         update_download_client,
         delete_download_client,
         bulk_download_clients,
+        export_download_clients,
+        import_download_clients,
         list_indexers,
         get_indexer,
         create_indexer,
         update_indexer,
         delete_indexer,
         bulk_indexers,
+        export_indexers,
+        import_indexers,
         test_indexer_endpoint,
         manual_search_endpoint,
         evaluate_import_candidate,
@@ -427,6 +445,10 @@ async fn metrics() -> axum::response::Response {
             QualityProfileErrorResponse,
             QualityProfileBulkRequest,
             QualityProfileBulkResponse,
+            QualityProfileExportEnvelope,
+            QualityProfileImportRequest,
+            QualityProfileImportResponse,
+            QualityProfileImportErrorResponse,
             ListMetadataProfilesResponse,
             MetadataProfileResponse,
             CreateMetadataProfileRequest,
@@ -434,6 +456,10 @@ async fn metrics() -> axum::response::Response {
             MetadataProfileErrorResponse,
             MetadataProfileBulkRequest,
             MetadataProfileBulkResponse,
+            MetadataProfileExportEnvelope,
+            MetadataProfileImportRequest,
+            MetadataProfileImportResponse,
+            MetadataProfileImportErrorResponse,
             ListDownloadClientsResponse,
             DownloadClientResponse,
             CreateDownloadClientRequest,
@@ -441,6 +467,10 @@ async fn metrics() -> axum::response::Response {
             DownloadClientErrorResponse,
             DownloadClientBulkRequest,
             DownloadClientBulkResponse,
+            DownloadClientExportEnvelope,
+            DownloadClientImportRequest,
+            DownloadClientImportResponse,
+            DownloadClientImportErrorResponse,
             ListIndexersResponse,
             IndexerResponse,
             CreateIndexerRequest,
@@ -448,6 +478,10 @@ async fn metrics() -> axum::response::Response {
             IndexerErrorResponse,
             IndexerBulkRequest,
             IndexerBulkResponse,
+            IndexerExportEnvelope,
+            IndexerImportRequest,
+            IndexerImportResponse,
+            IndexerImportErrorResponse,
             TestIndexerRequest,
             TestIndexerResponse,
             IndexerCapabilitiesResponse,
@@ -622,6 +656,14 @@ pub fn router(state: AppState) -> Router {
             get(list_quality_profiles).post(create_quality_profile),
         )
         .route(
+            "/settings/quality-profiles/export",
+            get(export_quality_profiles),
+        )
+        .route(
+            "/settings/quality-profiles/import",
+            post(import_quality_profiles),
+        )
+        .route(
             "/settings/quality-profiles/bulk",
             post(bulk_quality_profiles),
         )
@@ -634,6 +676,14 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/settings/metadata-profiles",
             get(list_metadata_profiles).post(create_metadata_profile),
+        )
+        .route(
+            "/settings/metadata-profiles/export",
+            get(export_metadata_profiles),
+        )
+        .route(
+            "/settings/metadata-profiles/import",
+            post(import_metadata_profiles),
         )
         .route(
             "/settings/metadata-profiles/bulk",
@@ -650,6 +700,14 @@ pub fn router(state: AppState) -> Router {
             get(list_download_clients).post(create_download_client),
         )
         .route(
+            "/settings/download-clients/export",
+            get(export_download_clients),
+        )
+        .route(
+            "/settings/download-clients/import",
+            post(import_download_clients),
+        )
+        .route(
             "/settings/download-clients/bulk",
             post(bulk_download_clients),
         )
@@ -663,6 +721,8 @@ pub fn router(state: AppState) -> Router {
             "/settings/indexers",
             get(list_indexers).post(create_indexer),
         )
+        .route("/settings/indexers/export", get(export_indexers))
+        .route("/settings/indexers/import", post(import_indexers))
         .route("/settings/indexers/bulk", post(bulk_indexers))
         .route(
             "/settings/indexers/:id",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,6 +20,9 @@ import type {
 	FormsLogoutResponse,
 	PaginatedResponse,
 	QualityProfile,
+	SettingsExportEnvelope,
+	SettingsImportRequest,
+	SettingsImportResponse,
 	SettingsBulkRequest,
 	SettingsBulkResponse,
 	SystemTasksResponse,
@@ -179,6 +182,20 @@ export async function bulkDownloadClients(payload: SettingsBulkRequest): Promise
 	});
 }
 
+export async function exportDownloadClients(): Promise<SettingsExportEnvelope<CreateDownloadClientRequest>> {
+	return request<SettingsExportEnvelope<CreateDownloadClientRequest>>('/api/v1/settings/download-clients/export');
+}
+
+export async function importDownloadClients(
+	payload: SettingsImportRequest<CreateDownloadClientRequest>,
+	dryRun = false
+): Promise<SettingsImportResponse> {
+	return request<SettingsImportResponse>(`/api/v1/settings/download-clients/import?dry_run=${dryRun}`, {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
 export async function getIndexers(params?: {
 	limit?: number;
 	offset?: number;
@@ -219,6 +236,20 @@ export async function deleteIndexer(id: string): Promise<void> {
 
 export async function bulkIndexers(payload: SettingsBulkRequest): Promise<SettingsBulkResponse> {
 	return request<SettingsBulkResponse>('/api/v1/settings/indexers/bulk', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function exportIndexers(): Promise<SettingsExportEnvelope<CreateIndexerRequest>> {
+	return request<SettingsExportEnvelope<CreateIndexerRequest>>('/api/v1/settings/indexers/export');
+}
+
+export async function importIndexers(
+	payload: SettingsImportRequest<CreateIndexerRequest>,
+	dryRun = false
+): Promise<SettingsImportResponse> {
+	return request<SettingsImportResponse>(`/api/v1/settings/indexers/import?dry_run=${dryRun}`, {
 		method: 'POST',
 		body: JSON.stringify(payload)
 	});
@@ -280,6 +311,20 @@ export async function bulkQualityProfiles(payload: SettingsBulkRequest): Promise
 	});
 }
 
+export async function exportQualityProfiles(): Promise<SettingsExportEnvelope<CreateQualityProfileRequest>> {
+	return request<SettingsExportEnvelope<CreateQualityProfileRequest>>('/api/v1/settings/quality-profiles/export');
+}
+
+export async function importQualityProfiles(
+	payload: SettingsImportRequest<CreateQualityProfileRequest>,
+	dryRun = false
+): Promise<SettingsImportResponse> {
+	return request<SettingsImportResponse>(`/api/v1/settings/quality-profiles/import?dry_run=${dryRun}`, {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
 export async function getMetadataProfiles(params?: {
 	limit?: number;
 	offset?: number;
@@ -324,6 +369,20 @@ export async function deleteMetadataProfile(id: string): Promise<void> {
 
 export async function bulkMetadataProfiles(payload: SettingsBulkRequest): Promise<SettingsBulkResponse> {
 	return request<SettingsBulkResponse>('/api/v1/settings/metadata-profiles/bulk', {
+		method: 'POST',
+		body: JSON.stringify(payload)
+	});
+}
+
+export async function exportMetadataProfiles(): Promise<SettingsExportEnvelope<CreateMetadataProfileRequest>> {
+	return request<SettingsExportEnvelope<CreateMetadataProfileRequest>>('/api/v1/settings/metadata-profiles/export');
+}
+
+export async function importMetadataProfiles(
+	payload: SettingsImportRequest<CreateMetadataProfileRequest>,
+	dryRun = false
+): Promise<SettingsImportResponse> {
+	return request<SettingsImportResponse>(`/api/v1/settings/metadata-profiles/import?dry_run=${dryRun}`, {
 		method: 'POST',
 		body: JSON.stringify(payload)
 	});

--- a/web/src/lib/components/settings/ImportPreviewDialog.svelte
+++ b/web/src/lib/components/settings/ImportPreviewDialog.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import type {
+		SettingsImportConflictPolicy,
+		SettingsImportPreviewItem,
+		SettingsImportSummary
+	} from '$lib/types';
+
+	interface Props {
+		open: boolean;
+		title: string;
+		summary: SettingsImportSummary;
+		preview: SettingsImportPreviewItem[];
+		policy: SettingsImportConflictPolicy;
+		applying?: boolean;
+		onPolicyChange: (policy: SettingsImportConflictPolicy) => void;
+		onConfirm: () => void;
+		onCancel: () => void;
+	}
+
+	let {
+		open,
+		title,
+		summary,
+		preview,
+		policy,
+		applying = false,
+		onPolicyChange,
+		onConfirm,
+		onCancel
+	}: Props = $props();
+</script>
+
+{#if open}
+	<div class="dialog-backdrop" role="dialog" aria-modal="true" aria-label={title}>
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<div class="dialog-scrim" role="presentation" onclick={onCancel}></div>
+		<div class="dialog-panel">
+			<h3>{title}</h3>
+			<div class="summary-row">
+				<span>Added: {summary.added}</span>
+				<span>Updated: {summary.updated}</span>
+				<span>Deleted: {summary.deleted}</span>
+			</div>
+			<label class="policy-label" for="import-policy">Conflict policy</label>
+			<select
+				id="import-policy"
+				value={policy}
+				onchange={(event) =>
+					onPolicyChange((event.currentTarget as HTMLSelectElement).value as SettingsImportConflictPolicy)}
+			>
+				<option value="merge">Merge</option>
+				<option value="replace_all">Replace All</option>
+			</select>
+			<div class="preview-list" role="list">
+				{#each preview.slice(0, 20) as item}
+					<div class="preview-item" role="listitem">
+						<span class="preview-action">{item.action}</span>
+						<span>{item.name}</span>
+					</div>
+				{/each}
+				{#if preview.length > 20}
+					<div class="preview-more">+ {preview.length - 20} more</div>
+				{/if}
+			</div>
+			<div class="dialog-actions">
+				<button type="button" class="btn-cancel" onclick={onCancel}>Cancel</button>
+				<button type="button" class="btn-confirm" onclick={onConfirm} disabled={applying}>
+					{applying ? 'Importing…' : 'Apply Import'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.dialog-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	.dialog-scrim {
+		position: absolute;
+		inset: 0;
+		background: rgba(15, 26, 31, 0.45);
+	}
+	.dialog-panel {
+		position: relative;
+		z-index: 1;
+		background: var(--paper, #fffdf7);
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.15));
+		border-radius: 12px;
+		padding: 1.25rem;
+		max-width: 520px;
+		width: calc(100% - 2rem);
+	}
+	.summary-row {
+		display: flex;
+		gap: 0.75rem;
+		margin-bottom: 0.75rem;
+		font-size: 0.85rem;
+	}
+	.policy-label {
+		display: block;
+		font-size: 0.8rem;
+		margin-bottom: 0.25rem;
+	}
+	select {
+		width: 100%;
+		margin-bottom: 0.75rem;
+	}
+	.preview-list {
+		max-height: 220px;
+		overflow: auto;
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
+		border-radius: 6px;
+		padding: 0.5rem;
+		margin-bottom: 0.75rem;
+	}
+	.preview-item {
+		display: flex;
+		gap: 0.5rem;
+		font-size: 0.8rem;
+		padding: 0.15rem 0;
+	}
+	.preview-action {
+		text-transform: uppercase;
+		font-weight: 700;
+		font-size: 0.7rem;
+		color: var(--accent, #0f7b6c);
+	}
+	.preview-more {
+		font-size: 0.75rem;
+		color: var(--text-secondary, #666);
+		padding-top: 0.25rem;
+	}
+	.dialog-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.5rem;
+	}
+	.btn-cancel,
+	.btn-confirm {
+		padding: 0.5rem 0.85rem;
+		border-radius: 6px;
+		cursor: pointer;
+	}
+	.btn-cancel {
+		border: 1px solid var(--border-color, rgba(15, 26, 31, 0.2));
+		background: transparent;
+	}
+	.btn-confirm {
+		border: none;
+		color: #fff;
+		background: var(--accent, #0f7b6c);
+	}
+</style>

--- a/web/src/lib/components/settings/ImportPreviewDialog.svelte
+++ b/web/src/lib/components/settings/ImportPreviewDialog.svelte
@@ -28,14 +28,30 @@
 		onConfirm,
 		onCancel
 	}: Props = $props();
+
+	const dialogTitleId = `import-dialog-title-${crypto.randomUUID()}`;
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			onCancel();
+		}
+	}
 </script>
 
 {#if open}
-	<div class="dialog-backdrop" role="dialog" aria-modal="true" aria-label={title}>
+	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+	<div
+		class="dialog-backdrop"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby={dialogTitleId}
+		tabindex="-1"
+		onkeydown={handleKeydown}
+	>
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<div class="dialog-scrim" role="presentation" onclick={onCancel}></div>
 		<div class="dialog-panel">
-			<h3>{title}</h3>
+			<h3 id={dialogTitleId}>{title}</h3>
 			<div class="summary-row">
 				<span>Added: {summary.added}</span>
 				<span>Updated: {summary.updated}</span>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -105,6 +105,38 @@ export interface SettingsBulkResponse {
 	results: SettingsBulkItemResult[];
 }
 
+export type SettingsImportConflictPolicy = 'merge' | 'replace_all';
+
+export interface SettingsExportEnvelope<T> {
+	version: string;
+	exported_at: string;
+	items: T[];
+}
+
+export interface SettingsImportRequest<T> {
+	version: string;
+	conflict_policy: SettingsImportConflictPolicy;
+	items: T[];
+}
+
+export interface SettingsImportPreviewItem {
+	name: string;
+	action: string;
+}
+
+export interface SettingsImportSummary {
+	added: number;
+	updated: number;
+	deleted: number;
+}
+
+export interface SettingsImportResponse {
+	dry_run: boolean;
+	summary: SettingsImportSummary;
+	preview: SettingsImportPreviewItem[];
+	results: SettingsBulkItemResult[];
+}
+
 export interface Indexer {
 	id: string;
 	name: string;

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -295,7 +295,6 @@
 	}
 
 	async function refreshImportPreview() {
-		if (importItems.length === 0) return;
 		importPreview = await importDownloadClients(
 			{
 				version: importVersion,

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -5,6 +5,7 @@
 	import LoadingSpinner from '$lib/components/settings/LoadingSpinner.svelte';
 	import ErrorMessage from '$lib/components/settings/ErrorMessage.svelte';
 	import ConfirmDialog from '$lib/components/settings/ConfirmDialog.svelte';
+	import ImportPreviewDialog from '$lib/components/settings/ImportPreviewDialog.svelte';
 	import SaveStatusBanner from '$lib/components/settings/SaveStatusBanner.svelte';
 	import type { SaveStatus } from '$lib/components/settings/SaveStatusBanner.svelte';
 	import {
@@ -13,6 +14,8 @@
 		updateDownloadClient,
 		deleteDownloadClient,
 		bulkDownloadClients,
+		exportDownloadClients,
+		importDownloadClients,
 		ApiError
 	} from '$lib/api';
 	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
@@ -20,6 +23,8 @@
 	import type {
 		DownloadClient,
 		CreateDownloadClientRequest,
+		SettingsImportConflictPolicy,
+		SettingsImportResponse,
 		UpdateDownloadClientRequest
 	} from '$lib/types';
 
@@ -55,6 +60,13 @@
 	let deleting = $state(false);
 	let bulkDeleteDialogOpen = $state(false);
 	let bulkActing = $state(false);
+	let importDialogOpen = $state(false);
+	let importApplying = $state(false);
+	let importPolicy = $state<SettingsImportConflictPolicy>('merge');
+	let importVersion = $state('1');
+	let importItems = $state<CreateDownloadClientRequest[]>([]);
+	let importPreview = $state<SettingsImportResponse | null>(null);
+	let importFileInput: HTMLInputElement | null = null;
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
@@ -262,6 +274,92 @@
 		}
 	}
 
+	async function exportItems() {
+		try {
+			const payload = await exportDownloadClients();
+			const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = 'download-clients.export.json';
+			link.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			saveError = err instanceof ApiError ? err.message : 'Export failed.';
+			saveStatus = 'error';
+		}
+	}
+
+	function triggerImport() {
+		importFileInput?.click();
+	}
+
+	async function refreshImportPreview() {
+		if (importItems.length === 0) return;
+		importPreview = await importDownloadClients(
+			{
+				version: importVersion,
+				conflict_policy: importPolicy,
+				items: importItems
+			},
+			true
+		);
+	}
+
+	async function handleImportFile(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		try {
+			const text = await file.text();
+			const parsed = JSON.parse(text);
+			importVersion = typeof parsed.version === 'string' ? parsed.version : '1';
+			importItems = Array.isArray(parsed.items)
+				? parsed.items
+				: Array.isArray(parsed)
+					? parsed
+					: [];
+			await refreshImportPreview();
+			importDialogOpen = true;
+		} catch (err) {
+			saveError = err instanceof Error ? err.message : 'Import file is invalid.';
+			saveStatus = 'error';
+		}
+		input.value = '';
+	}
+
+	async function applyImport() {
+		importApplying = true;
+		try {
+			const result = await importDownloadClients(
+				{
+					version: importVersion,
+					conflict_policy: importPolicy,
+					items: importItems
+				},
+				false
+			);
+			const failed = result.results.filter((item) => !item.success);
+			if (failed.length > 0) {
+				saveError = failed
+					.slice(0, 4)
+					.map((item) => `${item.id}: ${item.error ?? 'operation failed'}`)
+					.join('\n');
+				saveStatus = 'error';
+			} else {
+				saveStatus = 'saved';
+				scheduleBannerClear();
+			}
+			importDialogOpen = false;
+			await load();
+		} catch (err) {
+			saveError = err instanceof ApiError ? err.message : 'Import failed.';
+			saveStatus = 'error';
+		} finally {
+			importApplying = false;
+		}
+	}
+
 	function toggleRowSelection(id: string) {
 		const next = new Set(selectedIds);
 		if (next.has(id)) {
@@ -403,6 +501,9 @@
 >
 	{#snippet actions()}
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
+		<button class="btn-secondary" onclick={exportItems}>Export</button>
+		<button class="btn-secondary" onclick={triggerImport}>Import</button>
+		<input bind:this={importFileInput} type="file" accept="application/json" hidden onchange={handleImportFile} />
 		{#if hasSelection}
 			<div class="bulk-toolbar">
 				<button class="btn-secondary" onclick={() => runBulkAction('enable')} disabled={bulkActing}>
@@ -644,6 +745,21 @@
 	destructive
 	onconfirm={confirmBulkDelete}
 	oncancel={() => (bulkDeleteDialogOpen = false)}
+/>
+
+<ImportPreviewDialog
+	open={importDialogOpen}
+	title="Preview Download Client Import"
+	summary={importPreview?.summary ?? { added: 0, updated: 0, deleted: 0 }}
+	preview={importPreview?.preview ?? []}
+	policy={importPolicy}
+	applying={importApplying}
+	onPolicyChange={(policy) => {
+		importPolicy = policy;
+		void refreshImportPreview();
+	}}
+	onConfirm={applyImport}
+	onCancel={() => (importDialogOpen = false)}
 />
 
 <style>

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -5,6 +5,7 @@
 	import LoadingSpinner from '$lib/components/settings/LoadingSpinner.svelte';
 	import ErrorMessage from '$lib/components/settings/ErrorMessage.svelte';
 	import ConfirmDialog from '$lib/components/settings/ConfirmDialog.svelte';
+	import ImportPreviewDialog from '$lib/components/settings/ImportPreviewDialog.svelte';
 	import SaveStatusBanner from '$lib/components/settings/SaveStatusBanner.svelte';
 	import type { SaveStatus } from '$lib/components/settings/SaveStatusBanner.svelte';
 	import {
@@ -13,6 +14,8 @@
 		updateIndexer,
 		deleteIndexer,
 		bulkIndexers,
+		exportIndexers,
+		importIndexers,
 		testIndexer,
 		ApiError
 	} from '$lib/api';
@@ -21,6 +24,8 @@
 	import type {
 		Indexer,
 		CreateIndexerRequest,
+		SettingsImportConflictPolicy,
+		SettingsImportResponse,
 		UpdateIndexerRequest,
 		TestIndexerResponse
 	} from '$lib/types';
@@ -60,6 +65,13 @@
 	let deleting = $state(false);
 	let bulkDeleteDialogOpen = $state(false);
 	let bulkActing = $state(false);
+	let importDialogOpen = $state(false);
+	let importApplying = $state(false);
+	let importPolicy = $state<SettingsImportConflictPolicy>('merge');
+	let importVersion = $state('1');
+	let importItems = $state<CreateIndexerRequest[]>([]);
+	let importPreview = $state<SettingsImportResponse | null>(null);
+	let importFileInput: HTMLInputElement | null = null;
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
@@ -295,6 +307,92 @@
 		}
 	}
 
+	async function exportItems() {
+		try {
+			const payload = await exportIndexers();
+			const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = 'indexers.export.json';
+			link.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			saveError = err instanceof ApiError ? err.message : 'Export failed.';
+			saveStatus = 'error';
+		}
+	}
+
+	function triggerImport() {
+		importFileInput?.click();
+	}
+
+	async function refreshImportPreview() {
+		if (importItems.length === 0) return;
+		importPreview = await importIndexers(
+			{
+				version: importVersion,
+				conflict_policy: importPolicy,
+				items: importItems
+			},
+			true
+		);
+	}
+
+	async function handleImportFile(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		try {
+			const text = await file.text();
+			const parsed = JSON.parse(text);
+			importVersion = typeof parsed.version === 'string' ? parsed.version : '1';
+			importItems = Array.isArray(parsed.items)
+				? parsed.items
+				: Array.isArray(parsed)
+					? parsed
+					: [];
+			await refreshImportPreview();
+			importDialogOpen = true;
+		} catch (err) {
+			saveError = err instanceof Error ? err.message : 'Import file is invalid.';
+			saveStatus = 'error';
+		}
+		input.value = '';
+	}
+
+	async function applyImport() {
+		importApplying = true;
+		try {
+			const result = await importIndexers(
+				{
+					version: importVersion,
+					conflict_policy: importPolicy,
+					items: importItems
+				},
+				false
+			);
+			const failed = result.results.filter((item) => !item.success);
+			if (failed.length > 0) {
+				saveError = failed
+					.slice(0, 4)
+					.map((item) => `${item.id}: ${item.error ?? 'operation failed'}`)
+					.join('\n');
+				saveStatus = 'error';
+			} else {
+				saveStatus = 'saved';
+				scheduleBannerClear();
+			}
+			importDialogOpen = false;
+			await load();
+		} catch (err) {
+			saveError = err instanceof ApiError ? err.message : 'Import failed.';
+			saveStatus = 'error';
+		} finally {
+			importApplying = false;
+		}
+	}
+
 	function toggleRowSelection(id: string) {
 		const next = new Set(selectedIds);
 		if (next.has(id)) {
@@ -436,6 +534,9 @@
 >
 	{#snippet actions()}
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
+		<button class="btn-secondary" onclick={exportItems}>Export</button>
+		<button class="btn-secondary" onclick={triggerImport}>Import</button>
+		<input bind:this={importFileInput} type="file" accept="application/json" hidden onchange={handleImportFile} />
 		{#if hasSelection}
 			<div class="bulk-toolbar">
 				<button class="btn-secondary" onclick={() => runBulkAction('enable')} disabled={bulkActing}>
@@ -678,6 +779,21 @@
 	destructive
 	onconfirm={confirmBulkDelete}
 	oncancel={() => (bulkDeleteDialogOpen = false)}
+/>
+
+<ImportPreviewDialog
+	open={importDialogOpen}
+	title="Preview Indexer Import"
+	summary={importPreview?.summary ?? { added: 0, updated: 0, deleted: 0 }}
+	preview={importPreview?.preview ?? []}
+	policy={importPolicy}
+	applying={importApplying}
+	onPolicyChange={(policy) => {
+		importPolicy = policy;
+		void refreshImportPreview();
+	}}
+	onConfirm={applyImport}
+	onCancel={() => (importDialogOpen = false)}
 />
 
 <style>

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -328,7 +328,6 @@
 	}
 
 	async function refreshImportPreview() {
-		if (importItems.length === 0) return;
 		importPreview = await importIndexers(
 			{
 				version: importVersion,

--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -5,6 +5,7 @@
 	import LoadingSpinner from '$lib/components/settings/LoadingSpinner.svelte';
 	import ErrorMessage from '$lib/components/settings/ErrorMessage.svelte';
 	import ConfirmDialog from '$lib/components/settings/ConfirmDialog.svelte';
+	import ImportPreviewDialog from '$lib/components/settings/ImportPreviewDialog.svelte';
 	import SaveStatusBanner from '$lib/components/settings/SaveStatusBanner.svelte';
 	import type { SaveStatus } from '$lib/components/settings/SaveStatusBanner.svelte';
 	import {
@@ -13,6 +14,8 @@
 		updateMetadataProfile,
 		deleteMetadataProfile,
 		bulkMetadataProfiles,
+		exportMetadataProfiles,
+		importMetadataProfiles,
 		ApiError
 	} from '$lib/api';
 	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
@@ -20,6 +23,8 @@
 	import type {
 		MetadataProfile,
 		CreateMetadataProfileRequest,
+		SettingsImportConflictPolicy,
+		SettingsImportResponse,
 		UpdateMetadataProfileRequest
 	} from '$lib/types';
 
@@ -92,6 +97,13 @@
 	let deleting = $state(false);
 	let bulkDeleteDialogOpen = $state(false);
 	let bulkActing = $state(false);
+	let importDialogOpen = $state(false);
+	let importApplying = $state(false);
+	let importPolicy = $state<SettingsImportConflictPolicy>('merge');
+	let importVersion = $state('1');
+	let importItems = $state<CreateMetadataProfileRequest[]>([]);
+	let importPreview = $state<SettingsImportResponse | null>(null);
+	let importFileInput: HTMLInputElement | null = null;
 
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
 	const unsavedGuard = useUnsavedGuard(() => {
@@ -148,6 +160,92 @@
 			saveStatus = 'idle';
 			saveStatusTimer = null;
 		}, 2500);
+	}
+
+	async function exportItems() {
+		try {
+			const payload = await exportMetadataProfiles();
+			const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = 'metadata-profiles.export.json';
+			link.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			saveError = err instanceof ApiError ? err.message : 'Export failed.';
+			saveStatus = 'error';
+		}
+	}
+
+	function triggerImport() {
+		importFileInput?.click();
+	}
+
+	async function refreshImportPreview() {
+		if (importItems.length === 0) return;
+		importPreview = await importMetadataProfiles(
+			{
+				version: importVersion,
+				conflict_policy: importPolicy,
+				items: importItems
+			},
+			true
+		);
+	}
+
+	async function handleImportFile(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		try {
+			const text = await file.text();
+			const parsed = JSON.parse(text);
+			importVersion = typeof parsed.version === 'string' ? parsed.version : '1';
+			importItems = Array.isArray(parsed.items)
+				? parsed.items
+				: Array.isArray(parsed)
+					? parsed
+					: [];
+			await refreshImportPreview();
+			importDialogOpen = true;
+		} catch (err) {
+			saveError = err instanceof Error ? err.message : 'Import file is invalid.';
+			saveStatus = 'error';
+		}
+		input.value = '';
+	}
+
+	async function applyImport() {
+		importApplying = true;
+		try {
+			const result = await importMetadataProfiles(
+				{
+					version: importVersion,
+					conflict_policy: importPolicy,
+					items: importItems
+				},
+				false
+			);
+			const failed = result.results.filter((item) => !item.success);
+			if (failed.length > 0) {
+				saveError = failed
+					.slice(0, 4)
+					.map((item) => `${item.id}: ${item.error ?? 'operation failed'}`)
+					.join('\n');
+				saveStatus = 'error';
+			} else {
+				saveStatus = 'saved';
+				scheduleBannerClear();
+			}
+			importDialogOpen = false;
+			await load();
+		} catch (err) {
+			saveError = err instanceof ApiError ? err.message : 'Import failed.';
+			saveStatus = 'error';
+		} finally {
+			importApplying = false;
+		}
 	}
 
 	onDestroy(() => {
@@ -430,6 +528,9 @@
 >
 	{#snippet actions()}
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
+		<button class="btn-secondary" onclick={exportItems}>Export</button>
+		<button class="btn-secondary" onclick={triggerImport}>Import</button>
+		<input bind:this={importFileInput} type="file" accept="application/json" hidden onchange={handleImportFile} />
 		{#if hasSelection}
 			<div class="bulk-toolbar">
 				<button class="btn-icon destructive" onclick={openBulkDelete} disabled={bulkActing}>
@@ -731,6 +832,21 @@
 	destructive
 	onconfirm={confirmBulkDelete}
 	oncancel={() => (bulkDeleteDialogOpen = false)}
+/>
+
+<ImportPreviewDialog
+	open={importDialogOpen}
+	title="Preview Metadata Profile Import"
+	summary={importPreview?.summary ?? { added: 0, updated: 0, deleted: 0 }}
+	preview={importPreview?.preview ?? []}
+	policy={importPolicy}
+	applying={importApplying}
+	onPolicyChange={(policy) => {
+		importPolicy = policy;
+		void refreshImportPreview();
+	}}
+	onConfirm={applyImport}
+	onCancel={() => (importDialogOpen = false)}
 />
 
 <style>

--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -183,7 +183,6 @@
 	}
 
 	async function refreshImportPreview() {
-		if (importItems.length === 0) return;
 		importPreview = await importMetadataProfiles(
 			{
 				version: importVersion,

--- a/web/src/routes/(app)/settings/quality-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/quality-profiles/+page.svelte
@@ -5,6 +5,7 @@
 	import LoadingSpinner from '$lib/components/settings/LoadingSpinner.svelte';
 	import ErrorMessage from '$lib/components/settings/ErrorMessage.svelte';
 	import ConfirmDialog from '$lib/components/settings/ConfirmDialog.svelte';
+	import ImportPreviewDialog from '$lib/components/settings/ImportPreviewDialog.svelte';
 	import SaveStatusBanner from '$lib/components/settings/SaveStatusBanner.svelte';
 	import type { SaveStatus } from '$lib/components/settings/SaveStatusBanner.svelte';
 	import {
@@ -13,6 +14,8 @@
 		updateQualityProfile,
 		deleteQualityProfile,
 		bulkQualityProfiles,
+		exportQualityProfiles,
+		importQualityProfiles,
 		ApiError
 	} from '$lib/api';
 	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
@@ -20,6 +23,8 @@
 	import type {
 		QualityProfile,
 		CreateQualityProfileRequest,
+		SettingsImportConflictPolicy,
+		SettingsImportResponse,
 		UpdateQualityProfileRequest
 	} from '$lib/types';
 
@@ -91,6 +96,13 @@
 	let deleting = $state(false);
 	let bulkDeleteDialogOpen = $state(false);
 	let bulkActing = $state(false);
+	let importDialogOpen = $state(false);
+	let importApplying = $state(false);
+	let importPolicy = $state<SettingsImportConflictPolicy>('merge');
+	let importVersion = $state('1');
+	let importItems = $state<CreateQualityProfileRequest[]>([]);
+	let importPreview = $state<SettingsImportResponse | null>(null);
+	let importFileInput: HTMLInputElement | null = null;
 
 	// banner auto-clear timer
 	let saveStatusTimer: ReturnType<typeof setTimeout> | null = null;
@@ -105,6 +117,92 @@
 			cutoffQuality: formCutoffQuality,
 			upgradeAllowed: formUpgradeAllowed
 		});
+	}
+
+	async function exportItems() {
+		try {
+			const payload = await exportQualityProfiles();
+			const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = 'quality-profiles.export.json';
+			link.click();
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			saveError = err instanceof ApiError ? err.message : 'Export failed.';
+			saveStatus = 'error';
+		}
+	}
+
+	function triggerImport() {
+		importFileInput?.click();
+	}
+
+	async function refreshImportPreview() {
+		if (importItems.length === 0) return;
+		importPreview = await importQualityProfiles(
+			{
+				version: importVersion,
+				conflict_policy: importPolicy,
+				items: importItems
+			},
+			true
+		);
+	}
+
+	async function handleImportFile(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		try {
+			const text = await file.text();
+			const parsed = JSON.parse(text);
+			importVersion = typeof parsed.version === 'string' ? parsed.version : '1';
+			importItems = Array.isArray(parsed.items)
+				? parsed.items
+				: Array.isArray(parsed)
+					? parsed
+					: [];
+			await refreshImportPreview();
+			importDialogOpen = true;
+		} catch (err) {
+			saveError = err instanceof Error ? err.message : 'Import file is invalid.';
+			saveStatus = 'error';
+		}
+		input.value = '';
+	}
+
+	async function applyImport() {
+		importApplying = true;
+		try {
+			const result = await importQualityProfiles(
+				{
+					version: importVersion,
+					conflict_policy: importPolicy,
+					items: importItems
+				},
+				false
+			);
+			const failed = result.results.filter((item) => !item.success);
+			if (failed.length > 0) {
+				saveError = failed
+					.slice(0, 4)
+					.map((item) => `${item.id}: ${item.error ?? 'operation failed'}`)
+					.join('\n');
+				saveStatus = 'error';
+			} else {
+				saveStatus = 'saved';
+				scheduleBannerClear();
+			}
+			importDialogOpen = false;
+			await load();
+		} catch (err) {
+			saveError = err instanceof ApiError ? err.message : 'Import failed.';
+			saveStatus = 'error';
+		} finally {
+			importApplying = false;
+		}
 	}
 
 	function syncDirtyState() {
@@ -417,6 +515,9 @@
 >
 	{#snippet actions()}
 		<SaveStatusBanner status={saveStatus} errorMessage={saveError} />
+		<button class="btn-secondary" onclick={exportItems}>Export</button>
+		<button class="btn-secondary" onclick={triggerImport}>Import</button>
+		<input bind:this={importFileInput} type="file" accept="application/json" hidden onchange={handleImportFile} />
 		{#if hasSelection}
 			<div class="bulk-toolbar">
 				<button class="btn-icon destructive" onclick={openBulkDelete} disabled={bulkActing}>
@@ -621,6 +722,21 @@
 	destructive
 	onconfirm={confirmBulkDelete}
 	oncancel={() => (bulkDeleteDialogOpen = false)}
+/>
+
+<ImportPreviewDialog
+	open={importDialogOpen}
+	title="Preview Quality Profile Import"
+	summary={importPreview?.summary ?? { added: 0, updated: 0, deleted: 0 }}
+	preview={importPreview?.preview ?? []}
+	policy={importPolicy}
+	applying={importApplying}
+	onPolicyChange={(policy) => {
+		importPolicy = policy;
+		void refreshImportPreview();
+	}}
+	onConfirm={applyImport}
+	onCancel={() => (importDialogOpen = false)}
 />
 
 <style>

--- a/web/src/routes/(app)/settings/quality-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/quality-profiles/+page.svelte
@@ -140,7 +140,6 @@
 	}
 
 	async function refreshImportPreview() {
-		if (importItems.length === 0) return;
 		importPreview = await importQualityProfiles(
 			{
 				version: importVersion,


### PR DESCRIPTION
## Summary
- add import/export endpoints for settings domains: download clients, indexers, quality profiles, and metadata profiles
- add dry-run import previews with conflict policy support (`merge` and `replace_all`)
- wire new routes and OpenAPI docs for settings import/export APIs
- add frontend API contracts/methods and UI flows for export, file import, preview, and apply
- add reusable `ImportPreviewDialog` component for settings pages

## Validation
- `cargo fmt --all`
- `cargo build -p chorrosion-api`
- `npm run check` (in `web`)

Closes #465