### PR TITLE
Add metadata profile helper validation tests

### DIFF
--- a/crates/chorrosion-api/src/handlers/metadata_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/metadata_profiles.rs
@@ -788,6 +788,24 @@ mod tests {
         };
         use std::sync::Arc;
 
+        #[test]
+        fn validate_name_rejects_empty_input() {
+            assert!(validate_name("   ").is_err());
+        }
+
+        #[test]
+        fn validate_name_accepts_trimmed_non_empty_input() {
+            assert!(validate_name("  Metadata Profile  ").is_ok());
+        }
+
+        #[test]
+        fn default_import_conflict_policy_is_merge() {
+            assert!(matches!(
+                default_import_conflict_policy(),
+                ImportConflictPolicy::Merge
+            ));
+        }
+
         async fn make_test_state() -> AppState {
             use sqlx::sqlite::SqlitePoolOptions;
             let pool = SqlitePoolOptions::new()


### PR DESCRIPTION
## Summary

Adds focused helper-level tests for metadata profile validation/default logic in `crates/chorrosion-api/src/handlers/metadata_profiles.rs`.

## What Changed

- Added direct tests for:
  - empty metadata profile name rejection
  - trimmed non-empty metadata profile name acceptance
  - default import conflict policy resolving to `merge`

## Why

These helper branches are lightweight, deterministic, and easy to regress. Covering them directly is a low-risk incremental step toward the coverage goal.

## Validation

- `cargo test -p chorrosion-api validate_name_rejects_empty_input -- --nocapture`
- `cargo test -p chorrosion-api validate_name_accepts_trimmed_non_empty_input -- --nocapture`
- `cargo test -p chorrosion-api default_import_conflict_policy_is_merge -- --nocapture`

## Notes

- Change scope is intentionally limited to one file for fast review and merge.
