### PR TITLE
docs: add settings validation playbook and troubleshooting guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ All three must pass cleanly. The `frontend-ci.yml` workflow enforces them on Ubu
 
 ### Settings validation workflow
 
-When working on settings features (Quality Profiles, Metadata Profiles, Download Clients, Indexers), follow the [Settings Validation Playbook](../README.md#settings-validation-playbook) to verify:
+When working on settings features (Quality Profiles, Metadata Profiles, Download Clients, Indexers), follow the [Settings Validation Playbook](README.md#settings-validation-playbook) to verify:
 - API endpoint behavior (create, update, delete, bulk, import/export)
 - Frontend form handling and error classification
 - E2E workflows in both dev and preview modes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,15 @@ bun run build
 
 All three must pass cleanly. The `frontend-ci.yml` workflow enforces them on Ubuntu and Windows for every pull request that modifies files under `web/`.
 
+### Settings validation workflow
+
+When working on settings features (Quality Profiles, Metadata Profiles, Download Clients, Indexers), follow the [Settings Validation Playbook](../README.md#settings-validation-playbook) to verify:
+- API endpoint behavior (create, update, delete, bulk, import/export)
+- Frontend form handling and error classification
+- E2E workflows in both dev and preview modes
+
+This ensures settings changes work end-to-end before merging.
+
 ### Adding tests
 
 Tests live next to the source they cover, named `*.test.ts`:

--- a/README.md
+++ b/README.md
@@ -317,20 +317,20 @@ curl -X GET http://localhost:5150/api/v1/settings/quality-profiles/export \
   -H "X-Api-Key: $API_KEY" > profiles.json
 
 # 4. Test import (dry-run)
-curl -X POST http://localhost:5150/api/v1/settings/quality-profiles/import \
+curl -X POST 'http://localhost:5150/api/v1/settings/quality-profiles/import?dry_run=true' \
   -H "X-Api-Key: $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "version": "1",
     "conflict_policy": "merge",
-    "items": [{"name": "High Quality", "allowed_qualities": ["FLAC"]}]
-  }?dry_run=true'
+    "items": [{"name": "High Quality", "allowed_qualities": ["FLAC"], "upgrade_allowed": false}]
+  }'
 
-# 5. Apply import (dry_run=false)
+# 5. Apply import
 curl -X POST http://localhost:5150/api/v1/settings/quality-profiles/import \
   -H "X-Api-Key: $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{...}?dry_run=false'
+  -d '{...}'
 ```
 
 ### Frontend Settings Validation (Web UI)
@@ -373,14 +373,14 @@ bun run dev
 
 #### E2E test failures / build issues
 
-- **Frontend build fails**: Ensure `cd web && bun run build` completes without errors. Check Node version (`bun --version`).
+- **Frontend build fails**: Ensure `cd web && bun run build` completes without errors. Check Bun version (`bun --version`).
 - **HMR not working in dev**: Clear browser cache, restart `bun run dev`, check `VITE_CHORROSION_API_BASE` is set correctly.
 - **API requests fail with 401**: Ensure `X-Api-Key` header is present and valid (see [Bootstrap flow](#bootstrap-flow-first-time-setup)).
 
 #### Settings import/export issues
 
 - **Import preview shows no results**: Verify import JSON has `version: "1"` and `items` array is not empty.
-- **Import conflict policy not working**: Ensure item names match existing resources exactly (case-sensitive).
+- **Import conflict policy not working**: Ensure item names match existing resources (matching is case-insensitive).
 - **Export downloads blank file**: Check API returned 200 and response has `version`, `exported_at`, and `items` fields.
 
 #### Common prerequisites issues

--- a/README.md
+++ b/README.md
@@ -280,6 +280,117 @@ Example import/export envelope:
 }
 ```
 
+## Settings Validation Playbook
+
+This guide provides a one-pass command sequence to validate settings endpoints and import/export workflows locally.
+
+### Prerequisites
+
+- Backend running with default config: `cargo run -p chorrosion-cli`
+- Frontend dev server running: `cd web && bun run dev`
+- API key created: see [Bootstrap flow](#bootstrap-flow-first-time-setup) above
+- Curl or similar CLI tool (or use Swagger UI at `/docs` for interactive testing)
+
+### Backend Settings Validation (API)
+
+```bash
+# Set your API key from bootstrap
+API_KEY="ck_..."
+
+# 1. Create a quality profile
+curl -X POST http://localhost:5150/api/v1/settings/quality-profiles \
+  -H "X-Api-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Lossless",
+    "allowed_qualities": ["FLAC", "MP3 320"],
+    "upgrade_allowed": false,
+    "cutoff_quality": "FLAC"
+  }'
+
+# 2. List quality profiles
+curl -X GET http://localhost:5150/api/v1/settings/quality-profiles \
+  -H "X-Api-Key: $API_KEY"
+
+# 3. Export quality profiles
+curl -X GET http://localhost:5150/api/v1/settings/quality-profiles/export \
+  -H "X-Api-Key: $API_KEY" > profiles.json
+
+# 4. Test import (dry-run)
+curl -X POST http://localhost:5150/api/v1/settings/quality-profiles/import \
+  -H "X-Api-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "version": "1",
+    "conflict_policy": "merge",
+    "items": [{"name": "High Quality", "allowed_qualities": ["FLAC"]}]
+  }?dry_run=true'
+
+# 5. Apply import (dry_run=false)
+curl -X POST http://localhost:5150/api/v1/settings/quality-profiles/import \
+  -H "X-Api-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{...}?dry_run=false'
+```
+
+### Frontend Settings Validation (Web UI)
+
+```bash
+cd web
+
+# 1. Type-check all Svelte components and TS
+bun run check
+
+# 2. Run unit tests (includes settings validation tests)
+bun run test
+
+# 3. Start dev server (HMR enabled)
+bun run dev
+# Visit http://127.0.0.1:5173/settings to access settings pages
+```
+
+### End-to-End Settings Workflow
+
+1. **Backend + Frontend running**
+   - Backend: `cargo run -p chorrosion-cli`
+   - Frontend dev: `cd web && bun run dev`
+
+2. **In browser: Create settings**
+   - Visit <http://127.0.0.1:5173/settings/quality-profiles>
+   - Click "Add", fill form, save
+
+3. **In browser: Export**
+   - Visit settings page, click "Export"
+   - Browser downloads `quality-profiles.export.json`
+
+4. **In browser: Import with preview**
+   - Click "Import"
+   - Select the exported JSON file
+   - Dialog shows dry-run preview
+   - Click "Apply" to commit
+
+### Troubleshooting
+
+#### E2E test failures / build issues
+
+- **Frontend build fails**: Ensure `cd web && bun run build` completes without errors. Check Node version (`bun --version`).
+- **HMR not working in dev**: Clear browser cache, restart `bun run dev`, check `VITE_CHORROSION_API_BASE` is set correctly.
+- **API requests fail with 401**: Ensure `X-Api-Key` header is present and valid (see [Bootstrap flow](#bootstrap-flow-first-time-setup)).
+
+#### Settings import/export issues
+
+- **Import preview shows no results**: Verify import JSON has `version: "1"` and `items` array is not empty.
+- **Import conflict policy not working**: Ensure item names match existing resources exactly (case-sensitive).
+- **Export downloads blank file**: Check API returned 200 and response has `version`, `exported_at`, and `items` fields.
+
+#### Common prerequisites issues
+
+- **Database file not created**: Ensure `CHORROSION_DATABASE__URL` directory exists and is writable. Default: `sqlite://data/chorrosion.db` creates `./data/` automatically.
+- **Migrations fail on startup**: Check migrations in `./migrations/` are readable. Run `cargo build` to ensure compilation succeeds.
+- **Frontend can't connect to backend**: Verify backend is running on `127.0.0.1:5150` and `CHORROSION_WEB__ALLOWED_ORIGINS` includes frontend dev URL (default: `http://127.0.0.1:5173`).
+
+For additional setup help, see [EXTERNAL_DEPENDENCIES.md](EXTERNAL_DEPENDENCIES.md) for system library requirements (Chromaprint, FFmpeg).
+
 ## Testing with the Mock Server
 
 Integration tests for the `chorrosion-metadata` crate require a mock server running on `127.0.0.1:3030` **before** running tests. The test suite does not start or stop the server automatically.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -514,6 +514,14 @@ _(See design: [Embedded Tags Behavior](DESIGN.md#embedded-tags-behavior))_
 - [x] Test coverage expansion for settings UX (Issue #466) ✓
 - [x] Operator docs + final QA + ROADMAP update for Settings Wave 1 (Issue #467) ✓
 
+**Settings Validation & Troubleshooting:** See [Settings Validation Playbook](README.md#settings-validation-playbook) in README for end-to-end workflows, import/export validation, and troubleshooting guidance.
+
+### 12.6 Post-Wave-1 Cleanup & Tech Debt (Issue #480)
+
+- [x] E2E hardening & modular API mocks (Issue #481, PR #511) ✓
+- [x] Settings UI tech debt: shared form workflows (Issue #483, PRs #512-#515) ✓
+- [x] Operator docs polish: troubleshooting & playbook (Issue #482, PR #516) ✓
+
 ---
 
 ## Success Metrics


### PR DESCRIPTION
Closes #482

## Summary

Adds comprehensive Settings Validation Playbook to README with step-by-step commands for local validation, troubleshooting guidance, and E2E workflow documentation. Updates ROADMAP to cross-link playbook and track post-Wave-1 cleanup completion. Adds settings validation workflow reference to CONTRIBUTING.md for developers.

## Changes

### README.md
- **New Section:** Settings Validation Playbook after Settings UI Workflows section
  - Prerequisites checklist
  - Backend API validation command sequence (curl examples for quality profiles CRUD, export, import with dry-run)
  - Frontend validation (type-check, tests, dev server startup)
  - E2E settings workflow walkthrough (create → export → import with preview → apply)
  - Troubleshooting subsection covering:
    - E2E test failures (build issues, HMR, API auth)
    - Import/export issues (missing version, conflict policy, export blanks)
    - Prerequisite issues (database path, migrations, CORS)

### ROADMAP.md
- Added cross-reference from Settings Wave 1 completion to Settings Validation Playbook in README
- Added new Section 12.6 Post-Wave-1 Cleanup tracking completed issues #481-#483

### CONTRIBUTING.md
- Added "Settings validation workflow" subsection under Frontend Development
- Points developers to Settings Validation Playbook for verifying settings features before merging

## Validation

Locally tested:
- [ ] README builds and renders correctly
- [ ] All markdown links resolve
- [ ] ROADMAP structure preserved
- [ ] CONTRIBUTING.md formatting consistent

## Related
- Completes Wave-1 cleanup work: #480 ✓, #481 ✓, #483 ✓
- Issue #482: Operator docs + troubleshooting
