### PR TITLE
Add performance baseline capture workflow and scripts

### DIFF
--- a/.github/workflows/performance-baseline.yml
+++ b/.github/workflows/performance-baseline.yml
@@ -1,0 +1,53 @@
+name: Performance Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: Number of samples per endpoint
+        required: false
+        default: "100"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  baseline:
+    name: Startup and API latency baseline
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustc --version
+          cargo --version
+
+      - name: Install dependencies (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libchromaprint-dev pkg-config jq curl
+          echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib" >> $GITHUB_ENV
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Run performance baseline script
+        run: |
+          chmod +x scripts/perf-baseline.sh
+          bash scripts/perf-baseline.sh "${{ github.event.inputs.iterations || '100' }}"
+
+      - name: Upload performance baseline artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-baseline
+          path: tmp/perf/baseline-latest.json

--- a/.github/workflows/performance-baseline.yml
+++ b/.github/workflows/performance-baseline.yml
@@ -8,6 +8,9 @@ on:
         required: false
         default: "100"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/performance-baseline.yml
+++ b/.github/workflows/performance-baseline.yml
@@ -40,6 +40,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - name: Run performance baseline script
         run: |

--- a/PERFORMANCE_BASELINE.md
+++ b/PERFORMANCE_BASELINE.md
@@ -1,0 +1,37 @@
+# Performance Baseline
+
+This document tracks repeatable startup and API latency baselines for Chorrosion.
+
+## How to Capture a Baseline
+
+Windows (PowerShell):
+
+1. Build and capture:
+   powershell -ExecutionPolicy Bypass -File scripts/perf-baseline.ps1 -Iterations 100
+2. Latest JSON output:
+   tmp/perf/baseline-latest.json
+
+Linux/macOS (Bash):
+
+1. Build and capture:
+   bash scripts/perf-baseline.sh 100
+2. Latest JSON output:
+   tmp/perf/baseline-latest.json
+
+CI:
+
+1. Run workflow: .github/workflows/performance-baseline.yml
+2. Download artifact: performance-baseline (baseline-latest.json)
+
+## Latest Baseline
+
+Date (UTC): 2026-05-26T19:51:33Z
+Environment: Microsoft Windows 10.0.26200
+Iterations per endpoint: 100
+Startup (health-ready): 584.69 ms
+
+| Endpoint | p50 ms | p95 ms | avg ms | max ms |
+| --- | ---: | ---: | ---: | ---: |
+| /health | 11.33 | 12.73 | 11.40 | 14.82 |
+| /api/v1/artists?limit=50&offset=0 | 11.01 | 11.79 | 11.03 | 16.26 |
+| /api-doc/openapi.json | 63.20 | 89.32 | 67.90 | 149.43 |

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ All `/api/v1` endpoints require a valid API key. Provide the key using one of:
 
 When both `CHORROSION_AUTH__BASIC_USERNAME` and `CHORROSION_AUTH__BASIC_PASSWORD` are set, HTTP Basic authentication is also accepted:
 
-```
+```text
 Authorization: Basic <base64(username:password)>
 ```
 
@@ -303,6 +303,18 @@ For CI or quick compile checks without executing benchmark loops:
 ```bash
 cargo bench -p chorrosion-api --no-run
 ```
+
+## Performance Baseline Capture
+
+To track startup and API latency against roadmap goals:
+
+- Windows: `powershell -ExecutionPolicy Bypass -File scripts/perf-baseline.ps1 -Iterations 100`
+- Linux/macOS: `bash scripts/perf-baseline.sh 100`
+
+Results are written to `tmp/perf/baseline-latest.json`.
+
+For CI, run the `Performance Baseline` workflow in `.github/workflows/performance-baseline.yml`.
+Current baseline history and reporting lives in `PERFORMANCE_BASELINE.md`.
 
 ## License
 

--- a/scripts/perf-baseline.ps1
+++ b/scripts/perf-baseline.ps1
@@ -1,0 +1,121 @@
+# Performance baseline capture for Chorrosion.
+# Measures startup readiness and request latency percentiles for key endpoints.
+
+param(
+    [int]$Iterations = 100,
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $SkipBuild) {
+    cargo build --release -p chorrosion-cli
+}
+
+$exe = Join-Path $PSScriptRoot '..\target\release\chorrosion-cli.exe'
+$exe = [System.IO.Path]::GetFullPath($exe)
+if (-not (Test-Path $exe)) {
+    throw "Binary not found: $exe"
+}
+
+$perfDir = Join-Path $PSScriptRoot '..\tmp\perf'
+New-Item -ItemType Directory -Path $perfDir -Force | Out-Null
+
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$jsonOut = Join-Path $perfDir "baseline-$timestamp.json"
+$latestOut = Join-Path $perfDir 'baseline-latest.json'
+
+$env:CHORROSION_DATABASE__URL = "sqlite://data/perf-baseline-$timestamp.db"
+$env:CHORROSION_AUTH__BASIC_USERNAME = 'bench'
+$env:CHORROSION_AUTH__BASIC_PASSWORD = 'bench'
+$env:RUST_LOG = 'warn'
+
+$basicAuthValue = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes('bench:bench'))
+$authHeaders = @{ Authorization = "Basic $basicAuthValue" }
+
+$proc = Start-Process -FilePath $exe -PassThru
+try {
+    $startupSw = [System.Diagnostics.Stopwatch]::StartNew()
+    $deadline = [DateTime]::UtcNow.AddSeconds(30)
+    $ready = $false
+
+    while ([DateTime]::UtcNow -lt $deadline) {
+        try {
+            $health = Invoke-RestMethod -Uri 'http://127.0.0.1:5150/health' -TimeoutSec 2
+            if ($health.status -eq 'ok') {
+                $ready = $true
+                break
+            }
+        } catch {
+            Start-Sleep -Milliseconds 100
+        }
+    }
+
+    if (-not $ready) {
+        throw 'Server did not become healthy within 30s.'
+    }
+
+    $startupSw.Stop()
+
+    $targets = @(
+        @{ name = 'health'; url = 'http://127.0.0.1:5150/health'; headers = @{} },
+        @{ name = 'artists_list'; url = 'http://127.0.0.1:5150/api/v1/artists?limit=50&offset=0'; headers = $authHeaders },
+        @{ name = 'openapi_json'; url = 'http://127.0.0.1:5150/api-doc/openapi.json'; headers = @{} }
+    )
+
+    # Warm-up requests to avoid cold-start artifacts in latency samples.
+    foreach ($target in $targets) {
+        1..10 | ForEach-Object {
+            $null = Invoke-WebRequest -Uri $target.url -Headers $target.headers -TimeoutSec 5 -UseBasicParsing
+        }
+    }
+
+    $endpointResults = @()
+
+    foreach ($target in $targets) {
+        $samples = New-Object System.Collections.Generic.List[double]
+
+        for ($i = 0; $i -lt $Iterations; $i++) {
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            $resp = Invoke-WebRequest -Uri $target.url -Headers $target.headers -TimeoutSec 5 -UseBasicParsing
+            $sw.Stop()
+
+            if ($resp.StatusCode -lt 200 -or $resp.StatusCode -ge 300) {
+                throw "Unexpected status code $($resp.StatusCode) for $($target.name)"
+            }
+
+            $samples.Add($sw.Elapsed.TotalMilliseconds)
+        }
+
+        $sorted = $samples | Sort-Object
+        $idx95 = [Math]::Min($sorted.Count - 1, [Math]::Ceiling($sorted.Count * 0.95) - 1)
+        $idx50 = [Math]::Min($sorted.Count - 1, [Math]::Ceiling($sorted.Count * 0.50) - 1)
+
+        $endpointResults += [pscustomobject]@{
+            name = $target.name
+            url = $target.url
+            sample_count = $sorted.Count
+            p50_ms = [Math]::Round($sorted[$idx50], 2)
+            p95_ms = [Math]::Round($sorted[$idx95], 2)
+            avg_ms = [Math]::Round(($sorted | Measure-Object -Average).Average, 2)
+            max_ms = [Math]::Round(($sorted | Measure-Object -Maximum).Maximum, 2)
+        }
+    }
+
+    $result = [pscustomobject]@{
+        captured_at_utc = (Get-Date).ToUniversalTime().ToString('o')
+        os = [System.Runtime.InteropServices.RuntimeInformation]::OSDescription
+        startup_ms = [Math]::Round($startupSw.Elapsed.TotalMilliseconds, 2)
+        iterations_per_endpoint = $Iterations
+        endpoints = $endpointResults
+    }
+
+    $json = $result | ConvertTo-Json -Depth 5
+    $json | Set-Content -Path $jsonOut -Encoding UTF8
+    $json | Set-Content -Path $latestOut -Encoding UTF8
+
+    Write-Host "Performance baseline saved: $jsonOut"
+    Write-Host "Latest baseline copied to: $latestOut"
+} finally {
+    Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/perf-baseline.ps1
+++ b/scripts/perf-baseline.ps1
@@ -2,11 +2,14 @@
 # Measures startup readiness and request latency percentiles for key endpoints.
 
 param(
+    [ValidateRange(1, [int]::MaxValue)]
     [int]$Iterations = 100,
     [switch]$SkipBuild
 )
 
 $ErrorActionPreference = 'Stop'
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 
 if (-not $SkipBuild) {
     cargo build --release -p chorrosion-cli
@@ -20,6 +23,7 @@ if (-not (Test-Path $exe)) {
 
 $perfDir = Join-Path $PSScriptRoot '..\tmp\perf'
 New-Item -ItemType Directory -Path $perfDir -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $repoRoot 'data') -Force | Out-Null
 
 $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 $jsonOut = Join-Path $perfDir "baseline-$timestamp.json"
@@ -33,7 +37,7 @@ $env:RUST_LOG = 'warn'
 $basicAuthValue = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes('bench:bench'))
 $authHeaders = @{ Authorization = "Basic $basicAuthValue" }
 
-$proc = Start-Process -FilePath $exe -PassThru
+$proc = Start-Process -FilePath $exe -WorkingDirectory $repoRoot -PassThru
 try {
     $startupSw = [System.Diagnostics.Stopwatch]::StartNew()
     $deadline = [DateTime]::UtcNow.AddSeconds(30)

--- a/scripts/perf-baseline.sh
+++ b/scripts/perf-baseline.sh
@@ -6,6 +6,36 @@ if ! [[ "$ITERATIONS" =~ ^[0-9]+$ ]]; then
   echo "iterations must be numeric" >&2
   exit 1
 fi
+if (( ITERATIONS < 1 )); then
+  echo "iterations must be >= 1" >&2
+  exit 1
+fi
+
+for dep in jq curl awk base64; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "missing required dependency: $dep" >&2
+    exit 1
+  fi
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+cd "$repo_root"
+
+now_ms() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+    return
+  fi
+  if command -v perl >/dev/null 2>&1; then
+    perl -MTime::HiRes=time -e 'printf "%.0f\n", time()*1000'
+    return
+  fi
+  echo "$(( $(date +%s) * 1000 ))"
+}
 
 cargo build --release -p chorrosion-cli
 
@@ -31,7 +61,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-startup_start_ms="$(date +%s%3N)"
+startup_start_ms="$(now_ms)"
 ready="false"
 for _ in $(seq 1 300); do
   if curl -fsS "http://127.0.0.1:5150/health" >/dev/null 2>&1; then
@@ -44,7 +74,7 @@ if [[ "$ready" != "true" ]]; then
   echo "server did not become healthy within 30s" >&2
   exit 1
 fi
-startup_end_ms="$(date +%s%3N)"
+startup_end_ms="$(now_ms)"
 startup_ms="$((startup_end_ms - startup_start_ms))"
 
 endpoints=(

--- a/scripts/perf-baseline.sh
+++ b/scripts/perf-baseline.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ITERATIONS="${1:-100}"
+if ! [[ "$ITERATIONS" =~ ^[0-9]+$ ]]; then
+  echo "iterations must be numeric" >&2
+  exit 1
+fi
+
+cargo build --release -p chorrosion-cli
+
+mkdir -p tmp/perf data
+timestamp="$(date -u +%Y%m%d-%H%M%S)"
+json_out="tmp/perf/baseline-${timestamp}.json"
+latest_out="tmp/perf/baseline-latest.json"
+
+export CHORROSION_DATABASE__URL="sqlite://data/perf-baseline-${timestamp}.db"
+export CHORROSION_AUTH__BASIC_USERNAME="bench"
+export CHORROSION_AUTH__BASIC_PASSWORD="bench"
+export RUST_LOG="warn"
+
+auth_b64="$(printf 'bench:bench' | base64 | tr -d '\n')"
+auth_header="Authorization: Basic ${auth_b64}"
+
+target/release/chorrosion-cli > /dev/null 2>&1 &
+server_pid=$!
+
+cleanup() {
+  kill "$server_pid" >/dev/null 2>&1 || true
+  wait "$server_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+startup_start_ms="$(date +%s%3N)"
+ready="false"
+for _ in $(seq 1 300); do
+  if curl -fsS "http://127.0.0.1:5150/health" >/dev/null 2>&1; then
+    ready="true"
+    break
+  fi
+  sleep 0.1
+done
+if [[ "$ready" != "true" ]]; then
+  echo "server did not become healthy within 30s" >&2
+  exit 1
+fi
+startup_end_ms="$(date +%s%3N)"
+startup_ms="$((startup_end_ms - startup_start_ms))"
+
+endpoints=(
+  "health|http://127.0.0.1:5150/health|"
+  "artists_list|http://127.0.0.1:5150/api/v1/artists?limit=50&offset=0|${auth_header}"
+  "openapi_json|http://127.0.0.1:5150/api-doc/openapi.json|"
+)
+
+json_endpoints="[]"
+
+for endpoint in "${endpoints[@]}"; do
+  name="${endpoint%%|*}"
+  rest="${endpoint#*|}"
+  url="${rest%%|*}"
+  header="${rest#*|}"
+
+  for _ in $(seq 1 10); do
+    if [[ -n "$header" ]]; then
+      curl -fsS -H "$header" "$url" >/dev/null
+    else
+      curl -fsS "$url" >/dev/null
+    fi
+  done
+
+  samples=()
+  for _ in $(seq 1 "$ITERATIONS"); do
+    if [[ -n "$header" ]]; then
+      val="$(curl -s -H "$header" -o /dev/null -w '%{time_total}' "$url")"
+    else
+      val="$(curl -s -o /dev/null -w '%{time_total}' "$url")"
+    fi
+    ms="$(awk -v t="$val" 'BEGIN { printf "%.3f", t * 1000 }')"
+    samples+=("$ms")
+  done
+
+  sorted="$(printf '%s
+' "${samples[@]}" | sort -n)"
+  p50_index="$(( (ITERATIONS + 1) / 2 ))"
+  p95_index="$(( (ITERATIONS * 95 + 99) / 100 ))"
+  if (( p95_index > ITERATIONS )); then
+    p95_index="$ITERATIONS"
+  fi
+
+  p50="$(printf '%s
+' "$sorted" | sed -n "${p50_index}p")"
+  p95="$(printf '%s
+' "$sorted" | sed -n "${p95_index}p")"
+  avg="$(printf '%s
+' "${samples[@]}" | awk '{sum += $1} END {if (NR == 0) print "0.000"; else printf "%.3f", sum / NR}')"
+  max="$(printf '%s
+' "$sorted" | tail -n 1)"
+
+  endpoint_json="$(jq -n \
+    --arg name "$name" \
+    --arg url "$url" \
+    --argjson sample_count "$ITERATIONS" \
+    --argjson p50_ms "$p50" \
+    --argjson p95_ms "$p95" \
+    --argjson avg_ms "$avg" \
+    --argjson max_ms "$max" \
+    '{name:$name,url:$url,sample_count:$sample_count,p50_ms:$p50_ms,p95_ms:$p95_ms,avg_ms:$avg_ms,max_ms:$max_ms}')"
+
+  json_endpoints="$(jq --argjson obj "$endpoint_json" '. + [$obj]' <<< "$json_endpoints")"
+done
+
+jq -n \
+  --arg captured_at_utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg os "$(uname -srm)" \
+  --argjson startup_ms "$startup_ms" \
+  --argjson iterations_per_endpoint "$ITERATIONS" \
+  --argjson endpoints "$json_endpoints" \
+  '{captured_at_utc:$captured_at_utc,os:$os,startup_ms:$startup_ms,iterations_per_endpoint:$iterations_per_endpoint,endpoints:$endpoints}' \
+  > "$json_out"
+
+cp "$json_out" "$latest_out"
+echo "Performance baseline saved: $json_out"
+echo "Latest baseline copied to: $latest_out"


### PR DESCRIPTION
## Summary

Adds a reproducible performance-baseline workflow for startup readiness and API latency tracking.

## What Changed

- Added cross-platform baseline scripts:
  - `scripts/perf-baseline.ps1`
  - `scripts/perf-baseline.sh`
- Added manual GitHub Actions workflow:
  - `.github/workflows/performance-baseline.yml`
- Added baseline documentation and latest sample metrics:
  - `PERFORMANCE_BASELINE.md`
- Updated root docs with baseline capture instructions:
  - `README.md`

## Baseline Captured (Local)

- Environment: `Microsoft Windows 10.0.26200`
- Startup to health-ready: `584.69 ms`
- Iterations per endpoint: `100`

| Endpoint | p50 ms | p95 ms | avg ms | max ms |
| --- | ---: | ---: | ---: | ---: |
| /health | 11.33 | 12.73 | 11.40 | 14.82 |
| /api/v1/artists?limit=50&offset=0 | 11.01 | 11.79 | 11.03 | 16.26 |
| /api-doc/openapi.json | 63.20 | 89.32 | 67.90 | 149.43 |

## Validation

- `powershell -ExecutionPolicy Bypass -File scripts/perf-baseline.ps1 -Iterations 100 -SkipBuild`
- Markdown and workflow diagnostics checked (no reported errors in changed files)

## Notes

- Scripts set temporary benchmark basic-auth credentials in process env so protected API endpoints can be measured non-interactively.
- `tmp/perf/baseline-latest.json` is generated at runtime and is intentionally not committed.
