### PR TITLE
test(api): add download clients list validation tests

### DIFF
--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -1114,6 +1114,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_download_clients_rejects_invalid_limit() {
+        let state = make_test_state().await;
+
+        let result = list_download_clients(
+            State(state),
+            Query(ListDownloadClientsQuery {
+                limit: 0,
+                offset: 0,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn list_download_clients_rejects_negative_offset() {
+        let state = make_test_state().await;
+
+        let result = list_download_clients(
+            State(state),
+            Query(ListDownloadClientsQuery {
+                limit: 50,
+                offset: -1,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn create_download_client_returns_created() {
         let state = make_test_state().await;
         let response = create_download_client(


### PR DESCRIPTION
## Summary
- add test for list download clients rejecting invalid limit
- add test for list download clients rejecting negative offset

## Testing
- cargo test -p chorrosion-api list_download_clients_rejects_invalid_limit
- cargo test -p chorrosion-api list_download_clients_rejects_negative_offset