### PR TITLE
test(api): cover download clients import name and url validation branches

### DIFF
--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -1412,6 +1412,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn import_download_clients_rejects_empty_name_in_item() {
+        let state = make_test_state().await;
+
+        let response = import_download_clients(
+            State(state),
+            Query(SettingsImportQuery { dry_run: false }),
+            Json(DownloadClientImportRequest {
+                version: "1".to_string(),
+                conflict_policy: ImportConflictPolicy::Merge,
+                items: vec![DownloadClientImportItem {
+                    name: "   ".to_string(),
+                    client_type: "qbittorrent".to_string(),
+                    base_url: "https://downloads.example".to_string(),
+                    username: None,
+                    password: None,
+                    category: None,
+                    enabled: true,
+                }],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let error: serde_json::Value =
+            serde_json::from_slice(&body).expect("deserialize import error");
+        assert_eq!(error["error"], "invalid import payload");
+        assert!(
+            error["details"]
+                .as_array()
+                .expect("details array")
+                .iter()
+                .any(|detail| detail == "items[0].name cannot be empty")
+        );
+    }
+
+    #[tokio::test]
+    async fn import_download_clients_rejects_invalid_base_url_in_item() {
+        let state = make_test_state().await;
+
+        let response = import_download_clients(
+            State(state),
+            Query(SettingsImportQuery { dry_run: false }),
+            Json(DownloadClientImportRequest {
+                version: "1".to_string(),
+                conflict_policy: ImportConflictPolicy::Merge,
+                items: vec![DownloadClientImportItem {
+                    name: "Imported".to_string(),
+                    client_type: "qbittorrent".to_string(),
+                    base_url: "not-a-url".to_string(),
+                    username: None,
+                    password: None,
+                    category: None,
+                    enabled: true,
+                }],
+            }),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let error: serde_json::Value =
+            serde_json::from_slice(&body).expect("deserialize import error");
+        assert_eq!(error["error"], "invalid import payload");
+        assert!(
+            error["details"]
+                .as_array()
+                .expect("details array")
+                .iter()
+                .any(|detail| detail == "items[0].base_url is invalid")
+        );
+    }
+
+    #[tokio::test]
     async fn bulk_download_clients_enables_selected_items() {
         let state = make_test_state().await;
         let first = state


### PR DESCRIPTION
## Summary
- add import coverage for empty-name download client items
- add import coverage for invalid base_url download client items
- keep change scoped to one test file

## Testing
- cargo test -p chorrosion-api import_download_clients_rejects_empty_name_in_item
- cargo test -p chorrosion-api import_download_clients_rejects_invalid_base_url_in_item