### PR TITLE
Add download client validation helper tests

### DIFF
--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -1093,6 +1093,26 @@ mod tests {
         )
     }
 
+    #[test]
+    fn validate_name_rejects_empty_input() {
+        assert!(validate_name("   ").is_err());
+    }
+
+    #[test]
+    fn validate_base_url_accepts_trimmed_https_url() {
+        assert!(validate_base_url("  https://downloads.example  ").is_ok());
+    }
+
+    #[test]
+    fn validate_base_url_rejects_unsupported_scheme() {
+        assert!(validate_base_url("ftp://downloads.example").is_err());
+    }
+
+    #[test]
+    fn normalize_client_type_rejects_unknown_value() {
+        assert!(normalize_client_type("invalid-client").is_err());
+    }
+
     #[tokio::test]
     async fn create_download_client_returns_created() {
         let state = make_test_state().await;


### PR DESCRIPTION
## Summary

Adds focused unit tests for download client validation helpers in `crates/chorrosion-api/src/handlers/download_clients.rs`.

## What Changed

- Added direct tests for:
  - empty download-client name rejection
  - trimmed HTTPS base URL acceptance
  - unsupported URL scheme rejection
  - unknown `client_type` rejection

## Why

These are small, validation-heavy helper branches that are easy to regress and cheap to test directly. This is a low-risk incremental step toward the coverage target.

## Validation

- `cargo test -p chorrosion-api validate_name_rejects_empty_input -- --nocapture`
- `cargo test -p chorrosion-api validate_base_url_ -- --nocapture`
- `cargo test -p chorrosion-api normalize_client_type_rejects_unknown_value -- --nocapture`

## Notes

- Change is intentionally scoped to one handler file for fast review.
