### PR TITLE
refactor(web): apply shared save-error workflow to metadata profiles

### DIFF
--- a/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
+++ b/web/src/routes/(app)/settings/metadata-profiles/+page.svelte
@@ -19,7 +19,7 @@
 		ApiError
 	} from '$lib/api';
 	import { useUnsavedGuard } from '$lib/stores/unsavedGuard';
-	import { classifyFormError } from '$lib/settingsValidation';
+	import { classifyFormError, mapClassifiedSaveErrorToUiState } from '$lib/settingsValidation';
 	import type {
 		MetadataProfile,
 		CreateMetadataProfileRequest,
@@ -382,14 +382,10 @@
 			const classified = classifyFormError(err, [
 				{ field: 'name', messages: ['name cannot be empty', 'already exists'] }
 			]);
-			if (Object.keys(classified.fieldErrors).length > 0) {
-				formErrors = { ...formErrors, ...classified.fieldErrors };
-				saveStatus = 'idle';
-				saveError = '';
-			} else {
-				saveError = classified.bannerMessage || 'Save failed.';
-				saveStatus = 'error';
-			}
+			const uiState = mapClassifiedSaveErrorToUiState(classified, formErrors);
+			formErrors = uiState.formErrors;
+			saveStatus = uiState.saveStatus;
+			saveError = uiState.saveError;
 		} finally {
 			formSaving = false;
 		}


### PR DESCRIPTION
## Summary
- use mapClassifiedSaveErrorToUiState in metadata profiles save flow
- remove duplicated catch-branch form-error/banner-error state handling
- keep behavior unchanged while reducing repeated settings page logic

## Testing
- npm run test -- src/lib/settingsValidation.test.ts
- npm run check

Related to #483