### PR TITLE
test(api): cover download clients import validation branches

### DIFF
--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -1345,6 +1345,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn import_download_clients_rejects_unsupported_version() {
+        let state = make_test_state().await;
+
+        let response = import_download_clients(
+            State(state),
+            Query(SettingsImportQuery { dry_run: false }),
+            Json(DownloadClientImportRequest {
+                version: "2".to_string(),
+                conflict_policy: ImportConflictPolicy::Merge,
+                items: vec![],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn import_download_clients_rejects_unsupported_client_type_item() {
+        let state = make_test_state().await;
+
+        let response = import_download_clients(
+            State(state),
+            Query(SettingsImportQuery { dry_run: false }),
+            Json(DownloadClientImportRequest {
+                version: "1".to_string(),
+                conflict_policy: ImportConflictPolicy::Merge,
+                items: vec![DownloadClientImportItem {
+                    name: "Imported".to_string(),
+                    client_type: "not-supported".to_string(),
+                    base_url: "https://downloads.example".to_string(),
+                    username: None,
+                    password: None,
+                    category: None,
+                    enabled: true,
+                }],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn bulk_download_clients_enables_selected_items() {
         let state = make_test_state().await;
         let first = state

--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -1047,6 +1047,7 @@ pub async fn import_download_clients(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::to_bytes;
     use axum::extract::State;
     use chorrosion_config::AppConfig;
     use chorrosion_infrastructure::sqlite_adapters::{
@@ -1361,6 +1362,13 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let error: serde_json::Value =
+            serde_json::from_slice(&body).expect("deserialize import error");
+        assert_eq!(error["error"], "unsupported import version");
+        assert_eq!(error["details"], serde_json::json!(["version must be '1'"]));
     }
 
     #[tokio::test]
@@ -1388,6 +1396,19 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let error: serde_json::Value =
+            serde_json::from_slice(&body).expect("deserialize import error");
+        assert_eq!(error["error"], "invalid import payload");
+        assert!(
+            error["details"]
+                .as_array()
+                .expect("details array")
+                .iter()
+                .any(|detail| detail == "items[0].client_type is not supported")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add import coverage for unsupported download client import version
- add import coverage for unsupported client_type values in import items
- keep change scoped to one test file

## Testing
- cargo test -p chorrosion-api import_download_clients_rejects_unsupported_version
- cargo test -p chorrosion-api import_download_clients_rejects_unsupported_client_type_item