### PR TITLE
test(e2e): harden settings CRUD fixtures and Playwright stability (#481)

### DIFF
--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -188,8 +188,50 @@ export async function mockApiRoutes(page: Page): Promise<void> {
 		})
 	);
 
+	// Realtime/event endpoints to avoid backend proxy noise in non-SSE-focused tests.
+	await page.route(`${API_BASE}/api/v1/events**`, async (route) => {
+		const req = route.request();
+		const path = new URL(req.url()).pathname;
+
+		if (req.method() === 'GET' && path.endsWith('/events/connections')) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items: [], total: 0 })
+			});
+			return;
+		}
+
+		if (req.method() === 'POST' && path.endsWith('/events/broadcast')) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ success: true })
+			});
+			return;
+		}
+
+		if (
+			req.method() === 'GET' &&
+			(path.endsWith('/events') ||
+				path.endsWith('/events/download-progress') ||
+				path.endsWith('/events/import-progress') ||
+				path.endsWith('/events/job-status'))
+		) {
+			await route.fulfill({
+				status: 200,
+				headers: { 'content-type': 'text/event-stream' },
+				body: 'event: connected\ndata: {}\n\n'
+			});
+			return;
+		}
+
+		await route.fallback();
+	});
+
 	// Catalog endpoints
 	const emptyPage = { items: [], total: 0, limit: 25, offset: 0 };
+	const emptySettingsPage = { items: [], total: 0, limit: 100, offset: 0 };
 	await page.route(`${API_BASE}/api/v1/artists**`, (route) =>
 		route.fulfill({
 			status: 200,
@@ -204,4 +246,59 @@ export async function mockApiRoutes(page: Page): Promise<void> {
 			body: JSON.stringify(emptyPage)
 		})
 	);
+
+	// Default settings list mocks for tests that navigate through /settings but do not
+	// install domain-specific CRUD fixtures.
+	await page.route(`${API_BASE}/api/v1/settings/download-clients**`, async (route) => {
+		const req = route.request();
+		const path = new URL(req.url()).pathname;
+		if (req.method() === 'GET' && path.endsWith('/settings/download-clients')) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(emptySettingsPage)
+			});
+			return;
+		}
+		await route.fallback();
+	});
+	await page.route(`${API_BASE}/api/v1/settings/indexers**`, async (route) => {
+		const req = route.request();
+		const path = new URL(req.url()).pathname;
+		if (req.method() === 'GET' && path.endsWith('/settings/indexers')) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(emptySettingsPage)
+			});
+			return;
+		}
+		await route.fallback();
+	});
+	await page.route(`${API_BASE}/api/v1/settings/quality-profiles**`, async (route) => {
+		const req = route.request();
+		const path = new URL(req.url()).pathname;
+		if (req.method() === 'GET' && path.endsWith('/settings/quality-profiles')) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(emptySettingsPage)
+			});
+			return;
+		}
+		await route.fallback();
+	});
+	await page.route(`${API_BASE}/api/v1/settings/metadata-profiles**`, async (route) => {
+		const req = route.request();
+		const path = new URL(req.url()).pathname;
+		if (req.method() === 'GET' && path.endsWith('/settings/metadata-profiles')) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(emptySettingsPage)
+			});
+			return;
+		}
+		await route.fallback();
+	});
 }

--- a/web/e2e/settings-crud.spec.ts
+++ b/web/e2e/settings-crud.spec.ts
@@ -1,346 +1,29 @@
 import { expect, test, type Page } from '@playwright/test';
 import { injectAuth, mockApiRoutes } from './helpers';
+import {
+	mockDownloadClientsCrud,
+	mockIndexersCrud,
+	mockMetadataProfilesCrud,
+	mockQualityProfilesCrud
+} from './settings-fixtures';
 
-type DownloadClient = {
-	id: string;
-	name: string;
-	client_type: string;
-	base_url: string;
-	username: string | null;
-	category: string | null;
-	enabled: boolean;
-	has_password: boolean;
-};
-
-type Indexer = {
-	id: string;
-	name: string;
-	base_url: string;
-	protocol: string;
-	enabled: boolean;
-	has_api_key: boolean;
-};
-
-type QualityProfile = {
-	id: string;
-	name: string;
-	allowed_qualities: string[];
-	upgrade_allowed: boolean;
-	cutoff_quality: string | null;
-};
-
-type MetadataProfile = {
-	id: string;
-	name: string;
-	primary_album_types: string[];
-	secondary_album_types: string[];
-	release_statuses: string[];
-};
-
-function routeJson(page: Page, glob: string, handler: (route: Parameters<Page['route']>[1] extends (route: infer R) => unknown ? R : never) => Promise<void> | void) {
-	return page.route(glob, handler);
-}
-
-async function mockDownloadClientsCrud(page: Page) {
-	let nextId = 2;
-	const items: DownloadClient[] = [
-		{
-			id: 'dc-1',
-			name: 'Seed Client',
-			client_type: 'qbittorrent',
-			base_url: 'http://localhost:8080',
-			username: null,
-			category: null,
-			enabled: true,
-			has_password: false
-		}
-	];
-
-	await routeJson(page, '**/api/v1/settings/download-clients**', async (route) => {
-		const req = route.request();
-		const method = req.method();
-		const url = new URL(req.url());
-		const path = url.pathname;
-
-		if (path.endsWith('/settings/download-clients') && method === 'GET') {
-			await route.fulfill({
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
-			});
-			return;
-		}
-
-		if (path.endsWith('/settings/download-clients') && method === 'POST') {
-			const body = req.postDataJSON() as Partial<DownloadClient>;
-			const created: DownloadClient = {
-				id: `dc-${nextId++}`,
-				name: body.name ?? 'Unnamed',
-				client_type: body.client_type ?? 'qbittorrent',
-				base_url: body.base_url ?? 'http://localhost:8080',
-				username: body.username ?? null,
-				category: body.category ?? null,
-				enabled: body.enabled ?? true,
-				has_password: false
-			};
-			items.push(created);
-			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
-			return;
-		}
-
-		const id = path.split('/').pop() ?? '';
-		const idx = items.findIndex((item) => item.id === id);
-
-		if (idx === -1) {
-			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
-			return;
-		}
-
-		if (method === 'PUT') {
-			const patch = req.postDataJSON() as Partial<DownloadClient>;
-			items[idx] = { ...items[idx], ...patch };
-			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
-			return;
-		}
-
-		if (method === 'DELETE') {
-			items.splice(idx, 1);
-			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
-			return;
-		}
-
-		await route.fallback();
-	});
-}
-
-async function mockIndexersCrud(page: Page) {
-	let nextId = 2;
-	const items: Indexer[] = [
-		{
-			id: 'idx-1',
-			name: 'Seed Indexer',
-			base_url: 'http://localhost:9117',
-			protocol: 'torznab',
-			enabled: true,
-			has_api_key: false
-		}
-	];
-
-	await routeJson(page, '**/api/v1/indexers/test', async (route) => {
-		if (route.request().method() !== 'POST') {
-			await route.fallback();
-			return;
-		}
-
-		await route.fulfill({
-			status: 200,
-			contentType: 'application/json',
-			body: JSON.stringify({
-				success: true,
-				message: 'ok',
-				protocol: 'torznab',
-				capabilities: {
-					supports_search: true,
-					supports_rss: true,
-					supports_capabilities_detection: true,
-					supports_categories: true,
-					supported_categories: ['music']
-				}
-			})
-		});
-	});
-
-	await routeJson(page, '**/api/v1/settings/indexers**', async (route) => {
-		const req = route.request();
-		const method = req.method();
-		const url = new URL(req.url());
-		const path = url.pathname;
-
-		if (path.endsWith('/settings/indexers') && method === 'GET') {
-			await route.fulfill({
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
-			});
-			return;
-		}
-
-		if (path.endsWith('/settings/indexers') && method === 'POST') {
-			const body = req.postDataJSON() as Partial<Indexer>;
-			const created: Indexer = {
-				id: `idx-${nextId++}`,
-				name: body.name ?? 'Unnamed',
-				base_url: body.base_url ?? 'http://localhost:9117',
-				protocol: body.protocol ?? 'torznab',
-				enabled: body.enabled ?? true,
-				has_api_key: Boolean(body.has_api_key)
-			};
-			items.push(created);
-			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
-			return;
-		}
-
-		const id = path.split('/').pop() ?? '';
-		const idx = items.findIndex((item) => item.id === id);
-		if (idx === -1) {
-			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
-			return;
-		}
-
-		if (method === 'PUT') {
-			const patch = req.postDataJSON() as Partial<Indexer>;
-			items[idx] = { ...items[idx], ...patch };
-			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
-			return;
-		}
-
-		if (method === 'DELETE') {
-			items.splice(idx, 1);
-			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
-			return;
-		}
-
-		await route.fallback();
-	});
-}
-
-async function mockQualityProfilesCrud(page: Page) {
-	let nextId = 2;
-	const items: QualityProfile[] = [
-		{
-			id: 'qp-1',
-			name: 'Seed Quality',
-			allowed_qualities: ['FLAC'],
-			upgrade_allowed: true,
-			cutoff_quality: 'FLAC'
-		}
-	];
-
-	await routeJson(page, '**/api/v1/settings/quality-profiles**', async (route) => {
-		const req = route.request();
-		const method = req.method();
-		const path = new URL(req.url()).pathname;
-
-		if (path.endsWith('/settings/quality-profiles') && method === 'GET') {
-			await route.fulfill({
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
-			});
-			return;
-		}
-
-		if (path.endsWith('/settings/quality-profiles') && method === 'POST') {
-			const body = req.postDataJSON() as Partial<QualityProfile>;
-			const created: QualityProfile = {
-				id: `qp-${nextId++}`,
-				name: body.name ?? 'Unnamed',
-				allowed_qualities: body.allowed_qualities ?? ['FLAC'],
-				upgrade_allowed: body.upgrade_allowed ?? true,
-				cutoff_quality: body.cutoff_quality ?? null
-			};
-			items.push(created);
-			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
-			return;
-		}
-
-		const id = path.split('/').pop() ?? '';
-		const idx = items.findIndex((item) => item.id === id);
-		if (idx === -1) {
-			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
-			return;
-		}
-
-		if (method === 'PUT') {
-			const patch = req.postDataJSON() as Partial<QualityProfile>;
-			items[idx] = { ...items[idx], ...patch };
-			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
-			return;
-		}
-
-		if (method === 'DELETE') {
-			items.splice(idx, 1);
-			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
-			return;
-		}
-
-		await route.fallback();
-	});
-}
-
-async function mockMetadataProfilesCrud(page: Page) {
-	let nextId = 2;
-	const items: MetadataProfile[] = [
-		{
-			id: 'mp-1',
-			name: 'Seed Metadata',
-			primary_album_types: ['Album'],
-			secondary_album_types: [],
-			release_statuses: ['Official']
-		}
-	];
-
-	await routeJson(page, '**/api/v1/settings/metadata-profiles**', async (route) => {
-		const req = route.request();
-		const method = req.method();
-		const path = new URL(req.url()).pathname;
-
-		if (path.endsWith('/settings/metadata-profiles') && method === 'GET') {
-			await route.fulfill({
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
-			});
-			return;
-		}
-
-		if (path.endsWith('/settings/metadata-profiles') && method === 'POST') {
-			const body = req.postDataJSON() as Partial<MetadataProfile>;
-			const created: MetadataProfile = {
-				id: `mp-${nextId++}`,
-				name: body.name ?? 'Unnamed',
-				primary_album_types: body.primary_album_types ?? ['Album'],
-				secondary_album_types: body.secondary_album_types ?? [],
-				release_statuses: body.release_statuses ?? ['Official']
-			};
-			items.push(created);
-			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
-			return;
-		}
-
-		const id = path.split('/').pop() ?? '';
-		const idx = items.findIndex((item) => item.id === id);
-		if (idx === -1) {
-			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
-			return;
-		}
-
-		if (method === 'PUT') {
-			const patch = req.postDataJSON() as Partial<MetadataProfile>;
-			items[idx] = { ...items[idx], ...patch };
-			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
-			return;
-		}
-
-		if (method === 'DELETE') {
-			items.splice(idx, 1);
-			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
-			return;
-		}
-
-		await route.fallback();
-	});
-}
-
-test.describe.skip('Settings CRUD (blocked by /settings preview routing)', () => {
+test.describe('Settings CRUD', () => {
 	test.beforeEach(async ({ page }) => {
 		await mockApiRoutes(page);
 		await injectAuth(page);
 	});
 
 	async function openSettingsSubpage(page: Page, linkName: string) {
-		await page.goto('/settings');
-		await page.getByRole('link', { name: linkName }).click();
+		const slugs: Record<string, string> = {
+			'Download Clients': '/settings/download-clients',
+			Indexers: '/settings/indexers',
+			'Quality Profiles': '/settings/quality-profiles',
+			'Metadata Profiles': '/settings/metadata-profiles'
+		};
+		await page.goto(slugs[linkName]);
+		await expect(page).toHaveURL(slugs[linkName]);
+		await expect(page.getByRole('link', { name: linkName })).toHaveAttribute('aria-current', 'page');
+		await expect(page.getByRole('heading', { name: linkName })).toBeVisible();
 	}
 
 	test('download clients CRUD round trip', async ({ page }) => {
@@ -365,7 +48,7 @@ test.describe.skip('Settings CRUD (blocked by /settings preview routing)', () =>
 		await updatedRow.getByRole('button', { name: /Delete/ }).click();
 		const dialog = page.getByRole('dialog');
 		await dialog.getByRole('button', { name: 'Delete' }).click();
-		await expect(page.getByText('Updated Client')).not.toBeVisible();
+		await expect(updatedRow).toHaveCount(0);
 	});
 
 	test('indexers CRUD round trip', async ({ page }) => {
@@ -389,7 +72,7 @@ test.describe.skip('Settings CRUD (blocked by /settings preview routing)', () =>
 		const updatedRow = page.locator('.indexer-item').filter({ hasText: 'Updated Indexer' });
 		await updatedRow.getByRole('button', { name: /Delete/ }).click();
 		await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click();
-		await expect(page.getByText('Updated Indexer')).not.toBeVisible();
+		await expect(updatedRow).toHaveCount(0);
 	});
 
 	test('quality profiles CRUD round trip', async ({ page }) => {
@@ -412,7 +95,7 @@ test.describe.skip('Settings CRUD (blocked by /settings preview routing)', () =>
 		const updatedRow = page.locator('.profile-item').filter({ hasText: 'Updated Quality' });
 		await updatedRow.getByRole('button', { name: /Delete/ }).click();
 		await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click();
-		await expect(page.getByText('Updated Quality')).not.toBeVisible();
+		await expect(updatedRow).toHaveCount(0);
 	});
 
 	test('metadata profiles CRUD round trip', async ({ page }) => {
@@ -435,6 +118,6 @@ test.describe.skip('Settings CRUD (blocked by /settings preview routing)', () =>
 		const updatedRow = page.locator('.profile-item').filter({ hasText: 'Updated Metadata' });
 		await updatedRow.getByRole('button', { name: /Delete/ }).click();
 		await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click();
-		await expect(page.getByText('Updated Metadata')).not.toBeVisible();
+		await expect(updatedRow).toHaveCount(0);
 	});
 });

--- a/web/e2e/settings-fixtures.ts
+++ b/web/e2e/settings-fixtures.ts
@@ -71,7 +71,7 @@ export async function mockDownloadClientsCrud(page: Page): Promise<void> {
 		}
 
 		if (path.endsWith('/settings/download-clients') && method === 'POST') {
-			const body = req.postDataJSON() as Partial<DownloadClient>;
+			const body = req.postDataJSON() as Partial<DownloadClient> & { password?: string | null };
 			const created: DownloadClient = {
 				id: `dc-${nextId++}`,
 				name: body.name ?? 'Unnamed',
@@ -80,7 +80,7 @@ export async function mockDownloadClientsCrud(page: Page): Promise<void> {
 				username: body.username ?? null,
 				category: body.category ?? null,
 				enabled: body.enabled ?? true,
-				has_password: false
+				has_password: Boolean(body.password)
 			};
 			items.push(created);
 			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
@@ -96,8 +96,13 @@ export async function mockDownloadClientsCrud(page: Page): Promise<void> {
 		}
 
 		if (method === 'PUT') {
-			const patch = req.postDataJSON() as Partial<DownloadClient>;
-			items[idx] = { ...items[idx], ...patch };
+			const patch = req.postDataJSON() as Partial<DownloadClient> & { password?: string | null };
+			const { password, ...rest } = patch;
+			items[idx] = {
+				...items[idx],
+				...rest,
+				has_password: password === undefined ? items[idx].has_password : Boolean(password)
+			};
 			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
 			return;
 		}
@@ -165,14 +170,14 @@ export async function mockIndexersCrud(page: Page): Promise<void> {
 		}
 
 		if (path.endsWith('/settings/indexers') && method === 'POST') {
-			const body = req.postDataJSON() as Partial<Indexer>;
+			const body = req.postDataJSON() as Partial<Indexer> & { api_key?: string | null };
 			const created: Indexer = {
 				id: `idx-${nextId++}`,
 				name: body.name ?? 'Unnamed',
 				base_url: body.base_url ?? 'http://localhost:9117',
 				protocol: body.protocol ?? 'torznab',
 				enabled: body.enabled ?? true,
-				has_api_key: Boolean(body.has_api_key)
+				has_api_key: Boolean(body.api_key)
 			};
 			items.push(created);
 			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
@@ -187,8 +192,13 @@ export async function mockIndexersCrud(page: Page): Promise<void> {
 		}
 
 		if (method === 'PUT') {
-			const patch = req.postDataJSON() as Partial<Indexer>;
-			items[idx] = { ...items[idx], ...patch };
+			const patch = req.postDataJSON() as Partial<Indexer> & { api_key?: string | null };
+			const { api_key, ...rest } = patch;
+			items[idx] = {
+				...items[idx],
+				...rest,
+				has_api_key: api_key === undefined ? items[idx].has_api_key : Boolean(api_key)
+			};
 			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
 			return;
 		}

--- a/web/e2e/settings-fixtures.ts
+++ b/web/e2e/settings-fixtures.ts
@@ -1,0 +1,341 @@
+import type { Page, Route } from '@playwright/test';
+
+type DownloadClient = {
+	id: string;
+	name: string;
+	client_type: string;
+	base_url: string;
+	username: string | null;
+	category: string | null;
+	enabled: boolean;
+	has_password: boolean;
+};
+
+type Indexer = {
+	id: string;
+	name: string;
+	base_url: string;
+	protocol: string;
+	enabled: boolean;
+	has_api_key: boolean;
+};
+
+type QualityProfile = {
+	id: string;
+	name: string;
+	allowed_qualities: string[];
+	upgrade_allowed: boolean;
+	cutoff_quality: string | null;
+};
+
+type MetadataProfile = {
+	id: string;
+	name: string;
+	primary_album_types: string[];
+	secondary_album_types: string[];
+	release_statuses: string[];
+};
+
+function routeJson(page: Page, glob: string, handler: (route: Route) => Promise<void> | void) {
+	return page.route(glob, handler);
+}
+
+export async function mockDownloadClientsCrud(page: Page): Promise<void> {
+	let nextId = 2;
+	const items: DownloadClient[] = [
+		{
+			id: 'dc-1',
+			name: 'Seed Client',
+			client_type: 'qbittorrent',
+			base_url: 'http://localhost:8080',
+			username: null,
+			category: null,
+			enabled: true,
+			has_password: false
+		}
+	];
+
+	await routeJson(page, '**/api/v1/settings/download-clients**', async (route) => {
+		const req = route.request();
+		const method = req.method();
+		const url = new URL(req.url());
+		const path = url.pathname;
+
+		if (path.endsWith('/settings/download-clients') && method === 'GET') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
+			});
+			return;
+		}
+
+		if (path.endsWith('/settings/download-clients') && method === 'POST') {
+			const body = req.postDataJSON() as Partial<DownloadClient>;
+			const created: DownloadClient = {
+				id: `dc-${nextId++}`,
+				name: body.name ?? 'Unnamed',
+				client_type: body.client_type ?? 'qbittorrent',
+				base_url: body.base_url ?? 'http://localhost:8080',
+				username: body.username ?? null,
+				category: body.category ?? null,
+				enabled: body.enabled ?? true,
+				has_password: false
+			};
+			items.push(created);
+			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
+			return;
+		}
+
+		const id = path.split('/').pop() ?? '';
+		const idx = items.findIndex((item) => item.id === id);
+
+		if (idx === -1) {
+			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+			return;
+		}
+
+		if (method === 'PUT') {
+			const patch = req.postDataJSON() as Partial<DownloadClient>;
+			items[idx] = { ...items[idx], ...patch };
+			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
+			return;
+		}
+
+		if (method === 'DELETE') {
+			items.splice(idx, 1);
+			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+export async function mockIndexersCrud(page: Page): Promise<void> {
+	let nextId = 2;
+	const items: Indexer[] = [
+		{
+			id: 'idx-1',
+			name: 'Seed Indexer',
+			base_url: 'http://localhost:9117',
+			protocol: 'torznab',
+			enabled: true,
+			has_api_key: false
+		}
+	];
+
+	await routeJson(page, '**/api/v1/indexers/test', async (route) => {
+		if (route.request().method() !== 'POST') {
+			await route.fallback();
+			return;
+		}
+
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				success: true,
+				message: 'ok',
+				protocol: 'torznab',
+				capabilities: {
+					supports_search: true,
+					supports_rss: true,
+					supports_capabilities_detection: true,
+					supports_categories: true,
+					supported_categories: ['music']
+				}
+			})
+		});
+	});
+
+	await routeJson(page, '**/api/v1/settings/indexers**', async (route) => {
+		const req = route.request();
+		const method = req.method();
+		const url = new URL(req.url());
+		const path = url.pathname;
+
+		if (path.endsWith('/settings/indexers') && method === 'GET') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
+			});
+			return;
+		}
+
+		if (path.endsWith('/settings/indexers') && method === 'POST') {
+			const body = req.postDataJSON() as Partial<Indexer>;
+			const created: Indexer = {
+				id: `idx-${nextId++}`,
+				name: body.name ?? 'Unnamed',
+				base_url: body.base_url ?? 'http://localhost:9117',
+				protocol: body.protocol ?? 'torznab',
+				enabled: body.enabled ?? true,
+				has_api_key: Boolean(body.has_api_key)
+			};
+			items.push(created);
+			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
+			return;
+		}
+
+		const id = path.split('/').pop() ?? '';
+		const idx = items.findIndex((item) => item.id === id);
+		if (idx === -1) {
+			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+			return;
+		}
+
+		if (method === 'PUT') {
+			const patch = req.postDataJSON() as Partial<Indexer>;
+			items[idx] = { ...items[idx], ...patch };
+			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
+			return;
+		}
+
+		if (method === 'DELETE') {
+			items.splice(idx, 1);
+			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+export async function mockQualityProfilesCrud(page: Page): Promise<void> {
+	let nextId = 2;
+	const items: QualityProfile[] = [
+		{
+			id: 'qp-1',
+			name: 'Seed Quality',
+			allowed_qualities: ['FLAC'],
+			upgrade_allowed: true,
+			cutoff_quality: 'FLAC'
+		}
+	];
+
+	await routeJson(page, '**/api/v1/settings/quality-profiles**', async (route) => {
+		const req = route.request();
+		const method = req.method();
+		const path = new URL(req.url()).pathname;
+
+		if (path.endsWith('/settings/quality-profiles') && method === 'GET') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
+			});
+			return;
+		}
+
+		if (path.endsWith('/settings/quality-profiles') && method === 'POST') {
+			const body = req.postDataJSON() as Partial<QualityProfile>;
+			const created: QualityProfile = {
+				id: `qp-${nextId++}`,
+				name: body.name ?? 'Unnamed',
+				allowed_qualities: body.allowed_qualities ?? ['FLAC'],
+				upgrade_allowed: body.upgrade_allowed ?? true,
+				cutoff_quality: body.cutoff_quality ?? null
+			};
+			items.push(created);
+			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
+			return;
+		}
+
+		const id = path.split('/').pop() ?? '';
+		const idx = items.findIndex((item) => item.id === id);
+		if (idx === -1) {
+			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+			return;
+		}
+
+		if (method === 'PUT') {
+			const patch = req.postDataJSON() as Partial<QualityProfile>;
+			items[idx] = { ...items[idx], ...patch };
+			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
+			return;
+		}
+
+		if (method === 'DELETE') {
+			items.splice(idx, 1);
+			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+export async function mockMetadataProfilesCrud(page: Page): Promise<void> {
+	let nextId = 2;
+	const items: MetadataProfile[] = [
+		{
+			id: 'mp-1',
+			name: 'Seed Metadata',
+			primary_album_types: ['Album'],
+			secondary_album_types: [],
+			release_statuses: ['Official']
+		}
+	];
+
+	await routeJson(page, '**/api/v1/settings/metadata-profiles**', async (route) => {
+		const req = route.request();
+		const method = req.method();
+		const path = new URL(req.url()).pathname;
+
+		if (path.endsWith('/settings/metadata-profiles') && method === 'GET') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ items, total: items.length, limit: 100, offset: 0 })
+			});
+			return;
+		}
+
+		if (path.endsWith('/settings/metadata-profiles') && method === 'POST') {
+			const body = req.postDataJSON() as Partial<MetadataProfile>;
+			const created: MetadataProfile = {
+				id: `mp-${nextId++}`,
+				name: body.name ?? 'Unnamed',
+				primary_album_types: body.primary_album_types ?? ['Album'],
+				secondary_album_types: body.secondary_album_types ?? [],
+				release_statuses: body.release_statuses ?? ['Official']
+			};
+			items.push(created);
+			await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) });
+			return;
+		}
+
+		const id = path.split('/').pop() ?? '';
+		const idx = items.findIndex((item) => item.id === id);
+		if (idx === -1) {
+			await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+			return;
+		}
+
+		if (method === 'PUT') {
+			const patch = req.postDataJSON() as Partial<MetadataProfile>;
+			items[idx] = { ...items[idx], ...patch };
+			await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(items[idx]) });
+			return;
+		}
+
+		if (method === 'DELETE') {
+			items.splice(idx, 1);
+			await route.fulfill({ status: 204, contentType: 'application/json', body: '{}' });
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+export async function mockAllSettingsCrud(page: Page): Promise<void> {
+	await Promise.all([
+		mockDownloadClientsCrud(page),
+		mockIndexersCrud(page),
+		mockQualityProfilesCrud(page),
+		mockMetadataProfilesCrud(page)
+	]);
+}


### PR DESCRIPTION
## Summary
- extract settings CRUD route mocks into reusable fixtures in `web/e2e/settings-fixtures.ts`
- refactor `web/e2e/settings-crud.spec.ts` to consume shared fixtures
- unskip settings CRUD Playwright suite and stabilize selectors using scoped row assertions
- add explicit route availability assertions when opening settings subpages
- add baseline settings and event endpoint mocks in `web/e2e/helpers.ts` to reduce backend proxy noise in non-settings tests

## Validation
- `cd web && npm run check`
- `cd web && npx playwright test e2e/settings-crud.spec.ts`
- `cd web && npx playwright test`

Closes #481