### PR TITLE
Add indexer validation helper tests

### DIFF
--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -1140,6 +1140,26 @@ mod tests {
         )
     }
 
+    #[test]
+    fn validate_name_rejects_empty_input() {
+        assert!(validate_name("   ").is_err());
+    }
+
+    #[test]
+    fn validate_base_url_accepts_trimmed_https_url() {
+        assert!(validate_base_url("  https://indexer.example  ").is_ok());
+    }
+
+    #[test]
+    fn validate_base_url_rejects_unsupported_scheme() {
+        assert!(validate_base_url("ftp://indexer.example").is_err());
+    }
+
+    #[test]
+    fn parse_protocol_rejects_unknown_protocol() {
+        assert!(parse_protocol("not-a-protocol").is_err());
+    }
+
     #[tokio::test]
     async fn create_indexer_returns_created() {
         let state = make_test_state().await;


### PR DESCRIPTION
## Summary

Adds focused unit tests for the indexer validation helpers in `crates/chorrosion-api/src/handlers/indexers.rs`.

## What Changed

- Added direct tests for:
  - empty indexer name rejection
  - trimmed HTTPS base URL acceptance
  - unsupported URL scheme rejection
  - unknown protocol rejection

## Why

These helper branches are small, self-contained, and easy to regress. Testing them directly improves confidence in the indexer settings workflow and adds coverage to a validation-heavy handler module.

## Validation

- `cargo test -p chorrosion-api validate_ -- --nocapture`
- `cargo test -p chorrosion-api parse_protocol_rejects_unknown_protocol -- --nocapture`

## Notes

- The change is intentionally scoped to a single handler file to keep the PR focused.
