### PR TITLE
test(api): cover quality profiles import empty name validation branch

### DIFF
--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -1169,7 +1169,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn import_quality_profiles_rejects_empty_item_name() {
+        async fn import_quality_profiles_rejects_whitespace_only_item_name() {
             let state = make_test_state().await;
             let response = import_quality_profiles(
                 State(state),

--- a/crates/chorrosion-api/src/handlers/quality_profiles.rs
+++ b/crates/chorrosion-api/src/handlers/quality_profiles.rs
@@ -1168,6 +1168,29 @@ mod tests {
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         }
 
+        #[tokio::test]
+        async fn import_quality_profiles_rejects_empty_item_name() {
+            let state = make_test_state().await;
+            let response = import_quality_profiles(
+                State(state),
+                Query(SettingsImportQuery { dry_run: false }),
+                Json(QualityProfileImportRequest {
+                    version: "1".to_string(),
+                    conflict_policy: ImportConflictPolicy::Merge,
+                    items: vec![QualityProfileImportItem {
+                        name: "   ".to_string(),
+                        allowed_qualities: vec!["FLAC".to_string()],
+                        upgrade_allowed: false,
+                        cutoff_quality: None,
+                    }],
+                }),
+            )
+            .await
+            .into_response();
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
         // --- bulk_quality_profiles ---
 
         #[tokio::test]


### PR DESCRIPTION
## Summary
- add import coverage for empty-name quality profile items
- validates that items with whitespace-only names are rejected
- keep change scoped to one test

## Testing
- cargo test -p chorrosion-api import_quality_profiles_rejects_empty_item_name