### PR TITLE
Fix duplicate categories in extract_supported_categories and strengthen capability-detection test

### DIFF
--- a/crates/chorrosion-api/src/handlers/download_clients.rs
+++ b/crates/chorrosion-api/src/handlers/download_clients.rs
@@ -1402,13 +1402,11 @@ mod tests {
         let error: serde_json::Value =
             serde_json::from_slice(&body).expect("deserialize import error");
         assert_eq!(error["error"], "invalid import payload");
-        assert!(
-            error["details"]
-                .as_array()
-                .expect("details array")
-                .iter()
-                .any(|detail| detail == "items[0].client_type is not supported")
-        );
+        assert!(error["details"]
+            .as_array()
+            .expect("details array")
+            .iter()
+            .any(|detail| detail == "items[0].client_type is not supported"));
     }
 
     #[tokio::test]
@@ -1442,13 +1440,11 @@ mod tests {
         let error: serde_json::Value =
             serde_json::from_slice(&body).expect("deserialize import error");
         assert_eq!(error["error"], "invalid import payload");
-        assert!(
-            error["details"]
-                .as_array()
-                .expect("details array")
-                .iter()
-                .any(|detail| detail == "items[0].name cannot be empty")
-        );
+        assert!(error["details"]
+            .as_array()
+            .expect("details array")
+            .iter()
+            .any(|detail| detail == "items[0].name cannot be empty"));
     }
 
     #[tokio::test]
@@ -1482,13 +1478,11 @@ mod tests {
         let error: serde_json::Value =
             serde_json::from_slice(&body).expect("deserialize import error");
         assert_eq!(error["error"], "invalid import payload");
-        assert!(
-            error["details"]
-                .as_array()
-                .expect("details array")
-                .iter()
-                .any(|detail| detail == "items[0].base_url is invalid")
-        );
+        assert!(error["details"]
+            .as_array()
+            .expect("details array")
+            .iter()
+            .any(|detail| detail == "items[0].base_url is invalid"));
     }
 
     #[tokio::test]

--- a/crates/chorrosion-api/src/handlers/indexers.rs
+++ b/crates/chorrosion-api/src/handlers/indexers.rs
@@ -913,7 +913,11 @@ pub async fn import_indexers(
             existing_item.protocol = protocol.as_str().to_string();
             existing_item.api_key = item.api_key.as_ref().and_then(|key| {
                 let trimmed = key.trim();
-                if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
             });
             existing_item.enabled = item.enabled;
             existing_item.updated_at = Utc::now();
@@ -939,7 +943,11 @@ pub async fn import_indexers(
                 IndexerDefinition::new(item.name.trim(), item.base_url.trim(), protocol.as_str());
             new_item.api_key = item.api_key.as_ref().and_then(|key| {
                 let trimmed = key.trim();
-                if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
             });
             new_item.enabled = item.enabled;
 
@@ -1254,13 +1262,11 @@ mod tests {
         let error: serde_json::Value =
             serde_json::from_slice(&body).expect("deserialize import error");
         assert_eq!(error["error"], "invalid import payload");
-        assert!(
-            error["details"]
-                .as_array()
-                .expect("details array")
-                .iter()
-                .any(|detail| detail == "items[0].protocol is invalid")
-        );
+        assert!(error["details"]
+            .as_array()
+            .expect("details array")
+            .iter()
+            .any(|detail| detail == "items[0].protocol is invalid"));
     }
 
     #[tokio::test]
@@ -1292,13 +1298,11 @@ mod tests {
         let error: serde_json::Value =
             serde_json::from_slice(&body).expect("deserialize import error");
         assert_eq!(error["error"], "invalid import payload");
-        assert!(
-            error["details"]
-                .as_array()
-                .expect("details array")
-                .iter()
-                .any(|detail| detail == "items[0].name cannot be empty")
-        );
+        assert!(error["details"]
+            .as_array()
+            .expect("details array")
+            .iter()
+            .any(|detail| detail == "items[0].name cannot be empty"));
     }
 
     #[tokio::test]
@@ -1330,13 +1334,11 @@ mod tests {
         let error: serde_json::Value =
             serde_json::from_slice(&body).expect("deserialize import error");
         assert_eq!(error["error"], "invalid import payload");
-        assert!(
-            error["details"]
-                .as_array()
-                .expect("details array")
-                .iter()
-                .any(|detail| detail == "items[0].base_url is invalid")
-        );
+        assert!(error["details"]
+            .as_array()
+            .expect("details array")
+            .iter()
+            .any(|detail| detail == "items[0].base_url is invalid"));
     }
 
     #[tokio::test]

--- a/crates/chorrosion-api/src/handlers/tags.rs
+++ b/crates/chorrosion-api/src/handlers/tags.rs
@@ -574,7 +574,10 @@ mod tests {
 
     #[test]
     fn parse_entity_type_accepts_case_insensitive_values() {
-        assert!(matches!(parse_entity_type("artist"), Ok(EntityType::Artist)));
+        assert!(matches!(
+            parse_entity_type("artist"),
+            Ok(EntityType::Artist)
+        ));
         assert!(matches!(parse_entity_type("ALBUM"), Ok(EntityType::Album)));
     }
 

--- a/crates/chorrosion-api/src/middleware/auth.rs
+++ b/crates/chorrosion-api/src/middleware/auth.rs
@@ -405,12 +405,18 @@ mod tests {
 
     #[test]
     fn path_matches_accepts_prefixed_and_unprefixed_routes() {
-        assert!(super::path_matches("/auth/forms/logout", "/auth/forms/logout"));
+        assert!(super::path_matches(
+            "/auth/forms/logout",
+            "/auth/forms/logout"
+        ));
         assert!(super::path_matches(
             "/api/v1/auth/forms/logout",
             "/auth/forms/logout"
         ));
-        assert!(!super::path_matches("/api/v1/auth/forms/login", "/auth/forms/logout"));
+        assert!(!super::path_matches(
+            "/api/v1/auth/forms/login",
+            "/auth/forms/logout"
+        ));
     }
 
     #[test]

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -1048,7 +1048,7 @@ mod tests {
     use super::{
         extract_supported_categories, map_category_to_indexer, parse_rss_feed,
         parse_search_results, GazelleClient, IndexerClient, IndexerConfig, IndexerProtocol,
-        IndexerSearchQuery, NewznabClient, TorznabClient,
+        IndexerSearchQuery, NewznabClient, TorznabClient, DEFAULT_MUSIC_CATEGORIES,
     };
     use wiremock::matchers::{header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1671,7 +1671,7 @@ mod tests {
 
         // Should return sensible defaults even when no category info is present
         let categories = extract_supported_categories(sparse_xml);
-        assert!(categories.len() >= 3);
+        assert!(categories.len() >= DEFAULT_MUSIC_CATEGORIES.len());
         assert!(categories.contains(&"music".to_string()));
         assert!(categories.contains(&"audio/flac".to_string()));
         assert!(categories.contains(&"audio/mp3".to_string()));

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -1671,7 +1671,7 @@ mod tests {
 
         // Should return sensible defaults even when no category info is present
         let categories = extract_supported_categories(sparse_xml);
-        assert!(categories.len() >= DEFAULT_MUSIC_CATEGORIES.len());
+        assert_eq!(categories.len(), DEFAULT_MUSIC_CATEGORIES.len());
         assert!(categories.contains(&"music".to_string()));
         assert!(categories.contains(&"audio/flac".to_string()));
         assert!(categories.contains(&"audio/mp3".to_string()));
@@ -1721,7 +1721,7 @@ mod tests {
         "#;
 
         let categories = extract_supported_categories(xml_no_cats);
-        assert_eq!(categories.len(), 3);
+        assert_eq!(categories.len(), DEFAULT_MUSIC_CATEGORIES.len());
         assert!(categories.contains(&"music".to_string()));
         assert!(categories.contains(&"audio/flac".to_string()));
         assert!(categories.contains(&"audio/mp3".to_string()));

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -490,7 +490,10 @@ fn extract_supported_categories(xml: &str) -> Vec<String> {
             || xml_lower.contains(&format!("id='{}'", id))
             || xml_lower.contains(&format!(">{}<", id))
         {
-            categories.push(name.to_string());
+            let name_str = name.to_string();
+            if !categories.contains(&name_str) {
+                categories.push(name_str);
+            }
         }
     }
 
@@ -1649,10 +1652,12 @@ mod tests {
         </caps>
         "#;
 
-        // This should not panic and should return reasonable defaults
-        let xml_lower = sparse_xml.to_lowercase();
-        assert!(xml_lower.contains("<server"));
-        assert!(xml_lower.contains("<caps"));
+        // Should return sensible defaults even when no category info is present
+        let categories = extract_supported_categories(sparse_xml);
+        assert_eq!(categories.len(), 3);
+        assert!(categories.contains(&"music".to_string()));
+        assert!(categories.contains(&"audio/flac".to_string()));
+        assert!(categories.contains(&"audio/mp3".to_string()));
     }
 
     #[test]

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -455,11 +455,10 @@ async fn detect_capabilities(
     let supported_categories = if supports_categories {
         extract_supported_categories(&xml)
     } else {
-        vec![
-            "music".to_string(),
-            "audio/flac".to_string(),
-            "audio/mp3".to_string(),
-        ]
+        DEFAULT_MUSIC_CATEGORIES
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
     };
 
     Ok(IndexerCapabilities {
@@ -470,6 +469,8 @@ async fn detect_capabilities(
         supported_categories,
     })
 }
+
+const DEFAULT_MUSIC_CATEGORIES: &[&str] = &["music", "audio/flac", "audio/mp3"];
 
 fn extract_supported_categories(xml: &str) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
@@ -491,36 +492,36 @@ fn extract_supported_categories(xml: &str) -> Vec<String> {
         let attr_single = format!("id='{}'", id);
         let text_node = format!(">{}<", id);
         // Look for explicit category ID definitions
-        if xml_lower.contains(&attr_double)
+        if (xml_lower.contains(&attr_double)
             || xml_lower.contains(&attr_single)
-            || xml_lower.contains(&text_node)
+            || xml_lower.contains(&text_node))
+            && seen.insert(*name)
         {
-            if seen.insert(*name) {
-                categories.push(name.to_string());
-            }
+            categories.push(name.to_string());
         }
     }
 
     // Also check for text-based category names as fallback
     if categories.is_empty() {
-        if xml_lower.contains("music") {
+        if xml_lower.contains("music") && seen.insert("music") {
             categories.push("music".to_string());
         }
-        if xml_lower.contains("flac") || xml_lower.contains("lossless") {
+        if (xml_lower.contains("flac") || xml_lower.contains("lossless"))
+            && seen.insert("audio/flac")
+        {
             categories.push("audio/flac".to_string());
         }
-        if xml_lower.contains("mp3") {
+        if xml_lower.contains("mp3") && seen.insert("audio/mp3") {
             categories.push("audio/mp3".to_string());
         }
     }
 
     // Ensure we always have at least the defaults for music indexers
     if categories.is_empty() {
-        categories = vec![
-            "music".to_string(),
-            "audio/flac".to_string(),
-            "audio/mp3".to_string(),
-        ];
+        categories = DEFAULT_MUSIC_CATEGORIES
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
     }
 
     categories

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -472,6 +472,13 @@ async fn detect_capabilities(
 
 const DEFAULT_MUSIC_CATEGORIES: &[&str] = &["music", "audio/flac", "audio/mp3"];
 
+// Text keywords that identify each default category when no numeric IDs are present
+const DEFAULT_CATEGORY_KEYWORDS: &[&[&str]] = &[
+    &["music"],
+    &["flac", "lossless"],
+    &["mp3"],
+];
+
 fn extract_supported_categories(xml: &str) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     let mut categories = Vec::new();
@@ -486,15 +493,23 @@ fn extract_supported_categories(xml: &str) -> Vec<String> {
         ("5070", "audio/flac"), // Alternative ID range
     ];
 
-    for (id, name) in &music_patterns {
-        // Pre-compute the three search strings once per pattern
-        let attr_double = format!("id=\"{}\"", id);
-        let attr_single = format!("id='{}'", id);
-        let text_node = format!(">{}<", id);
-        // Look for explicit category ID definitions
-        if (xml_lower.contains(&attr_double)
-            || xml_lower.contains(&attr_single)
-            || xml_lower.contains(&text_node))
+    // Pre-compute all search strings before iterating
+    let id_patterns: Vec<_> = music_patterns
+        .iter()
+        .map(|(id, name)| {
+            (
+                format!("id=\"{}\"", id),
+                format!("id='{}'", id),
+                format!(">{}<", id),
+                *name,
+            )
+        })
+        .collect();
+
+    for (attr_double, attr_single, text_node, name) in &id_patterns {
+        if (xml_lower.contains(attr_double)
+            || xml_lower.contains(attr_single)
+            || xml_lower.contains(text_node))
             && seen.insert(*name)
         {
             categories.push(name.to_string());
@@ -503,16 +518,13 @@ fn extract_supported_categories(xml: &str) -> Vec<String> {
 
     // Also check for text-based category names as fallback
     if categories.is_empty() {
-        if xml_lower.contains("music") && seen.insert("music") {
-            categories.push("music".to_string());
-        }
-        if (xml_lower.contains("flac") || xml_lower.contains("lossless"))
-            && seen.insert("audio/flac")
+        for (category, keywords) in DEFAULT_MUSIC_CATEGORIES
+            .iter()
+            .zip(DEFAULT_CATEGORY_KEYWORDS.iter())
         {
-            categories.push("audio/flac".to_string());
-        }
-        if xml_lower.contains("mp3") && seen.insert("audio/mp3") {
-            categories.push("audio/mp3".to_string());
+            if keywords.iter().any(|kw| xml_lower.contains(*kw)) && seen.insert(*category) {
+                categories.push(category.to_string());
+            }
         }
     }
 
@@ -1659,7 +1671,7 @@ mod tests {
 
         // Should return sensible defaults even when no category info is present
         let categories = extract_supported_categories(sparse_xml);
-        assert_eq!(categories.len(), 3);
+        assert!(categories.len() >= 3);
         assert!(categories.contains(&"music".to_string()));
         assert!(categories.contains(&"audio/flac".to_string()));
         assert!(categories.contains(&"audio/mp3".to_string()));

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -472,6 +472,7 @@ async fn detect_capabilities(
 }
 
 fn extract_supported_categories(xml: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
     let mut categories = Vec::new();
     let xml_lower = xml.to_lowercase();
 
@@ -485,14 +486,17 @@ fn extract_supported_categories(xml: &str) -> Vec<String> {
     ];
 
     for (id, name) in &music_patterns {
+        // Pre-compute the three search strings once per pattern
+        let attr_double = format!("id=\"{}\"", id);
+        let attr_single = format!("id='{}'", id);
+        let text_node = format!(">{}<", id);
         // Look for explicit category ID definitions
-        if xml_lower.contains(&format!("id=\"{}\"", id))
-            || xml_lower.contains(&format!("id='{}'", id))
-            || xml_lower.contains(&format!(">{}<", id))
+        if xml_lower.contains(&attr_double)
+            || xml_lower.contains(&attr_single)
+            || xml_lower.contains(&text_node)
         {
-            let name_str = name.to_string();
-            if !categories.contains(&name_str) {
-                categories.push(name_str);
+            if seen.insert(*name) {
+                categories.push(name.to_string());
             }
         }
     }

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -481,6 +481,7 @@ const DEFAULT_CATEGORY_KEYWORDS: &[&[&str]] = &[
 
 // Music-related category ID patterns with their pre-computed search strings.
 // Computed once at startup to avoid repeated allocations on every call.
+// Requires Rust 1.80+ (std::sync::LazyLock stabilised in 1.80).
 static ID_SEARCH_PATTERNS: std::sync::LazyLock<Vec<(String, String, String, &'static str)>> =
     std::sync::LazyLock::new(|| {
         [
@@ -517,15 +518,15 @@ fn extract_supported_categories(xml: &str) -> Vec<String> {
         }
     }
 
-    // Also check for text-based category names as fallback
-    if categories.is_empty() {
-        for (category, keywords) in DEFAULT_MUSIC_CATEGORIES
-            .iter()
-            .zip(DEFAULT_CATEGORY_KEYWORDS.iter())
-        {
-            if keywords.iter().any(|kw| xml_lower.contains(*kw)) && seen.insert(*category) {
-                categories.push(category.to_string());
-            }
+    // Also check for text-based category names; runs alongside ID detection so
+    // that categories signalled only by keyword (and not by a numeric ID) are
+    // still picked up.  The HashSet guards against duplicates.
+    for (category, keywords) in DEFAULT_MUSIC_CATEGORIES
+        .iter()
+        .zip(DEFAULT_CATEGORY_KEYWORDS.iter())
+    {
+        if keywords.iter().any(|kw| xml_lower.contains(*kw)) && seen.insert(*category) {
+            categories.push(category.to_string());
         }
     }
 
@@ -1716,6 +1717,32 @@ mod tests {
         "#;
 
         let categories = extract_supported_categories(xml_alt_id);
+        assert!(categories.contains(&"music".to_string()));
+        assert!(categories.contains(&"audio/flac".to_string()));
+    }
+
+    #[test]
+    fn extract_categories_no_duplicates_with_mixed_id_and_text() {
+        // XML with both numeric category IDs and text-based keywords; deduplication
+        // must prevent the same logical category from appearing more than once even
+        // when both detection paths match it.
+        let xml_mixed = r#"<?xml version="1.0"?>
+        <caps>
+            <categories>
+                <category id="3000" name="Music" />
+                <category id="3040" name="Music/Lossless" />
+                <category id="3020" name="Music/FLAC" />
+            </categories>
+        </caps>
+        "#;
+
+        let categories = extract_supported_categories(xml_mixed);
+        let unique: std::collections::HashSet<_> = categories.iter().collect();
+        assert_eq!(
+            categories.len(),
+            unique.len(),
+            "Categories should not contain duplicates"
+        );
         assert!(categories.contains(&"music".to_string()));
         assert!(categories.contains(&"audio/flac".to_string()));
     }

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -488,7 +488,7 @@ fn extract_supported_categories(xml: &str) -> Vec<String> {
     let music_patterns = [
         ("3000", "music"),
         ("3010", "audio/mp3"),
-        ("3020", "audio/flac"), // Some providers use 3020 instead of 3040
+        ("3020", "audio/flac"), // Some providers use 3020 as an alternative FLAC ID alongside 3040
         ("3040", "audio/flac"),
         ("5070", "audio/flac"), // Alternative ID range
     ];
@@ -1661,7 +1661,7 @@ mod tests {
     }
 
     #[test]
-    fn newznab_capability_detection_with_sparse_caps() {
+    fn extract_categories_with_sparse_caps() {
         // Test that capability detection works with minimal caps element
         let sparse_xml = r#"<?xml version="1.0"?>
         <caps>
@@ -1669,9 +1669,11 @@ mod tests {
         </caps>
         "#;
 
-        // Should return sensible defaults even when no category info is present
+        // Should return sensible defaults even when no category info is present,
+        // with no duplicate entries.
         let categories = extract_supported_categories(sparse_xml);
-        assert_eq!(categories.len(), DEFAULT_MUSIC_CATEGORIES.len());
+        let unique: std::collections::HashSet<_> = categories.iter().collect();
+        assert_eq!(unique.len(), DEFAULT_MUSIC_CATEGORIES.len());
         assert!(categories.contains(&"music".to_string()));
         assert!(categories.contains(&"audio/flac".to_string()));
         assert!(categories.contains(&"audio/mp3".to_string()));

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -479,22 +479,17 @@ const DEFAULT_CATEGORY_KEYWORDS: &[&[&str]] = &[
     &["mp3"],
 ];
 
-fn extract_supported_categories(xml: &str) -> Vec<String> {
-    let mut seen = std::collections::HashSet::new();
-    let mut categories = Vec::new();
-    let xml_lower = xml.to_lowercase();
-
-    // Look for music-related category IDs in common ranges and explicit names
-    let music_patterns = [
-        ("3000", "music"),
-        ("3010", "audio/mp3"),
-        ("3020", "audio/flac"), // Some providers use 3020 as an alternative FLAC ID alongside 3040
-        ("3040", "audio/flac"),
-        ("5070", "audio/flac"), // Alternative ID range
-    ];
-
-    // Pre-compute all search strings before iterating
-    let id_patterns: Vec<_> = music_patterns
+// Music-related category ID patterns with their pre-computed search strings.
+// Computed once at startup to avoid repeated allocations on every call.
+static ID_SEARCH_PATTERNS: std::sync::LazyLock<Vec<(String, String, String, &'static str)>> =
+    std::sync::LazyLock::new(|| {
+        [
+            ("3000", "music"),
+            ("3010", "audio/mp3"),
+            ("3020", "audio/flac"), // Some providers use 3020 as an alternative FLAC ID alongside 3040
+            ("3040", "audio/flac"),
+            ("5070", "audio/flac"), // Alternative ID range
+        ]
         .iter()
         .map(|(id, name)| {
             (
@@ -504,9 +499,15 @@ fn extract_supported_categories(xml: &str) -> Vec<String> {
                 *name,
             )
         })
-        .collect();
+        .collect()
+    });
 
-    for (attr_double, attr_single, text_node, name) in &id_patterns {
+fn extract_supported_categories(xml: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut categories = Vec::new();
+    let xml_lower = xml.to_lowercase();
+
+    for (attr_double, attr_single, text_node, name) in ID_SEARCH_PATTERNS.iter() {
         if (xml_lower.contains(attr_double)
             || xml_lower.contains(attr_single)
             || xml_lower.contains(text_node))
@@ -1673,6 +1674,11 @@ mod tests {
         // with no duplicate entries.
         let categories = extract_supported_categories(sparse_xml);
         let unique: std::collections::HashSet<_> = categories.iter().collect();
+        assert_eq!(
+            categories.len(),
+            unique.len(),
+            "Categories should not contain duplicates"
+        );
         assert_eq!(unique.len(), DEFAULT_MUSIC_CATEGORIES.len());
         assert!(categories.contains(&"music".to_string()));
         assert!(categories.contains(&"audio/flac".to_string()));

--- a/crates/chorrosion-application/src/indexers.rs
+++ b/crates/chorrosion-application/src/indexers.rs
@@ -433,27 +433,34 @@ async fn detect_capabilities(
     config: &IndexerConfig,
 ) -> Result<IndexerCapabilities, IndexerError> {
     let xml = execute_api_request(client, config, "caps", None).await?;
-    let supports_search = xml.contains("search") || xml.contains("<searching>");
+    let xml_lower = xml.to_lowercase();
+
+    // Detect search support: look for search-related tags or explicit boolean
+    let supports_search = xml_lower.contains("<search")
+        || xml_lower.contains("<searching>")
+        || xml_lower.contains("supports_search=\"yes\"")
+        || xml_lower.contains("supportedparams=\"q\"");
+
     let supports_rss = true;
-    let supports_capabilities_detection = xml.contains("<caps") || xml.contains("<categories");
-    let supports_categories = xml.contains("<category");
 
-    let mut supported_categories = Vec::new();
-    if supports_categories {
-        for token in ["music", "audio/flac", "audio/mp3"] {
-            if xml.to_lowercase().contains(token) {
-                supported_categories.push(token.to_string());
-            }
-        }
-    }
+    // Detect capability detection support via presence of caps container
+    let supports_capabilities_detection = xml_lower.contains("<caps")
+        || xml_lower.contains("<categories")
+        || xml_lower.contains("<server");
 
-    if supported_categories.is_empty() {
-        supported_categories = vec![
+    // Detect category support: look for actual category definitions
+    let supports_categories = xml_lower.contains("<category");
+
+    // Extract supported categories from caps if available, otherwise use defaults
+    let supported_categories = if supports_categories {
+        extract_supported_categories(&xml)
+    } else {
+        vec![
             "music".to_string(),
             "audio/flac".to_string(),
             "audio/mp3".to_string(),
-        ];
-    }
+        ]
+    };
 
     Ok(IndexerCapabilities {
         supports_search,
@@ -462,6 +469,54 @@ async fn detect_capabilities(
         supports_categories,
         supported_categories,
     })
+}
+
+fn extract_supported_categories(xml: &str) -> Vec<String> {
+    let mut categories = Vec::new();
+    let xml_lower = xml.to_lowercase();
+
+    // Look for music-related category IDs in common ranges and explicit names
+    let music_patterns = [
+        ("3000", "music"),
+        ("3010", "audio/mp3"),
+        ("3020", "audio/flac"), // Some providers use 3020 instead of 3040
+        ("3040", "audio/flac"),
+        ("5070", "audio/flac"), // Alternative ID range
+    ];
+
+    for (id, name) in &music_patterns {
+        // Look for explicit category ID definitions
+        if xml_lower.contains(&format!("id=\"{}\"", id))
+            || xml_lower.contains(&format!("id='{}'", id))
+            || xml_lower.contains(&format!(">{}<", id))
+        {
+            categories.push(name.to_string());
+        }
+    }
+
+    // Also check for text-based category names as fallback
+    if categories.is_empty() {
+        if xml_lower.contains("music") {
+            categories.push("music".to_string());
+        }
+        if xml_lower.contains("flac") || xml_lower.contains("lossless") {
+            categories.push("audio/flac".to_string());
+        }
+        if xml_lower.contains("mp3") {
+            categories.push("audio/mp3".to_string());
+        }
+    }
+
+    // Ensure we always have at least the defaults for music indexers
+    if categories.is_empty() {
+        categories = vec![
+            "music".to_string(),
+            "audio/flac".to_string(),
+            "audio/mp3".to_string(),
+        ];
+    }
+
+    categories
 }
 
 async fn execute_search(
@@ -495,10 +550,13 @@ async fn execute_search(
 
 fn map_category_to_indexer(category: &str, protocol: &IndexerProtocol) -> &'static str {
     let normalized = category.trim().to_lowercase();
+    // For Newznab/Torznab protocols, prefer standard category IDs that work across most providers
+    // Use 3040 for FLAC (most common), but fallback gracefully if provider uses different IDs
     match (protocol, normalized.as_str()) {
         (IndexerProtocol::Newznab | IndexerProtocol::Torznab, "music") => "3000",
         (IndexerProtocol::Newznab | IndexerProtocol::Torznab, "audio/mp3") => "3010",
         (IndexerProtocol::Newznab | IndexerProtocol::Torznab, "audio/flac") => "3040",
+        (IndexerProtocol::Newznab | IndexerProtocol::Torznab, "audio/lossless") => "3040", // Normalize lossless to FLAC category
         _ => "3000",
     }
 }
@@ -968,8 +1026,9 @@ struct RssRawItem {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_rss_feed, parse_search_results, GazelleClient, IndexerClient, IndexerConfig,
-        IndexerProtocol, IndexerSearchQuery, NewznabClient, TorznabClient,
+        extract_supported_categories, map_category_to_indexer, parse_rss_feed,
+        parse_search_results, GazelleClient, IndexerClient, IndexerConfig, IndexerProtocol,
+        IndexerSearchQuery, NewznabClient, TorznabClient,
     };
     use wiremock::matchers::{header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1578,6 +1637,79 @@ mod tests {
         assert_eq!(
             results[0].download_url.as_deref(),
             Some(expected_download.as_str())
+        );
+    }
+
+    #[test]
+    fn newznab_capability_detection_with_sparse_caps() {
+        // Test that capability detection works with minimal caps element
+        let sparse_xml = r#"<?xml version="1.0"?>
+        <caps>
+            <server appversion="1.0" title="TestIndexer" />
+        </caps>
+        "#;
+
+        // This should not panic and should return reasonable defaults
+        let xml_lower = sparse_xml.to_lowercase();
+        assert!(xml_lower.contains("<server"));
+        assert!(xml_lower.contains("<caps"));
+    }
+
+    #[test]
+    fn newznab_extract_music_categories_from_ids() {
+        let xml_with_ids = r#"<?xml version="1.0"?>
+        <caps>
+            <categories>
+                <category id="3000" name="Music" />
+                <category id="3010" name="Music/MP3" />
+                <category id="3040" name="Music/Lossless" />
+            </categories>
+        </caps>
+        "#;
+
+        let categories = extract_supported_categories(xml_with_ids);
+        assert!(categories.contains(&"music".to_string()));
+        assert!(categories.contains(&"audio/mp3".to_string()));
+        assert!(categories.contains(&"audio/flac".to_string()));
+    }
+
+    #[test]
+    fn newznab_extract_categories_with_alternative_flac_id() {
+        // Some providers use 3020 for FLAC instead of 3040
+        let xml_alt_id = r#"<?xml version="1.0"?>
+        <caps>
+            <categories>
+                <category id="3000" name="Music" />
+                <category id="3020" name="Music/FLAC" />
+            </categories>
+        </caps>
+        "#;
+
+        let categories = extract_supported_categories(xml_alt_id);
+        assert!(categories.contains(&"music".to_string()));
+        assert!(categories.contains(&"audio/flac".to_string()));
+    }
+
+    #[test]
+    fn newznab_defaults_when_categories_missing() {
+        let xml_no_cats = r#"<?xml version="1.0"?>
+        <caps>
+            <server title="TestIndexer" />
+        </caps>
+        "#;
+
+        let categories = extract_supported_categories(xml_no_cats);
+        assert_eq!(categories.len(), 3);
+        assert!(categories.contains(&"music".to_string()));
+        assert!(categories.contains(&"audio/flac".to_string()));
+        assert!(categories.contains(&"audio/mp3".to_string()));
+    }
+
+    #[test]
+    fn category_mapping_normalizes_lossless_to_flac() {
+        assert_eq!(
+            map_category_to_indexer("audio/lossless", &IndexerProtocol::Newznab),
+            "3040"
         );
     }
 


### PR DESCRIPTION
Hardens the `extract_supported_categories` helper and its test coverage based on review feedback.

## Changes Made

- **Deduplication**: `extract_supported_categories()` now uses a `HashSet` to deduplicate results across both the numeric-ID detection path and the text-based keyword fallback. Multiple category IDs that map to the same logical name (e.g. 3020, 3040, 5070 → `audio/flac`) and keyword aliases (`flac`/`lossless`) can no longer produce duplicate entries.
- **Both detection paths always run**: Removed the `if categories.is_empty()` guard so numeric-ID and text-keyword detection are both applied, with the `HashSet` preventing overlaps.
- **Pre-computed search strings**: Introduced a `static LazyLock<…>` (`ID_SEARCH_PATTERNS`) that builds the 15 format strings for ID matching once at program startup (requires Rust 1.80+) instead of on every call.
- **Shared constants**: Extracted `DEFAULT_MUSIC_CATEGORIES` and `DEFAULT_CATEGORY_KEYWORDS` constants, reused by both `detect_capabilities()` and `extract_supported_categories()` to eliminate duplicated inline `vec!` literals.
- **Strengthened test**: Rewrote `extract_categories_with_sparse_caps` (formerly `newznab_capability_detection_with_sparse_caps`) to call `extract_supported_categories()` and assert on the actual returned defaults, including an explicit no-duplicate check via `HashSet` comparison.
- **New test**: Added `extract_categories_no_duplicates_with_mixed_id_and_text` to exercise XML containing both numeric category IDs and keyword-matchable text, verifying deduplication across both detection paths.
- **No magic numbers**: All default-count assertions in tests use `DEFAULT_MUSIC_CATEGORIES.len()`.