### PR TITLE
test(api): cover forms auth config and logout branches

### DIFF
--- a/crates/chorrosion-api/src/handlers/auth.rs
+++ b/crates/chorrosion-api/src/handlers/auth.rs
@@ -742,6 +742,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn forms_login_returns_service_unavailable_when_not_configured() {
+        let _lock = auth_test_mutex().lock().await;
+        clear_stores_for_tests().await;
+
+        let state = make_test_state_with_config(AppConfig::default()).await;
+
+        let login = forms_login(
+            State(state),
+            Form(FormsLoginRequest {
+                username: "user".to_string(),
+                password: "pass".to_string(),
+            }),
+        )
+        .await;
+
+        assert!(matches!(login, Err((StatusCode::SERVICE_UNAVAILABLE, _))));
+    }
+
+    #[tokio::test]
+    async fn forms_logout_without_cookie_returns_logged_out_false() {
+        let _lock = auth_test_mutex().lock().await;
+        clear_stores_for_tests().await;
+
+        let state = make_test_state().await;
+        let headers = HeaderMap::new();
+
+        let (_, Json(response)) = forms_logout(State(state), headers).await;
+        assert!(!response.logged_out);
+    }
+
+    #[tokio::test]
     async fn forms_login_returns_configured_permission_level() {
         let _lock = auth_test_mutex().lock().await;
         clear_stores_for_tests().await;


### PR DESCRIPTION
## Summary
- add forms login coverage for the not-configured auth branch
- add forms logout coverage for missing session cookie branch
- keep change scoped to a single test file

## Testing
- cargo test -p chorrosion-api forms_login_returns_service_unavailable_when_not_configured
- cargo test -p chorrosion-api forms_logout_without_cookie_returns_logged_out_false