### PR TITLE
test(api): add indexers list validation branch tests

### DIFF
--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -1161,6 +1161,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_indexers_rejects_invalid_limit() {
+        let state = make_test_state().await;
+
+        let result = list_indexers(
+            State(state),
+            Query(ListIndexersQuery {
+                limit: 0,
+                offset: 0,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn list_indexers_rejects_negative_offset() {
+        let state = make_test_state().await;
+
+        let result = list_indexers(
+            State(state),
+            Query(ListIndexersQuery {
+                limit: 50,
+                offset: -1,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn create_indexer_returns_created() {
         let state = make_test_state().await;
         let response = create_indexer(

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -1174,8 +1174,9 @@ mod tests {
         .await;
 
         assert!(result.is_err());
-        let (status, _) = result.unwrap_err();
+        let (status, Json(error)) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.error, "limit must be between 1 and 500");
     }
 
     #[tokio::test]
@@ -1192,8 +1193,9 @@ mod tests {
         .await;
 
         assert!(result.is_err());
-        let (status, _) = result.unwrap_err();
+        let (status, Json(error)) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.error, "offset must be greater than or equal to 0");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add test for list indexers rejecting invalid limit
- add test for list indexers rejecting negative offset

## Testing
- cargo test -p chorrosion-api list_indexers_rejects_invalid_limit
- cargo test -p chorrosion-api list_indexers_rejects_negative_offset