### PR TITLE
docs(settings): finalize wave 1 QA and operator guidance (#467)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,8 +4117,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 figment = { version = "0.10", features = ["env", "toml"] }
 utoipa = "5"
-utoipa-swagger-ui = { version = "8", features = ["axum"] }
+utoipa-swagger-ui = { version = "8", features = ["axum", "vendored"] }
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "macros", "migrate", "chrono", "uuid", "sqlite"] }
 reqwest = { version = "0.12", features = ["json", "gzip", "brotli", "stream", "rustls-tls", "cookies"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -231,22 +231,54 @@ Current implemented endpoints:
 - `POST /api/v1/settings/quality-profiles`
 - `PUT /api/v1/settings/quality-profiles/{id}`
 - `DELETE /api/v1/settings/quality-profiles/{id}`
+- `POST /api/v1/settings/quality-profiles/bulk`
+- `GET /api/v1/settings/quality-profiles/export`
+- `POST /api/v1/settings/quality-profiles/import`
 - `GET /api/v1/settings/metadata-profiles`
 - `GET /api/v1/settings/metadata-profiles/{id}`
 - `POST /api/v1/settings/metadata-profiles`
 - `PUT /api/v1/settings/metadata-profiles/{id}`
 - `DELETE /api/v1/settings/metadata-profiles/{id}`
+- `POST /api/v1/settings/metadata-profiles/bulk`
+- `GET /api/v1/settings/metadata-profiles/export`
+- `POST /api/v1/settings/metadata-profiles/import`
 - `GET /api/v1/settings/download-clients`
 - `GET /api/v1/settings/download-clients/{id}`
 - `POST /api/v1/settings/download-clients`
 - `PUT /api/v1/settings/download-clients/{id}`
 - `DELETE /api/v1/settings/download-clients/{id}`
+- `POST /api/v1/settings/download-clients/bulk`
+- `GET /api/v1/settings/download-clients/export`
+- `POST /api/v1/settings/download-clients/import`
 - `GET /api/v1/settings/indexers`
 - `GET /api/v1/settings/indexers/{id}`
 - `POST /api/v1/settings/indexers`
 - `PUT /api/v1/settings/indexers/{id}`
 - `DELETE /api/v1/settings/indexers/{id}`
+- `POST /api/v1/settings/indexers/bulk`
+- `GET /api/v1/settings/indexers/export`
+- `POST /api/v1/settings/indexers/import`
 - `POST /api/v1/indexers/test`
+
+## Settings UI Workflows
+
+The web settings area at `/settings` now includes dedicated screens for Download Clients, Indexers, Quality Profiles, Metadata Profiles, and Appearance.
+
+- Bulk actions are available on the four settings resource screens for enable, disable, and delete operations.
+- Export downloads the current resource set as JSON with a `version`, `exported_at`, and `items` envelope.
+- Import supports a dry-run preview before apply.
+- Import conflict policy `merge` updates matching items by name and adds new ones.
+- Import conflict policy `replace_all` also removes existing items that are not present in the import file.
+
+Example import/export envelope:
+
+```json
+{
+  "version": "1",
+  "exported_at": "2026-05-18T12:00:00Z",
+  "items": []
+}
+```
 
 ## Testing with the Mock Server
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -481,7 +481,7 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ## Phase 12: UI Production Readiness (Q2-Q3 2026)
 
-- Related issues: #444, #445, #446, #447, #448
+- Related issues: #444, #445, #446, #447, #448, #457, #458, #459, #460, #461, #462, #463, #464, #465, #466, #467
 
 ### 12.1 UX Hardening
 
@@ -499,6 +499,20 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 ### 12.4 UI-State Maintainability
 
 - [x] Consolidate dashboard presentation logic into tested UI-state helpers (Issue #448) ✓
+
+### 12.5 Settings UX Wave 1
+
+- [x] Settings IA + shared shell/navigation foundation (Issue #457) ✓
+- [x] Frontend API/type coverage for four settings domains (Issue #458) ✓
+- [x] Download Clients settings page (Issue #459) ✓
+- [x] Indexers settings page (Issue #460) ✓
+- [x] Quality Profiles settings page (Issue #461) ✓
+- [x] Metadata Profiles settings page (Issue #462) ✓
+- [x] Polished UX pass for settings forms and guards (Issue #463) ✓
+- [x] Bulk operations for settings (Issue #464) ✓
+- [x] Import/export for settings domains (Issue #465) ✓
+- [x] Test coverage expansion for settings UX (Issue #466) ✓
+- [x] Operator docs + final QA + ROADMAP update for Settings Wave 1 (Issue #467) ✓
 
 ---
 
@@ -553,6 +567,6 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 
 ---
 
-**Last Updated:** 2026-05-06  
+**Last Updated:** 2026-05-18  
 **Current Phase:** Phase 12: UI Production Readiness ✅ COMPLETE  
-**Status:** All Phase 12 UI production readiness items merged; project ready for v1.0 milestone planning
+**Status:** All Phase 12 items and the Settings UX Wave 1 rollout (#457-#467) are merged; project ready for v1.0 milestone planning

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
 		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }
 	],
 	webServer: {
-		command: 'npm run build && npm run preview',
+		command: 'bun run build && bun run preview',
 		url: 'http://localhost:4173',
 		reuseExistingServer: !process.env.CI,
 		timeout: 30_000

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
 		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }
 	],
 	webServer: {
-		command: 'bun run preview',
+		command: 'npm run build && npm run preview',
 		url: 'http://localhost:4173',
 		reuseExistingServer: !process.env.CI,
 		timeout: 30_000

--- a/web/src/lib/components/settings/ImportPreviewDialog.svelte
+++ b/web/src/lib/components/settings/ImportPreviewDialog.svelte
@@ -67,6 +67,10 @@
 				<option value="merge">Merge</option>
 				<option value="replace_all">Replace All</option>
 			</select>
+			<p class="policy-hint">
+				Merge updates matching names and keeps everything else. Replace All also deletes existing items
+				that are not present in the import file.
+			</p>
 			<div class="preview-list" role="list">
 				{#each preview.slice(0, 20) as item}
 					<div class="preview-item" role="listitem">
@@ -126,6 +130,12 @@
 	select {
 		width: 100%;
 		margin-bottom: 0.75rem;
+	}
+	.policy-hint {
+		margin: -0.35rem 0 0.75rem;
+		font-size: 0.78rem;
+		line-height: 1.4;
+		color: var(--text-secondary, #666);
 	}
 	.preview-list {
 		max-height: 220px;

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -641,7 +641,7 @@
 							syncDirtyState();
 						}}
 					/>
-					<span class="field-hint">Include the full client URL, including `http://` or `https://` and the web UI port.</span>
+					<span class="field-hint">Include the full client URL, including <code>http://</code> or <code>https://</code> and the web UI port.</span>
 					{#if formErrors.base_url}<span class="field-error">{formErrors.base_url}</span>{/if}
 				</div>
 

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -641,6 +641,7 @@
 							syncDirtyState();
 						}}
 					/>
+					<span class="field-hint">Include the full client URL, including `http://` or `https://` and the web UI port.</span>
 					{#if formErrors.base_url}<span class="field-error">{formErrors.base_url}</span>{/if}
 				</div>
 
@@ -689,6 +690,7 @@
 							syncDirtyState();
 						}}
 					/>
+					<span class="field-hint">Optional label/category used by the client to group Chorrosion-managed downloads.</span>
 				</div>
 
 				<div class="field field-inline">
@@ -1059,6 +1061,12 @@
 	.field-error {
 		font-size: 0.78rem;
 		color: var(--error, #b6422e);
+	}
+
+	.field-hint {
+		font-size: 0.78rem;
+		line-height: 1.4;
+		color: var(--text-secondary, #666);
 	}
 
 	.hint {

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -674,6 +674,7 @@
 							syncDirtyState();
 						}}
 					/>
+					<span class="field-hint">Use the root Torznab, Newznab, or Gazelle endpoint URL, including `http://` or `https://`.</span>
 					{#if formErrors.base_url}<span class="field-error">{formErrors.base_url}</span>{/if}
 				</div>
 
@@ -694,6 +695,7 @@
 							syncDirtyState();
 						}}
 					/>
+					<span class="field-hint">Paste the provider-issued API token exactly as shown in the indexer or aggregator UI.</span>
 				</div>
 
 				<div class="field field-inline">
@@ -1054,6 +1056,12 @@
 	.hint {
 		font-weight: 400;
 		font-size: 0.78rem;
+		color: var(--text-secondary, #666);
+	}
+
+	.field-hint {
+		font-size: 0.78rem;
+		line-height: 1.4;
 		color: var(--text-secondary, #666);
 	}
 

--- a/web/src/routes/(app)/settings/indexers/+page.svelte
+++ b/web/src/routes/(app)/settings/indexers/+page.svelte
@@ -674,7 +674,7 @@
 							syncDirtyState();
 						}}
 					/>
-					<span class="field-hint">Use the root Torznab, Newznab, or Gazelle endpoint URL, including `http://` or `https://`.</span>
+					<span class="field-hint">Use the root Torznab, Newznab, or Gazelle endpoint URL, including <code>http://</code> or <code>https://</code>.</span>
 					{#if formErrors.base_url}<span class="field-error">{formErrors.base_url}</span>{/if}
 				</div>
 

--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -629,6 +629,7 @@
 
 				<div class="field-group">
 					<span class="field-group-title">Primary Album Types</span>
+					<span class="field-hint">Choose the primary release types to keep when metadata is imported or refreshed.</span>
 					<div class="option-grid">
 						{#each primaryTypeOptions as value}
 							<label class="option-check">
@@ -684,6 +685,7 @@
 
 				<div class="field-group">
 					<span class="field-group-title">Secondary Album Types</span>
+					<span class="field-hint">Use secondary types to include or exclude compilations, live releases, soundtracks, and similar variants.</span>
 					<div class="option-grid">
 						{#each secondaryTypeOptions as value}
 							<label class="option-check">
@@ -739,6 +741,7 @@
 
 				<div class="field-group">
 					<span class="field-group-title">Release Statuses</span>
+					<span class="field-hint">Statuses help filter official releases from promos, bootlegs, or pseudo-releases.</span>
 					<div class="option-grid">
 						{#each releaseStatusOptions as value}
 							<label class="option-check">
@@ -1026,6 +1029,12 @@
 	.field-error {
 		font-size: 0.78rem;
 		color: #c0392b;
+	}
+
+	.field-hint {
+		font-size: 0.78rem;
+		line-height: 1.4;
+		color: var(--text-secondary, #666);
 	}
 
 	.field-group {


### PR DESCRIPTION
## Summary
- update Settings Wave 1 status in ROADMAP with completed issue references (#457-#467)
- expand README settings API coverage to include bulk/import/export endpoints for all four settings domains
- document settings import/export envelope and conflict-policy behavior for operators
- add inline operator hints for non-obvious settings fields (indexer/download-client URLs, API key usage, metadata type/status guidance)
- clarify import conflict policy behavior in the preview dialog
- make Playwright E2E webServer build before preview to avoid stale navigation artifacts
- enable vendored Swagger UI assets for deterministic workspace builds/tests

## Validation
- `cargo test --workspace`
- `cargo clippy -- -D warnings`
- `cd web && npm run check`
- `cd web && npm run test`
- `cd web && npx playwright test`

Closes #467