### PR TITLE
refactor(web): extract shared settings save-error workflow

### DIFF
--- a/web/src/lib/settingsValidation.test.ts
+++ b/web/src/lib/settingsValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ApiError } from '$lib/api';
-import { classifyFormError } from '$lib/settingsValidation';
+import { classifyFormError, mapClassifiedSaveErrorToUiState } from '$lib/settingsValidation';
 
 describe('classifyFormError', () => {
 	it('returns structured field errors from API response bodies', () => {
@@ -41,5 +41,52 @@ describe('classifyFormError', () => {
 
 		expect(result.fieldErrors).toEqual({});
 		expect(result.bannerMessage).toBe('Network failed');
+	});
+});
+
+describe('mapClassifiedSaveErrorToUiState', () => {
+	it('merges field errors and keeps banner clear when field mapping succeeds', () => {
+		const result = mapClassifiedSaveErrorToUiState(
+			{
+				fieldErrors: { name: 'Name already exists.' },
+				bannerMessage: ''
+			},
+			{ base_url: 'Base URL is required.' }
+		);
+
+		expect(result.formErrors).toEqual({
+			base_url: 'Base URL is required.',
+			name: 'Name already exists.'
+		});
+		expect(result.saveStatus).toBe('idle');
+		expect(result.saveError).toBe('');
+	});
+
+	it('returns banner error state when no field errors are present', () => {
+		const result = mapClassifiedSaveErrorToUiState(
+			{
+				fieldErrors: {},
+				bannerMessage: 'Request failed.'
+			},
+			{ base_url: 'Existing field error' }
+		);
+
+		expect(result.formErrors).toEqual({ base_url: 'Existing field error' });
+		expect(result.saveStatus).toBe('error');
+		expect(result.saveError).toBe('Request failed.');
+	});
+
+	it('uses fallback message when banner message is empty', () => {
+		const result = mapClassifiedSaveErrorToUiState(
+			{
+				fieldErrors: {},
+				bannerMessage: ''
+			},
+			{}
+		);
+
+		expect(result.formErrors).toEqual({});
+		expect(result.saveStatus).toBe('error');
+		expect(result.saveError).toBe('Save failed.');
 	});
 });

--- a/web/src/lib/settingsValidation.ts
+++ b/web/src/lib/settingsValidation.ts
@@ -11,6 +11,12 @@ export interface ClassifiedFormError {
 	bannerMessage: string;
 }
 
+export interface ClassifiedSaveUiState {
+	formErrors: Record<string, string>;
+	saveStatus: 'idle' | 'error';
+	saveError: string;
+}
+
 function getBodyMessage(body: unknown): string {
 	if (typeof body === 'object' && body !== null && 'error' in body) {
 		return String((body as { error?: unknown }).error ?? '');
@@ -61,5 +67,25 @@ export function classifyFormError(error: unknown, rules: FieldValidationRule[]):
 	return {
 		fieldErrors,
 		bannerMessage: error instanceof Error ? error.message : 'Save failed.'
+	};
+}
+
+export function mapClassifiedSaveErrorToUiState(
+	classified: ClassifiedFormError,
+	currentFormErrors: Record<string, string>,
+	fallbackMessage = 'Save failed.'
+): ClassifiedSaveUiState {
+	if (Object.keys(classified.fieldErrors).length > 0) {
+		return {
+			formErrors: { ...currentFormErrors, ...classified.fieldErrors },
+			saveStatus: 'idle',
+			saveError: ''
+		};
+	}
+
+	return {
+		formErrors: currentFormErrors,
+		saveStatus: 'error',
+		saveError: classified.bannerMessage || fallbackMessage
 	};
 }

--- a/web/src/routes/(app)/settings/download-clients/+page.svelte
+++ b/web/src/routes/(app)/settings/download-clients/+page.svelte
@@ -19,7 +19,7 @@
 		ApiError
 	} from '$lib/api';
 	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
-	import { classifyFormError } from '$lib/settingsValidation';
+	import { classifyFormError, mapClassifiedSaveErrorToUiState } from '$lib/settingsValidation';
 	import type {
 		DownloadClient,
 		CreateDownloadClientRequest,
@@ -250,14 +250,10 @@
 				},
 				{ field: 'client_type', messages: ['unsupported client_type'] }
 			]);
-			if (Object.keys(classified.fieldErrors).length > 0) {
-				formErrors = { ...formErrors, ...classified.fieldErrors };
-				saveStatus = 'idle';
-				saveError = '';
-			} else {
-				saveError = classified.bannerMessage || 'Save failed.';
-				saveStatus = 'error';
-			}
+			const uiState = mapClassifiedSaveErrorToUiState(classified, formErrors);
+			formErrors = uiState.formErrors;
+			saveStatus = uiState.saveStatus;
+			saveError = uiState.saveError;
 		} finally {
 			formSaving = false;
 		}


### PR DESCRIPTION
## Summary
- extract shared helper to map classified form errors into settings UI save state
- apply helper in the download clients settings page to remove duplicated catch-branch logic
- add unit tests for merged field-error and banner-error behaviors

## Testing
- npm run test -- src/lib/settingsValidation.test.ts
- npm run check

Closes #483