### PR TITLE
Add search helper edge-case tests

### DIFF
--- a/crates/chorrosion-api/src/handlers/search.rs
+++ b/crates/chorrosion-api/src/handlers/search.rs
@@ -376,6 +376,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_preferred_qualities_accepts_trimmed_case_insensitive_values() {
+        let parsed = parse_preferred_qualities(&[
+            "  FLAC ".to_string(),
+            "Mp3".to_string(),
+            "aAc".to_string(),
+        ])
+        .expect("valid qualities");
+
+        assert_eq!(
+            parsed,
+            vec![AudioQuality::Flac, AudioQuality::Mp3, AudioQuality::Aac]
+        );
+    }
+
+    #[test]
     fn parse_custom_format_rules_maps_valid_rule() {
         let rules = vec![ManualSearchCustomFormatRule {
             name: "MQA".to_string(),
@@ -424,6 +439,50 @@ mod tests {
 
         let err = parse_custom_format_rules(rules).expect_err("invalid score bonus");
         assert!(err.contains("score_bonus must be between"));
+    }
+
+    #[test]
+    fn parse_custom_format_rules_accepts_boundary_score_bonus_values() {
+        let rules = vec![
+            ManualSearchCustomFormatRule {
+                name: "Lowest".to_string(),
+                keywords: vec!["lossy".to_string()],
+                score_bonus: -MAX_CUSTOM_FORMAT_SCORE_BONUS,
+            },
+            ManualSearchCustomFormatRule {
+                name: "Highest".to_string(),
+                keywords: vec!["lossless".to_string()],
+                score_bonus: MAX_CUSTOM_FORMAT_SCORE_BONUS,
+            },
+        ];
+
+        let parsed = parse_custom_format_rules(rules).expect("boundary bonuses are valid");
+        assert_eq!(parsed[0].score_bonus, -MAX_CUSTOM_FORMAT_SCORE_BONUS);
+        assert_eq!(parsed[1].score_bonus, MAX_CUSTOM_FORMAT_SCORE_BONUS);
+    }
+
+    #[tokio::test]
+    async fn manual_search_endpoint_returns_400_when_indexer_id_is_empty() {
+        let state = make_test_state().await;
+
+        let response = manual_search_endpoint(
+            State(state),
+            Json(ManualSearchApiRequest {
+                indexer_id: "   ".to_string(),
+                artist: Some("Boards of Canada".to_string()),
+                album: None,
+                query: None,
+                preferred_qualities: vec![],
+                min_bitrate_kbps: None,
+                preferred_release_groups: vec![],
+                preferred_words: vec![],
+                custom_format_rules: vec![],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds focused edge-case tests for search parsing helpers and request validation in `crates/chorrosion-api/src/handlers/search.rs`.

## What Changed

- Added test for case-insensitive and trimmed preferred quality parsing.
- Added test for inclusive boundary score-bonus values in custom format rules.
- Added test asserting manual search returns `400` when `indexer_id` is empty/whitespace.

## Why

These are small, deterministic helper/request branches that are easy to regress and improve coverage without changing runtime behavior.

## Validation

- `cargo test -p chorrosion-api parse_preferred_qualities_accepts_trimmed_case_insensitive_values -- --nocapture`
- `cargo test -p chorrosion-api parse_custom_format_rules_accepts_boundary_score_bonus_values -- --nocapture`
- `cargo test -p chorrosion-api manual_search_endpoint_returns_400_when_indexer_id_is_empty -- --nocapture`

## Notes

- Change scope is intentionally limited to one handler file for fast review.
