### PR TITLE
test(api): cover auth cookie helper branches

### DIFF
--- a/crates/chorrosion-api/src/handlers/auth.rs
+++ b/crates/chorrosion-api/src/handlers/auth.rs
@@ -576,6 +576,29 @@ mod tests {
         assert!(deleted.0.deleted);
     }
 
+    #[test]
+    fn key_prefix_truncates_to_eight_characters() {
+        assert_eq!(super::key_prefix("123456789abcdef"), "12345678");
+        assert_eq!(super::key_prefix("short"), "short");
+    }
+
+    #[test]
+    fn build_form_session_cookie_includes_secure_directive_when_enabled() {
+        let cookie = super::build_form_session_cookie("token-123", true);
+
+        assert!(cookie.contains("chorrosion_session=token-123"));
+        assert!(cookie.contains("; Secure"));
+    }
+
+    #[test]
+    fn clear_form_session_cookie_omits_secure_directive_when_disabled() {
+        let cookie = super::clear_form_session_cookie(false);
+
+        assert!(cookie.contains("chorrosion_session=;"));
+        assert!(!cookie.contains("; Secure"));
+        assert!(cookie.ends_with("Max-Age=0"));
+    }
+
     /// Tests the TOCTOU branch in `validate_api_key_and_touch` where the key is
     /// deleted between the read-lock check and the write-lock update.
     ///


### PR DESCRIPTION
## Summary
- add direct coverage for auth API key prefix truncation
- add coverage for secure form session cookie construction
- add coverage for clearing form session cookies without Secure

## Testing
- cargo test -p chorrosion-api key_prefix_truncates_to_eight_characters
- cargo test -p chorrosion-api build_form_session_cookie_includes_secure_directive_when_enabled
- cargo test -p chorrosion-api clear_form_session_cookie_omits_secure_directive_when_disabled